### PR TITLE
Add TLS, Volume Mount and Platform runtime

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -21,6 +21,15 @@ This guide covers everything you need to build, run, and extend JaisCloud locall
   - [KMS · SecretsManager · SSM e2e tests](#kms--secretsmanager--ssm-e2e-tests-kms_fullmode-build-tag)
   - [CloudFormation e2e tests](#cloudformation-e2e-tests-cfn_fullmode-build-tag)
   - [Apache Iceberg e2e tests](#apache-iceberg-e2e-tests-iceberg_e2e-build-tag)
+- [Platform Runtime Layer](#platform-runtime-layer)
+  - [TLS CA injection](#tls-ca-injection)
+  - [Extra volumes](#extra-volumes)
+  - [Extra environment variables](#extra-environment-variables)
+  - [Docker mode behaviour](#docker-mode-behaviour)
+  - [Kubernetes mode behaviour](#kubernetes-mode-behaviour)
+- [Multi-Cloud Spark Transforms](#multi-cloud-spark-transforms)
+  - [Azure](#azure-spark-transform)
+  - [GCP](#gcp-spark-transform)
 - [Platform Setup](#platform-setup)
 
 ---
@@ -1155,6 +1164,404 @@ Always run with `-race`. JaisCloud is heavily concurrent and the race detector c
 
 ```bash
 go test -race ./...
+```
+
+---
+
+---
+
+## Platform Runtime Layer
+
+The Platform Runtime Layer (`internal/platform/`) injects TLS certificate trust, extra volumes, and environment variables uniformly into **every** JaisCloud-managed container or pod — Lambda Docker/K8s executors and Spark Docker/K8s executors alike. Configuration is loaded once at startup via `platform.LoadFromEnv()` and passed by pointer to each executor constructor. It never embeds into any workload-specific config.
+
+### TLS CA injection
+
+Two materializers run in order whenever `JAISCLOUD_PLATFORM_TLS_ENABLED=true`:
+
+| Materializer | What it does |
+|---|---|
+| **JVM truststore** | Copies the default JVM `cacerts` into an `emptyDir` and imports all CA certs via `keytool`. Sets `JAVA_TOOL_OPTIONS=-Djavax.net.ssl.trustStore=...` on the main container. |
+| **PEM bundle** | Concatenates all CA files into a single PEM bundle and sets `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`, `AWS_CA_BUNDLE`, `GIT_SSL_CAINFO`, `CURL_CA_BUNDLE` on the main container. |
+
+CA sources are specified as a JSON or YAML array via `JAISCLOUD_PLATFORM_TLS_CA_SOURCES`:
+
+```bash
+# Single ConfigMap source (K8s mode — default if unset)
+export JAISCLOUD_PLATFORM_TLS_CA_SOURCES='[
+  {"name":"jaiscloud","source":{"kind":"configMap","name":"jaiscloud-ca-cert","key":"ca.crt"}}
+]'
+
+# Multiple sources (ConfigMap + Secret)
+export JAISCLOUD_PLATFORM_TLS_CA_SOURCES='[
+  {"name":"corp-ca","source":{"kind":"configMap","name":"corp-ca","key":"ca.pem"}},
+  {"name":"internal","source":{"kind":"secret","name":"internal-ca","key":"tls.crt"}}
+]'
+
+# Local file (Docker mode — only "kind":"file" sources can be read by the host process)
+export JAISCLOUD_PLATFORM_TLS_CA_SOURCES='[
+  {"name":"my-ca","source":{"kind":"file","key":"/etc/ssl/certs/my-ca.pem"}}
+]'
+```
+
+> **Docker mode note:** Only `kind="file"` CA sources can be materialised on the Docker host. `configMap` and `secret` sources are skipped with a warning — they are K8s-only. For Docker deployments, use `kind="file"` sources pointing to host-local PEM files.
+
+Disable TLS injection entirely:
+
+```bash
+export JAISCLOUD_PLATFORM_TLS_ENABLED=false
+```
+
+### Extra volumes
+
+Inject additional volumes into every pod/container via `JAISCLOUD_PLATFORM_VOLUMES` (JSON/YAML array, or `_FILE` variant for a file path). Both a short-form and a long-form spec are supported.
+
+**Short form** — convenience for the common cases:
+
+```bash
+export JAISCLOUD_PLATFORM_VOLUMES='[
+  {"name":"my-configmap", "configMap":"my-cm-name",   "mountPath":"/etc/conf"},
+  {"name":"my-secret",    "secret":"my-secret-name",  "mountPath":"/etc/secret",  "readOnly":true},
+  {"name":"my-pvc",       "pvc":"my-pvc-claim",       "mountPath":"/data"},
+  {"name":"scratch",      "emptyDir":true,             "mountPath":"/tmp/scratch"}
+]'
+```
+
+**Long form** — for projected volumes, CSI, hostPath, and per-mount subPath:
+
+```bash
+export JAISCLOUD_PLATFORM_VOLUMES='[
+  {
+    "name": "azure-workload-id",
+    "source": {
+      "kind": "projected",
+      "projected": {
+        "sources": [
+          {"serviceAccountToken": {"audience":"api://AzureADTokenExchange","expirationSeconds":3600,"path":"token"}}
+        ]
+      }
+    },
+    "mounts": [{"mountPath":"/var/run/secrets/azure/identity"}]
+  }
+]'
+```
+
+> **Docker mode note:** Only `kind="hostPath"` volumes produce `-v` bind-mount args. `configMap`, `secret`, `pvc`, and `projected` volumes are K8s-only and are silently skipped in Docker mode.
+
+### Extra environment variables
+
+Inject extra env vars into every pod/container:
+
+```bash
+export JAISCLOUD_PLATFORM_ENV='{"CUSTOM_VAR":"value","ANOTHER":"value2"}'
+
+# Or via file
+export JAISCLOUD_PLATFORM_ENV_FILE=/etc/jaiscloud/extra-env.json
+```
+
+### Environment variable reference
+
+| Variable | Default | Description |
+|---|---|---|
+| `JAISCLOUD_PLATFORM_TLS_ENABLED` | `true` | Enable CA injection |
+| `JAISCLOUD_PLATFORM_TLS_CA_SOURCES` | JaisCloud default ConfigMap | JSON/YAML CA source array |
+| `JAISCLOUD_PLATFORM_TLS_CA_SOURCES_FILE` | _(empty)_ | File-based variant; takes precedence over the inline var |
+| `JAISCLOUD_PLATFORM_TLS_CLIENT_CERT` | _(empty)_ | Optional mTLS client cert source (same shape as one CA source element) |
+| `JAISCLOUD_PLATFORM_TLS_PASSWORD` | `changeit` | JVM truststore password |
+| `JAISCLOUD_PLATFORM_VOLUMES` | _(empty)_ | JSON/YAML volume spec array |
+| `JAISCLOUD_PLATFORM_VOLUMES_FILE` | _(empty)_ | File-based variant |
+| `JAISCLOUD_PLATFORM_ENV` | _(empty)_ | JSON/YAML `{"KEY":"VALUE"}` map |
+| `JAISCLOUD_PLATFORM_ENV_FILE` | _(empty)_ | File-based variant |
+| `JAISCLOUD_PLATFORM_HOSTPATH_ALLOWLIST` | _(empty)_ | Comma-separated allowed `hostPath` prefixes; empty = hostPath disabled |
+
+### Docker mode behaviour
+
+`platform.ApplyDocker` is called inside `DockerExecutor.Submit` / `startContainer` and returns `-v` and `-e` args appended to the `docker run` command:
+
+- TLS PEM bundle materialised to a host temp file → `-v /tmp/jaiscloud-ca-bundle-*.pem:/etc/ssl/certs/jaiscloud-ca.pem:ro`
+- All six non-JVM env vars set to the container path → `-e SSL_CERT_FILE=/etc/ssl/certs/jaiscloud-ca.pem ...`
+- `hostPath` volumes → `-v host/path:container/path:ro`
+- Extra env → `-e KEY=VALUE`
+
+### Kubernetes mode behaviour
+
+`platform.ApplyK8s` is called inside `K8sExecutor.buildJobManifest` / `createPod` and mutates the `k8stypes.PodSpec` in place **after** the cloud-specific transform has already contributed its volumes and env:
+
+1. CA source volumes added to `spec.volumes`
+2. JVM materializer: `emptyDir` output volume + init container (keytool import) + main container env
+3. PEM materializer: `emptyDir` output volume + init container (concatenate) + main container env vars
+4. Platform extra volumes appended (conflict-checked against existing names)
+5. Platform extra volume mounts added to the main container
+6. Platform extra env merged into the main container env (first-wins deduplication)
+
+---
+
+## Multi-Cloud Spark Transforms
+
+The `CloudSparkTransform` registry (`internal/executor/spark/cloud_transform.go`) decouples cloud-specific Spark contributions from the executor. Each cloud registers itself via `init()` and is selected at manifest build time from `SparkConfig.Cloud` (derived from `--cloud` / `JAISCLOUD_CLOUD`).
+
+| Cloud | Transform | URI rewrite | Auth mechanism |
+|---|---|---|---|
+| `aws` | `awsTransform` | `s3a://` → `s3a://` (identity) | S3 endpoint env + Hadoop S3A confs |
+| `azure` | `azureTransform` | `s3a://` → `abfss://bucket@account.dfs.core.windows.net/` | SharedKey or OAuth/Workload Identity |
+| `gcp` | `gcpTransform` | `s3a://` → `gs://` | Service account key file or K8s Secret |
+
+Each transform contributes:
+- `ResolveCommand` — binary path + rewritten `spark-submit` args
+- `SparkConfs` — `--conf` flags injected before the JAR path
+- `PodEnv` — environment variables for the spark-submit container
+- `PodVolumes` — cloud-specific volumes and mounts (credentials, identity tokens)
+
+### Azure Spark transform
+
+Set `JAISCLOUD_CLOUD=azure` and configure one of two authentication modes:
+
+**Shared key** (simpler, for dev):
+
+```bash
+export JAISCLOUD_CLOUD=azure
+export JAISCLOUD_AZURE_STORAGE_ACCOUNT=mystorageacct
+export JAISCLOUD_AZURE_STORAGE_KEY=base64encodedkey==
+```
+
+This injects `fs.azure.account.auth.type.*.dfs.core.windows.net=SharedKey` and the account key into Spark confs. URIs are rewritten `s3a://bucket/key` → `abfss://bucket@mystorageacct.dfs.core.windows.net/key`.
+
+**OAuth / Workload Identity** (for production K8s):
+
+```bash
+export JAISCLOUD_CLOUD=azure
+export JAISCLOUD_AZURE_STORAGE_ACCOUNT=mystorageacct
+export JAISCLOUD_AZURE_CLIENT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+export JAISCLOUD_AZURE_CLIENT_SECRET=my-client-secret
+export JAISCLOUD_AZURE_TENANT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+```
+
+This injects OAuth confs and mounts a `projected` volume (`serviceAccountToken` + `downwardAPI`) at `/var/run/secrets/azure/identity` for Workload Identity federation.
+
+Optionally override the ADLS endpoint:
+
+```bash
+export JAISCLOUD_AZURE_STORAGE_ENDPOINT=https://mystorageacct.dfs.core.windows.net
+```
+
+### GCP Spark transform
+
+Set `JAISCLOUD_CLOUD=gcp` and configure one of two service-account modes:
+
+**Key file path** (the key is already present on the container filesystem):
+
+```bash
+export JAISCLOUD_CLOUD=gcp
+export JAISCLOUD_GCP_PROJECT_ID=my-gcp-project
+export JAISCLOUD_GCP_SA_KEY_PATH=/etc/gcp/key.json
+```
+
+**K8s Secret** (the key is stored in a Kubernetes Secret and mounted by the executor):
+
+```bash
+export JAISCLOUD_CLOUD=gcp
+export JAISCLOUD_GCP_PROJECT_ID=my-gcp-project
+export JAISCLOUD_GCP_SA_SECRET=my-gcp-sa-key-secret   # K8s Secret name in the executor namespace
+```
+
+The executor mounts the Secret at `/etc/gcp` and sets `GOOGLE_APPLICATION_CREDENTIALS=/etc/gcp/key.json`. URIs are rewritten `s3a://bucket/key` → `gs://bucket/key`. GCS Spark confs (`spark.hadoop.google.cloud.auth.service.account.enable=true`, `spark.hadoop.fs.gs.project.id`) are injected automatically.
+
+Optionally override the GCS endpoint (for emulators):
+
+```bash
+export JAISCLOUD_GCP_STORAGE_ENDPOINT=http://fake-gcs-server:4443
+```
+
+---
+
+## Executor Mode Configuration Examples
+
+Complete environment variable sets for each executor mode. Copy the block that matches your setup and adjust paths / names.
+
+### Mock mode (default — no containers, instant completion)
+
+No extra configuration needed. This is the default when `JAISCLOUD_EXECUTOR_MODE` is unset.
+
+```bash
+# Minimal — everything defaults to in-memory mock
+./jaiscloud start
+
+# Explicit mock with full persistence
+./jaiscloud start \
+  --mode full \
+  --dsn "postgres://jaiscloud:jaiscloud@localhost:5433/jaiscloud" \
+  --executor-mode mock
+```
+
+All Lambda invocations return an echo of the request payload. All EMR steps and job runs complete immediately with `COMPLETED` state. No Docker daemon or Kubernetes cluster needed.
+
+---
+
+### Docker mode
+
+Requires a running Docker daemon. Each Lambda function gets a warm Docker container; each Spark job runs `spark-submit` inside a Docker container.
+
+```bash
+# ── Core ──────────────────────────────────────────────────────────────────────
+export JAISCLOUD_EXECUTOR_MODE=docker
+export JAISCLOUD_MODE=full
+export JAISCLOUD_DSN=postgres://jaiscloud:jaiscloud@localhost:5433/jaiscloud
+
+# ── Lambda ────────────────────────────────────────────────────────────────────
+export JAISCLOUD_LAMBDA_IMAGE=public.ecr.aws/lambda/python:3.12  # default per-runtime; override globally here
+export JAISCLOUD_LAMBDA_NETWORK=jaiscloud-net                     # Docker network containers join
+export JAISCLOUD_LAMBDA_KEEPALIVE_SECS=300                        # idle container TTL
+
+# ── Spark (EMR / EMR on EKS) ──────────────────────────────────────────────────
+export JAISCLOUD_SPARK_IMAGE=apache/spark:3.5.0   # Spark Docker image
+
+# Optional: S3 endpoint so Spark containers can reach JaisCloud's S3
+export JAISCLOUD_SPARK_S3_ENDPOINT=http://host.docker.internal:4566
+export JAISCLOUD_AWS_REGION=us-east-1
+export JAISCLOUD_AWS_ACCESS_KEY_ID=test
+export JAISCLOUD_AWS_SECRET_ACCESS_KEY=test
+
+# ── Platform layer ─────────────────────────────────────────────────────────────
+# TLS: disable if no custom CA is needed
+export JAISCLOUD_PLATFORM_TLS_ENABLED=false
+
+# TLS: inject a local CA PEM file into every container
+# export JAISCLOUD_PLATFORM_TLS_ENABLED=true
+# export JAISCLOUD_PLATFORM_TLS_CA_SOURCES='[{"name":"corp-ca","source":{"kind":"file","key":"/etc/ssl/certs/corp-ca.pem"}}]'
+
+# Extra env passed to every managed container
+export JAISCLOUD_PLATFORM_ENV='{"HTTP_PROXY":"http://proxy.corp:3128","NO_PROXY":"localhost"}'
+
+# hostPath bind-mounts (must be in allowlist)
+export JAISCLOUD_PLATFORM_HOSTPATH_ALLOWLIST=/etc/ssl/certs,/run/secrets
+export JAISCLOUD_PLATFORM_VOLUMES='[{"name":"corp-certs","mountPath":"/etc/corp/certs","hostPath":"/etc/ssl/certs","readOnly":true}]'
+
+./jaiscloud start
+```
+
+**Verify Docker executor is active:**
+```bash
+# After starting, you should see in the logs:
+# INFO  executor  lambda=docker  spark=docker
+# INFO  platform tls  enabled=false  ...
+
+# Lambda cold start creates a container visible via:
+docker ps --filter name=jc-lambda-
+# Spark jobs create containers visible via:
+docker ps --filter name=jc-spark-
+```
+
+---
+
+### Kubernetes mode
+
+Requires a reachable Kubernetes cluster. Each Lambda function gets a warm Pod + ClusterIP Service; each Spark job submits a `batch/v1` Job.
+
+```bash
+# ── Core ──────────────────────────────────────────────────────────────────────
+export JAISCLOUD_EXECUTOR_MODE=k8s
+export JAISCLOUD_MODE=full
+export JAISCLOUD_DSN=postgres://jaiscloud:jaiscloud@localhost:5433/jaiscloud
+
+# ── Kubernetes API server ─────────────────────────────────────────────────────
+# In-cluster (JaisCloud runs inside a pod): leave these unset — auto-detected
+# Out-of-cluster (local dev / CI):
+export JAISCLOUD_K8S_APISERVER=https://127.0.0.1:6443          # kubectl cluster-info
+export JAISCLOUD_K8S_TOKEN=$(kubectl create token jaiscloud-sa -n jaiscloud --duration=24h)
+export JAISCLOUD_K8S_CA_FILE=$HOME/.kube/ca.crt                # unset = system roots
+export JAISCLOUD_K8S_NAMESPACE=jaiscloud
+export JAISCLOUD_K8S_SA=jaiscloud-sa
+
+# ── Lambda ────────────────────────────────────────────────────────────────────
+export JAISCLOUD_LAMBDA_KEEPALIVE_SECS=300    # idle pod TTL before garbage collection
+
+# ── Spark (EMR / EMR on EKS) ──────────────────────────────────────────────────
+export JAISCLOUD_SPARK_IMAGE=apache/spark:3.5.0
+export JAISCLOUD_K8S_SPARK_NAMESPACE=jaiscloud       # namespace for Spark batch Jobs
+export JAISCLOUD_K8S_SPARK_SA=spark-sa               # service account for the Spark driver
+
+# Optional: S3 endpoint for Spark pods to reach JaisCloud's S3
+export JAISCLOUD_SPARK_S3_ENDPOINT=http://jaiscloud.jaiscloud.svc.cluster.local:4566
+export JAISCLOUD_AWS_REGION=us-east-1
+export JAISCLOUD_AWS_ACCESS_KEY_ID=test
+export JAISCLOUD_AWS_SECRET_ACCESS_KEY=test
+
+# ── Platform layer ─────────────────────────────────────────────────────────────
+# TLS: inject a CA from a ConfigMap that already exists in the cluster
+export JAISCLOUD_PLATFORM_TLS_ENABLED=true
+export JAISCLOUD_PLATFORM_TLS_CA_SOURCES='[
+  {"name":"corp-ca","source":{"kind":"configMap","name":"corp-ca-bundle","key":"ca.crt"}}
+]'
+# Password for the JVM truststore init container
+export JAISCLOUD_PLATFORM_TLS_PASSWORD=changeit
+
+# Extra env injected into every pod's main container
+export JAISCLOUD_PLATFORM_ENV='{"CUSTOM_ENDPOINT":"http://internal-service:8080"}'
+
+# Extra volume from a Secret mounted at a specific path
+export JAISCLOUD_PLATFORM_VOLUMES='[
+  {"name":"corp-tls","secret":"corp-tls-secret","mountPath":"/etc/corp/tls","readOnly":true}
+]'
+
+./jaiscloud start
+```
+
+**Verify K8s executor is active:**
+```bash
+# After starting you should see in the logs:
+# INFO  executor  lambda=k8s  spark=k8s
+# INFO  platform tls  enabled=true  ca-sources=[corp-ca]  ...
+
+# Lambda warm pods:
+kubectl get pods -n jaiscloud -l app=jaiscloud-lambda
+
+# Lambda ClusterIP services (one per function):
+kubectl get svc -n jaiscloud -l app=jaiscloud-lambda
+
+# Spark batch jobs:
+kubectl get jobs -n jaiscloud -l app=jaiscloud-spark
+```
+
+---
+
+### Multi-cloud (Azure / GCP) with K8s executor
+
+Set `--cloud` to select the cloud adapter, then add the cloud-specific Spark transform env vars. The Platform layer applies identically across all clouds.
+
+**Azure (K8s executor, OAuth auth):**
+```bash
+export JAISCLOUD_CLOUD=azure
+export JAISCLOUD_EXECUTOR_MODE=k8s
+export JAISCLOUD_K8S_APISERVER=https://127.0.0.1:6443
+export JAISCLOUD_K8S_TOKEN=$(kubectl create token jaiscloud-sa -n jaiscloud --duration=24h)
+export JAISCLOUD_K8S_NAMESPACE=jaiscloud
+
+export JAISCLOUD_AZURE_STORAGE_ACCOUNT=mystorageacct
+export JAISCLOUD_AZURE_CLIENT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+export JAISCLOUD_AZURE_CLIENT_SECRET=my-client-secret
+export JAISCLOUD_AZURE_TENANT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+export JAISCLOUD_PLATFORM_TLS_ENABLED=true
+export JAISCLOUD_PLATFORM_TLS_CA_SOURCES='[
+  {"name":"azure-ca","source":{"kind":"configMap","name":"azure-ca-bundle","key":"ca.crt"}}
+]'
+
+./jaiscloud start --mode full --dsn "postgres://..."
+```
+
+**GCP (K8s executor, Secret-based SA key):**
+```bash
+export JAISCLOUD_CLOUD=gcp
+export JAISCLOUD_EXECUTOR_MODE=k8s
+export JAISCLOUD_K8S_APISERVER=https://127.0.0.1:6443
+export JAISCLOUD_K8S_TOKEN=$(kubectl create token jaiscloud-sa -n jaiscloud --duration=24h)
+export JAISCLOUD_K8S_NAMESPACE=jaiscloud
+
+export JAISCLOUD_GCP_PROJECT_ID=my-gcp-project
+export JAISCLOUD_GCP_SA_SECRET=my-gcp-sa-key-secret   # K8s Secret in the executor namespace
+
+export JAISCLOUD_PLATFORM_TLS_ENABLED=false   # GCP root CAs already trusted by default JVM
+
+./jaiscloud start --mode full --dsn "postgres://..."
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -283,6 +283,22 @@ All flags have an equivalent `JAISCLOUD_*` environment variable.
 | `--blob-dir` | `JAISCLOUD_BLOB_DIR` | _(empty)_ | Directory for S3 blob bytes (full mode, optional) |
 | `--executor-mode` | `JAISCLOUD_EXECUTOR_MODE` | _(empty)_ | Container orchestrator: `mock` / `docker` / `k8s` |
 
+### Platform Runtime Layer
+
+The Platform Runtime Layer injects TLS trust, extra volumes, and environment variables uniformly into every JaisCloud-managed container or pod — without coupling the configuration to any specific executor.
+
+| Env var | Default | Description |
+|---|---|---|
+| `JAISCLOUD_PLATFORM_TLS_ENABLED` | `true` | Enable TLS CA injection into managed containers |
+| `JAISCLOUD_PLATFORM_TLS_CA_SOURCES` | JaisCloud ConfigMap | JSON/YAML array of CA sources (`configMap`, `secret`, or `file`) |
+| `JAISCLOUD_PLATFORM_TLS_CA_SOURCES_FILE` | _(empty)_ | File path variant of the above |
+| `JAISCLOUD_PLATFORM_TLS_PASSWORD` | `changeit` | JVM truststore password |
+| `JAISCLOUD_PLATFORM_VOLUMES` | _(empty)_ | JSON/YAML array of extra volume specs to mount into every pod/container |
+| `JAISCLOUD_PLATFORM_VOLUMES_FILE` | _(empty)_ | File path variant of the above |
+| `JAISCLOUD_PLATFORM_ENV` | _(empty)_ | JSON/YAML map of extra environment variables injected into every pod/container |
+| `JAISCLOUD_PLATFORM_ENV_FILE` | _(empty)_ | File path variant of the above |
+| `JAISCLOUD_PLATFORM_HOSTPATH_ALLOWLIST` | _(empty)_ | Comma-separated list of allowed `hostPath` prefixes (Docker bind-mounts) |
+
 **`lite` (default)** — all state in memory. Zero external dependencies. State is lost on restart. Ideal for unit tests and CI.
 
 **`full`** — resource metadata persisted in PostgreSQL; S3 object bytes optionally persisted to `--blob-dir`. Ideal for integration environments.
@@ -413,9 +429,11 @@ HTTP request
       → inject: Clock, Region, AccountID, Cloud, ResourceID
       → Registry.Dispatch("Service.Action", NormalizedRequest)
           → Provider (business logic, pure Go)
-              → ResourceStore  (metadata)
-              → ServiceStore   (messages / items / objects)
-              → Executor       (mock | docker | k8s)
+              → ResourceStore          (metadata)
+              → ServiceStore           (messages / items / objects)
+              → CloudSparkTransform    (AWS | Azure | GCP — URI rewrite, confs, pod env)
+              → Executor               (mock | docker | k8s)
+                  → PlatformConfig     (TLS CA injection, extra volumes, extra env)
       → Codec.Encode (XML / JSON / raw bytes)
   → HTTP response
 ```

--- a/cmd/jaiscloud/main.go
+++ b/cmd/jaiscloud/main.go
@@ -50,6 +50,7 @@ import (
 	stackprovider "jaiscloud/internal/provider/stack"
 	"jaiscloud/internal/provider/table"
 	"jaiscloud/internal/certstore"
+	"jaiscloud/internal/platform"
 	"jaiscloud/internal/store"
 	dynamostore "jaiscloud/internal/store/aws/dynamodb"
 	s3store "jaiscloud/internal/store/aws/s3"
@@ -263,9 +264,15 @@ func buildRegistry(ctx context.Context, cfg *config.Config, s appStores, dek []b
 	bus := events.NewEventBus()
 	streams := streamstore.NewMemoryStreamStore()
 
+	platformCfg, err := platform.LoadFromEnv()
+	if err != nil {
+		slog.Error("platform config", "err", err)
+		os.Exit(1)
+	}
+
 	// Build spark executor. cfg.ExecutorMode drives both Spark and Lambda.
 	// "" / "mock" → instant mock completion (nil exec); "docker" / "k8s" → real executor.
-	sparkExec, sparkCfg := buildSparkExecutor(cfg.ExecutorMode)
+	sparkExec, sparkCfg := buildSparkExecutor(cfg.ExecutorMode, cfg.Cloud, platformCfg)
 	if sparkExec != nil {
 		slog.Info("spark executor enabled", "mode", cfg.ExecutorMode)
 	}
@@ -327,7 +334,15 @@ func buildRegistry(ctx context.Context, cfg *config.Config, s appStores, dek []b
 	if v := os.Getenv("JAISCLOUD_ENDPOINT"); v != "" {
 		lambdaCfg.JaisCloudEndpoint = v
 	}
-	lambdaExec := lambdaexec.NewExecutor(lambdaCfg)
+	var lambdaExec lambdaexec.LambdaExecutor
+	switch cfg.ExecutorMode {
+	case "docker":
+		lambdaExec = lambdaexec.NewDockerExecutor(lambdaCfg, platformCfg)
+	case "k8s":
+		lambdaExec = lambdaexec.NewK8sExecutor(lambdaCfg, platformCfg)
+	default:
+		lambdaExec = lambdaexec.NewExecutor(lambdaCfg)
+	}
 	slog.Info("lambda executor", "mode", cfg.ExecutorMode)
 	prevCleanup := cleanup
 	cleanup = func() { lambdaExec.Close(); prevCleanup() }
@@ -370,11 +385,12 @@ func buildRegistry(ctx context.Context, cfg *config.Config, s appStores, dek []b
 
 // buildSparkExecutor creates a SparkExecutor for the given mode.
 // Returns (nil, zero) when mode is "" or "off" — instant completion remains the default.
-func buildSparkExecutor(mode string) (spark.SparkExecutor, spark.SparkConfig) {
+func buildSparkExecutor(mode, cloud string, plat *platform.PlatformConfig) (spark.SparkExecutor, spark.SparkConfig) {
 	if mode == "" || mode == "off" {
 		return nil, spark.SparkConfig{}
 	}
 	cfg := spark.SparkConfigFrom(mode, spark.SizeSmall)
+	cfg.Cloud = model.Cloud(cloud)
 	// Generic image override — applies to both docker and k8s modes.
 	// JAISCLOUD_K8S_SPARK_IMAGE (legacy) is read by SparkConfigFrom; this wins if set.
 	if v := os.Getenv("JAISCLOUD_SPARK_IMAGE"); v != "" {
@@ -390,6 +406,10 @@ func buildSparkExecutor(mode string) (spark.SparkExecutor, spark.SparkConfig) {
 		if v := os.Getenv("JAISCLOUD_K8S_SA"); v != "" {
 			cfg.ServiceAccount = v
 		}
+		return spark.NewK8sExecutor(cfg, plat), cfg
+	}
+	if mode == "docker" {
+		return spark.NewDockerExecutor(cfg, plat), cfg
 	}
 	return spark.NewExecutor(mode, cfg), cfg
 }

--- a/internal/executor/lambda/config.go
+++ b/internal/executor/lambda/config.go
@@ -22,6 +22,8 @@ type LambdaConfig struct {
 	JaisCloudEndpoint string
 	// Region is injected as AWS_DEFAULT_REGION into containers.
 	Region string
+	// Cloud is used for metadata labels on managed pods/containers.
+	Cloud string
 }
 
 // regionOrDefault returns r if non-empty, else "us-east-1".
@@ -87,12 +89,13 @@ func ImageForRuntime(req InvokeRequest, cfg LambdaConfig) string {
 }
 
 // NewExecutor constructs the appropriate LambdaExecutor for the given mode.
+// For executors with a platform config use NewK8sExecutor / NewDockerExecutor directly.
 func NewExecutor(cfg LambdaConfig) LambdaExecutor {
 	switch cfg.Mode {
 	case "docker":
-		return NewDockerExecutor(cfg)
+		return NewDockerExecutor(cfg, nil)
 	case "k8s":
-		return NewK8sExecutor(cfg)
+		return NewK8sExecutor(cfg, nil)
 	default:
 		return &MockExecutor{}
 	}

--- a/internal/executor/lambda/docker.go
+++ b/internal/executor/lambda/docker.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"jaiscloud/internal/platform"
 )
 
 const (
@@ -32,7 +34,8 @@ type warmContainer struct {
 // until it has been idle for cfg.KeepaliveSecs seconds.
 type DockerExecutor struct {
 	cfg        LambdaConfig
-	client     *http.Client   // talks to Docker socket
+	platform   *platform.PlatformConfig
+	client     *http.Client // talks to Docker socket
 	mu         sync.Mutex
 	containers map[string]*warmContainer // functionName → container
 	nextPort   int
@@ -41,9 +44,11 @@ type DockerExecutor struct {
 }
 
 // NewDockerExecutor creates a DockerExecutor and starts the GC goroutine.
-func NewDockerExecutor(cfg LambdaConfig) *DockerExecutor {
+// plat may be nil.
+func NewDockerExecutor(cfg LambdaConfig, plat *platform.PlatformConfig) *DockerExecutor {
 	e := &DockerExecutor{
 		cfg:        cfg,
+		platform:   plat,
 		containers: make(map[string]*warmContainer),
 		nextPort:   9100,
 		done:       make(chan struct{}),
@@ -165,21 +170,43 @@ func (e *DockerExecutor) startContainer(ctx context.Context, req InvokeRequest, 
 		env = append(env, k+"="+v)
 	}
 
+	// Platform layer: TLS PEM bundle + extra env for this container.
+	var binds []string
+	if e.platform != nil {
+		volArgs, envArgs, err := platform.ApplyDocker(e.platform)
+		if err != nil {
+			slog.Warn("lambda docker: platform apply failed", "err", err)
+		}
+		// volArgs are pairs ["-v", "src:dst:ro"]; extract bind strings.
+		for i := 1; i < len(volArgs); i += 2 {
+			binds = append(binds, volArgs[i])
+		}
+		// envArgs are pairs ["-e", "KEY=VAL"]; extract env strings.
+		for i := 1; i < len(envArgs); i += 2 {
+			env = append(env, envArgs[i])
+		}
+	}
+
+	hostConfig := map[string]any{
+		"PortBindings": map[string]any{
+			fmt.Sprintf("%d/tcp", invocationPort): []map[string]any{
+				{"HostPort": fmt.Sprintf("%d", hostPort)},
+			},
+		},
+		"NetworkMode": e.cfg.Network,
+		"Memory":      int64(req.MemoryMB) * 1024 * 1024,
+	}
+	if len(binds) > 0 {
+		hostConfig["Binds"] = binds
+	}
+
 	body, _ := json.Marshal(map[string]any{
 		"Image": image,
 		"Env":   env,
 		"ExposedPorts": map[string]any{
 			fmt.Sprintf("%d/tcp", invocationPort): map[string]any{},
 		},
-		"HostConfig": map[string]any{
-			"PortBindings": map[string]any{
-				fmt.Sprintf("%d/tcp", invocationPort): []map[string]any{
-					{"HostPort": fmt.Sprintf("%d", hostPort)},
-				},
-			},
-			"NetworkMode": e.cfg.Network,
-			"Memory":      int64(req.MemoryMB) * 1024 * 1024,
-		},
+		"HostConfig": hostConfig,
 	})
 
 	createURL := fmt.Sprintf("http://localhost/v1.41/containers/create?name=%s", name)
@@ -248,6 +275,9 @@ func (e *DockerExecutor) gcOnce() {
 	e.mu.Lock()
 	var toRemove []string
 	for name, c := range e.containers {
+		if c.id == "" {
+			continue // sentinel during cold start; skip
+		}
 		if now.Sub(c.lastUsed) > keepalive {
 			toRemove = append(toRemove, name)
 		}

--- a/internal/executor/lambda/k8s.go
+++ b/internal/executor/lambda/k8s.go
@@ -16,6 +16,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"jaiscloud/internal/k8stypes"
+	"jaiscloud/internal/platform"
 )
 
 const (
@@ -35,18 +38,20 @@ type warmPod struct {
 
 // K8sExecutor manages warm Pods per Lambda function using the Lambda RIE HTTP protocol.
 type K8sExecutor struct {
-	cfg    LambdaConfig
-	k8s    *http.Client // talks to K8s API server (30s timeout, custom TLS)
-	invoke *http.Client // talks to Lambda RIE pods (5min timeout)
-	token  string
-	mu     sync.Mutex
-	pods   map[string]*warmPod // functionName -> warm pod
-	done   chan struct{}
-	wg     sync.WaitGroup
+	cfg      LambdaConfig
+	platform *platform.PlatformConfig
+	k8s      *http.Client // talks to K8s API server (30s timeout, custom TLS)
+	invoke   *http.Client // talks to Lambda RIE pods (5min timeout)
+	token    string
+	mu       sync.Mutex
+	pods     map[string]*warmPod // functionName -> warm pod
+	done     chan struct{}
+	wg       sync.WaitGroup
 }
 
 // NewK8sExecutor creates a K8sExecutor with warm-pod-per-function architecture.
-func NewK8sExecutor(cfg LambdaConfig) *K8sExecutor {
+// plat may be nil.
+func NewK8sExecutor(cfg LambdaConfig, plat *platform.PlatformConfig) *K8sExecutor {
 	// Read bearer token.
 	token := os.Getenv("JAISCLOUD_K8S_TOKEN")
 	if token == "" {
@@ -94,12 +99,13 @@ func NewK8sExecutor(cfg LambdaConfig) *K8sExecutor {
 	invokeClient := &http.Client{Timeout: 5 * time.Minute}
 
 	e := &K8sExecutor{
-		cfg:    cfg,
-		k8s:    k8sClient,
-		invoke: invokeClient,
-		token:  token,
-		pods:   make(map[string]*warmPod),
-		done:   make(chan struct{}),
+		cfg:      cfg,
+		platform: plat,
+		k8s:      k8sClient,
+		invoke:   invokeClient,
+		token:    token,
+		pods:     make(map[string]*warmPod),
+		done:     make(chan struct{}),
 	}
 	e.cleanupOrphans()
 	e.wg.Add(1)
@@ -235,15 +241,15 @@ func (e *K8sExecutor) createPod(ctx context.Context, req InvokeRequest) (*warmPo
 	podName := podPrefix + sanitized + "-" + shortID()
 	svcName := svcPrefix + sanitized
 
-	env := []map[string]string{
-		{"name": "AWS_LAMBDA_FUNCTION_NAME", "value": req.FunctionName},
-		{"name": "AWS_DEFAULT_REGION", "value": regionOrDefault(e.cfg.Region)},
+	env := []k8stypes.EnvVar{
+		{Name: "AWS_LAMBDA_FUNCTION_NAME", Value: req.FunctionName},
+		{Name: "AWS_DEFAULT_REGION", Value: regionOrDefault(e.cfg.Region)},
 	}
 	if e.cfg.JaisCloudEndpoint != "" {
-		env = append(env, map[string]string{"name": "JAISCLOUD_ENDPOINT", "value": e.cfg.JaisCloudEndpoint})
+		env = append(env, k8stypes.EnvVar{Name: "JAISCLOUD_ENDPOINT", Value: e.cfg.JaisCloudEndpoint})
 	}
 	for k, v := range req.EnvVars {
-		env = append(env, map[string]string{"name": k, "value": v})
+		env = append(env, k8stypes.EnvVar{Name: k, Value: v})
 	}
 
 	var args []string
@@ -256,38 +262,44 @@ func (e *K8sExecutor) createPod(ctx context.Context, req InvokeRequest) (*warmPo
 		memMB = 128
 	}
 
+	podSpec := k8stypes.PodSpec{
+		RestartPolicy: "Never",
+		Containers: []k8stypes.Container{{
+			Name:            "lambda",
+			Image:           image,
+			ImagePullPolicy: "IfNotPresent",
+			Args:            args,
+			Env:             env,
+			Ports:           []k8stypes.ContainerPort{{ContainerPort: riePort}},
+			Resources: &k8stypes.Resources{
+				Requests: map[string]string{"cpu": "100m", "memory": "64Mi"},
+				Limits:   map[string]string{"cpu": "1", "memory": fmt.Sprintf("%dMi", memMB)},
+			},
+			ReadinessProbe: &k8stypes.Probe{
+				TCPSocket:           &k8stypes.TCPSocketAction{Port: riePort},
+				InitialDelaySeconds: 1,
+				PeriodSeconds:       1,
+				FailureThreshold:    30,
+			},
+		}},
+	}
+
+	// Platform layer: TLS, generic volumes, env — applied before submission.
+	if e.platform != nil {
+		if err := platform.ApplyK8s(&podSpec, &podSpec.Containers[0], e.platform); err != nil {
+			return nil, fmt.Errorf("platform apply: %w", err)
+		}
+	}
+
 	podManifest := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Pod",
 		"metadata": map[string]any{
 			"name":      podName,
 			"namespace": ns,
-			"labels": map[string]string{
-				"app":      labelApp,
-				"function": sanitized,
-			},
+			"labels":    map[string]string{"app": labelApp, "function": sanitized},
 		},
-		"spec": map[string]any{
-			"restartPolicy": "Never",
-			"containers": []map[string]any{{
-				"name":            "lambda",
-				"image":           image,
-				"imagePullPolicy": "IfNotPresent",
-				"args":            args,
-				"env":             env,
-				"ports":           []map[string]any{{"containerPort": riePort}},
-				"resources": map[string]any{
-					"requests": map[string]string{"cpu": "100m", "memory": "64Mi"},
-					"limits":   map[string]string{"cpu": "1", "memory": fmt.Sprintf("%dMi", memMB)},
-				},
-				"readinessProbe": map[string]any{
-					"tcpSocket":           map[string]any{"port": riePort},
-					"initialDelaySeconds": 1,
-					"periodSeconds":       1,
-					"failureThreshold":    30,
-				},
-			}},
-		},
+		"spec": podSpec,
 	}
 
 	podBody, _ := json.Marshal(podManifest)
@@ -298,6 +310,10 @@ func (e *K8sExecutor) createPod(ctx context.Context, req InvokeRequest) (*warmPo
 	slog.Info("lambda k8s: pod created", "pod", podName, "function", req.FunctionName)
 
 	// Create ClusterIP service (idempotent — ignore errors if already exists).
+	type svcPort struct {
+		Port       int `json:"port"`
+		TargetPort int `json:"targetPort"`
+	}
 	svcManifest := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Service",
@@ -309,7 +325,7 @@ func (e *K8sExecutor) createPod(ctx context.Context, req InvokeRequest) (*warmPo
 		"spec": map[string]any{
 			"type":     "ClusterIP",
 			"selector": map[string]string{"function": sanitized},
-			"ports":    []map[string]any{{"port": riePort, "targetPort": riePort}},
+			"ports":    []svcPort{{Port: riePort, TargetPort: riePort}},
 		},
 	}
 	svcBody, _ := json.Marshal(svcManifest)

--- a/internal/executor/spark/aws_transform.go
+++ b/internal/executor/spark/aws_transform.go
@@ -1,6 +1,64 @@
 package spark
 
-import "strings"
+import (
+	"strings"
+
+	"jaiscloud/internal/k8stypes"
+	"jaiscloud/internal/model"
+)
+
+// awsTransform implements CloudSparkTransform for AWS EMR / EMR-on-EKS.
+type awsTransform struct{}
+
+func init() { RegisterTransform(model.CloudAWS, awsTransform{}) }
+
+func (awsTransform) Cloud() model.Cloud { return model.CloudAWS }
+
+func (awsTransform) Rewrite(uri string, _ SparkConfig) string { return uri } // s3a:// is native on AWS
+
+func (t awsTransform) ResolveCommand(job SparkJob, cfg SparkConfig) SparkSubmitCommand {
+	return AWSResolveSparkCommand(job, cfg)
+}
+
+func (awsTransform) PodEnv(cfg SparkConfig) []k8stypes.EnvVar {
+	if cfg.S3Endpoint == "" {
+		return nil
+	}
+	return toEnvVars(map[string]string{
+		"AWS_ENDPOINT_URL":          cfg.S3Endpoint,
+		"AWS_REGION":                cfg.Region,
+		"AWS_ACCESS_KEY_ID":         cfg.AWSAccessKey,
+		"AWS_SECRET_ACCESS_KEY":     cfg.AWSSecretKey,
+		"AWS_S3_FORCE_PATH_STYLE":   "true",
+	})
+}
+
+func (awsTransform) PodVolumes(cfg SparkConfig) ([]k8stypes.Volume, []k8stypes.VolumeMount) {
+	if cfg.S3Endpoint == "" {
+		return nil, nil
+	}
+	vols := []k8stypes.Volume{{
+		Name:      "jaiscloud-aws-credentials",
+		ConfigMap: &k8stypes.ConfigMapVol{Name: "jaiscloud-aws-credentials"},
+	}}
+	mounts := []k8stypes.VolumeMount{{
+		Name:      "jaiscloud-aws-credentials",
+		MountPath: "/etc/aws",
+		ReadOnly:  true,
+	}}
+	return vols, mounts
+}
+
+func (awsTransform) SparkConfs(cfg SparkConfig) []string {
+	if cfg.S3Endpoint == "" {
+		return nil
+	}
+	image := cfg.Image
+	if image == "" {
+		image = DefaultImage
+	}
+	return awsDevboxSparkConfs(cfg, image)
+}
 
 // SparkSubmitCommand holds the resolved container command and arguments
 // after applying all transformations for local execution.

--- a/internal/executor/spark/azure_transform.go
+++ b/internal/executor/spark/azure_transform.go
@@ -1,0 +1,99 @@
+package spark
+
+import (
+	"fmt"
+
+	"jaiscloud/internal/k8stypes"
+	"jaiscloud/internal/model"
+)
+
+type azureTransform struct{}
+
+func init() { RegisterTransform(model.CloudAzure, azureTransform{}) }
+
+func (azureTransform) Cloud() model.Cloud { return model.CloudAzure }
+
+func (azureTransform) Rewrite(uri string, cfg SparkConfig) string {
+	return rewriteS3aToABFS(uri, cfg.AzureStorageAccount)
+}
+
+func (azureTransform) ResolveCommand(job SparkJob, cfg SparkConfig) SparkSubmitCommand {
+	image := resolveImage(job, cfg)
+	binary := resolveContainerBinary("spark-submit")
+	args := rewriteSparkMaster(SparkSubmitArgs(job))
+	return SparkSubmitCommand{Binary: binary, Args: args, Image: image}
+}
+
+func (azureTransform) PodEnv(cfg SparkConfig) []k8stypes.EnvVar {
+	m := map[string]string{
+		"AZURE_STORAGE_ACCOUNT": cfg.AzureStorageAccount,
+	}
+	if cfg.AzureStorageKey != "" {
+		// Shared key auth
+		m["AZURE_STORAGE_KEY"] = cfg.AzureStorageKey
+	} else {
+		// OAuth / Workload Identity
+		m["AZURE_CLIENT_ID"] = cfg.AzureClientID
+		m["AZURE_CLIENT_SECRET"] = cfg.AzureClientSecret
+		m["AZURE_TENANT_ID"] = cfg.AzureTenantID
+	}
+	return toEnvVars(m)
+}
+
+func (azureTransform) PodVolumes(cfg SparkConfig) ([]k8stypes.Volume, []k8stypes.VolumeMount) {
+	// Workload Identity projected volume only in OAuth mode (no storage key).
+	if cfg.AzureStorageKey != "" {
+		return nil, nil
+	}
+	expirySeconds := int64(3600)
+	vol := k8stypes.Volume{
+		Name: azureIdentityVolumeName,
+		Projected: &k8stypes.ProjectedVol{
+			Sources: []k8stypes.ProjectionElement{
+				{ServiceAccountToken: &k8stypes.SATokenProjection{
+					Audience:          "api://AzureADTokenExchange",
+					ExpirationSeconds: expirySeconds,
+					Path:              "token",
+				}},
+				{DownwardAPI: &k8stypes.DownwardAPIProjection{
+					Items: []k8stypes.DownwardAPIItem{
+						{Path: "labels", FieldRef: &k8stypes.ObjectFieldSelector{FieldPath: "metadata.labels"}},
+						{Path: "namespace", FieldRef: &k8stypes.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
+					},
+				}},
+			},
+		},
+	}
+	mount := k8stypes.VolumeMount{
+		Name:      azureIdentityVolumeName,
+		MountPath: "/var/run/secrets/azure/identity",
+	}
+	return []k8stypes.Volume{vol}, []k8stypes.VolumeMount{mount}
+}
+
+func (azureTransform) SparkConfs(cfg SparkConfig) []string {
+	acct := cfg.AzureStorageAccount
+	if acct == "" {
+		return nil
+	}
+	var confs []string
+	if cfg.AzureStorageKey != "" {
+		confs = append(confs,
+			"--conf", fmt.Sprintf("fs.azure.account.auth.type.%s.dfs.core.windows.net=SharedKey", acct),
+			"--conf", fmt.Sprintf("fs.azure.account.key.%s.dfs.core.windows.net=%s", acct, cfg.AzureStorageKey),
+		)
+	} else {
+		// OAuth / Workload Identity
+		confs = append(confs,
+			"--conf", fmt.Sprintf("fs.azure.account.auth.type.%s.dfs.core.windows.net=OAuth", acct),
+			"--conf", fmt.Sprintf("fs.azure.account.oauth.provider.type.%s.dfs.core.windows.net=org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider", acct),
+			"--conf", fmt.Sprintf("fs.azure.account.oauth2.client.id.%s.dfs.core.windows.net=%s", acct, cfg.AzureClientID),
+			"--conf", fmt.Sprintf("fs.azure.account.oauth2.client.secret.%s.dfs.core.windows.net=%s", acct, cfg.AzureClientSecret),
+			"--conf", fmt.Sprintf("fs.azure.account.oauth2.client.endpoint.%s.dfs.core.windows.net=https://login.microsoftonline.com/%s/oauth2/token", acct, cfg.AzureTenantID),
+		)
+	}
+	if cfg.AzureStorageEndpoint != "" {
+		confs = append(confs, "--conf", "fs.azure.endpoint="+cfg.AzureStorageEndpoint)
+	}
+	return confs
+}

--- a/internal/executor/spark/azure_transform_test.go
+++ b/internal/executor/spark/azure_transform_test.go
@@ -1,0 +1,165 @@
+package spark
+
+import (
+	"strings"
+	"testing"
+)
+
+func azureCfgSharedKey() SparkConfig {
+	cfg := SparkConfigFrom("k8s", SizeSmall)
+	cfg.AzureStorageAccount = "mystorageacct"
+	cfg.AzureStorageKey = "base64key=="
+	return cfg
+}
+
+func azureCfgOAuth() SparkConfig {
+	cfg := SparkConfigFrom("k8s", SizeSmall)
+	cfg.AzureStorageAccount = "mystorageacct"
+	cfg.AzureClientID = "client-id"
+	cfg.AzureClientSecret = "client-secret"
+	cfg.AzureTenantID = "tenant-id"
+	return cfg
+}
+
+func TestAzureTransform_PodEnv_SharedKey(t *testing.T) {
+	envs := azureTransform{}.PodEnv(azureCfgSharedKey())
+	names := make(map[string]string, len(envs))
+	for _, e := range envs {
+		names[e.Name] = e.Value
+	}
+	if names["AZURE_STORAGE_ACCOUNT"] != "mystorageacct" {
+		t.Errorf("AZURE_STORAGE_ACCOUNT: got %q", names["AZURE_STORAGE_ACCOUNT"])
+	}
+	if names["AZURE_STORAGE_KEY"] != "base64key==" {
+		t.Errorf("AZURE_STORAGE_KEY: got %q", names["AZURE_STORAGE_KEY"])
+	}
+	if _, ok := names["AZURE_CLIENT_ID"]; ok {
+		t.Error("AZURE_CLIENT_ID should not be set in SharedKey mode")
+	}
+}
+
+func TestAzureTransform_PodEnv_OAuth(t *testing.T) {
+	envs := azureTransform{}.PodEnv(azureCfgOAuth())
+	names := make(map[string]string, len(envs))
+	for _, e := range envs {
+		names[e.Name] = e.Value
+	}
+	if names["AZURE_CLIENT_ID"] != "client-id" {
+		t.Errorf("AZURE_CLIENT_ID: got %q", names["AZURE_CLIENT_ID"])
+	}
+	if names["AZURE_TENANT_ID"] != "tenant-id" {
+		t.Errorf("AZURE_TENANT_ID: got %q", names["AZURE_TENANT_ID"])
+	}
+	if _, ok := names["AZURE_STORAGE_KEY"]; ok {
+		t.Error("AZURE_STORAGE_KEY should not be set in OAuth mode")
+	}
+}
+
+func TestAzureTransform_PodVolumes_SharedKey_NoVolumes(t *testing.T) {
+	vols, mounts := azureTransform{}.PodVolumes(azureCfgSharedKey())
+	if len(vols) != 0 || len(mounts) != 0 {
+		t.Errorf("SharedKey mode should produce no volumes/mounts; got %d vols, %d mounts", len(vols), len(mounts))
+	}
+}
+
+func TestAzureTransform_PodVolumes_OAuth_ProjectedVolume(t *testing.T) {
+	vols, mounts := azureTransform{}.PodVolumes(azureCfgOAuth())
+	if len(vols) != 1 {
+		t.Fatalf("OAuth mode should produce 1 volume; got %d", len(vols))
+	}
+	if vols[0].Name != azureIdentityVolumeName {
+		t.Errorf("volume name: got %q, want %q", vols[0].Name, azureIdentityVolumeName)
+	}
+	if vols[0].Projected == nil {
+		t.Error("volume should be projected")
+	}
+	if len(mounts) != 1 {
+		t.Fatalf("OAuth mode should produce 1 mount; got %d", len(mounts))
+	}
+	if mounts[0].MountPath != "/var/run/secrets/azure/identity" {
+		t.Errorf("mount path: got %q", mounts[0].MountPath)
+	}
+}
+
+func TestAzureTransform_SparkConfs_SharedKey(t *testing.T) {
+	confs := azureTransform{}.SparkConfs(azureCfgSharedKey())
+	confsStr := strings.Join(confs, " ")
+	if !strings.Contains(confsStr, "SharedKey") {
+		t.Error("SharedKey confs should contain auth.type=SharedKey")
+	}
+	if !strings.Contains(confsStr, "account.key.mystorageacct") {
+		t.Error("SharedKey confs should contain the account key conf")
+	}
+	if strings.Contains(confsStr, "OAuth") {
+		t.Error("SharedKey confs must not contain OAuth")
+	}
+	// Verify proper --conf pairing (even number of elements)
+	if len(confs)%2 != 0 {
+		t.Errorf("confs must have even length (--conf KEY=VAL pairs); got %d", len(confs))
+	}
+	for i := 0; i < len(confs); i += 2 {
+		if confs[i] != "--conf" {
+			t.Errorf("confs[%d] should be --conf, got %q", i, confs[i])
+		}
+	}
+}
+
+func TestAzureTransform_SparkConfs_OAuth(t *testing.T) {
+	confs := azureTransform{}.SparkConfs(azureCfgOAuth())
+	confsStr := strings.Join(confs, " ")
+	if !strings.Contains(confsStr, "OAuth") {
+		t.Error("OAuth confs should contain auth.type=OAuth")
+	}
+	if strings.Contains(confsStr, "SharedKey") {
+		t.Error("OAuth confs must not contain SharedKey")
+	}
+	if !strings.Contains(confsStr, "client-id") {
+		t.Error("OAuth confs should contain client ID")
+	}
+	if !strings.Contains(confsStr, "tenant-id") {
+		t.Error("OAuth confs should contain tenant endpoint")
+	}
+	if len(confs)%2 != 0 {
+		t.Errorf("confs must have even length; got %d", len(confs))
+	}
+}
+
+func TestAzureTransform_SparkConfs_Empty_NoAccount(t *testing.T) {
+	cfg := SparkConfigFrom("k8s", SizeSmall)
+	confs := azureTransform{}.SparkConfs(cfg)
+	if len(confs) != 0 {
+		t.Errorf("no storage account should produce empty confs; got %v", confs)
+	}
+}
+
+func TestAzureTransform_Rewrite_S3aToABFS(t *testing.T) {
+	cfg := azureCfgSharedKey() // AzureStorageAccount = "mystorageacct"
+	tr := azureTransform{}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"s3a://mybucket/path/to/file", "abfss://mybucket@mystorageacct.dfs.core.windows.net/path/to/file"},
+		{"s3a://mybucket", "abfss://mybucket@mystorageacct.dfs.core.windows.net"},
+		{"gs://other/path", "gs://other/path"},    // non-s3a passthrough
+		{"s3://native/key", "s3://native/key"},    // non-s3a passthrough
+		{"", ""},                                  // empty passthrough
+	}
+	for _, tt := range tests {
+		got := tr.Rewrite(tt.input, cfg)
+		if got != tt.want {
+			t.Errorf("Rewrite(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestAzureTransform_SparkConfs_StorageEndpoint(t *testing.T) {
+	cfg := azureCfgSharedKey()
+	cfg.AzureStorageEndpoint = "https://custom-endpoint.azure.com"
+	confs := azureTransform{}.SparkConfs(cfg)
+	confsStr := strings.Join(confs, " ")
+	if !strings.Contains(confsStr, "fs.azure.endpoint=https://custom-endpoint.azure.com") {
+		t.Error("custom storage endpoint should appear in confs")
+	}
+}

--- a/internal/executor/spark/cloud_transform.go
+++ b/internal/executor/spark/cloud_transform.go
@@ -1,0 +1,100 @@
+package spark
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"jaiscloud/internal/k8stypes"
+	"jaiscloud/internal/model"
+)
+
+// CloudSparkTransform encapsulates all cloud-specific contributions to a
+// Spark K8s Job manifest. Implementations register themselves via init().
+type CloudSparkTransform interface {
+	Cloud() model.Cloud
+	// Rewrite rewrites a cloud-neutral URI (e.g. s3a://bucket/key) into the
+	// cloud's native scheme. It receives cfg so it can use cloud-specific
+	// identifiers (e.g. Azure storage account). Idempotent.
+	Rewrite(uri string, cfg SparkConfig) string
+	ResolveCommand(job SparkJob, cfg SparkConfig) SparkSubmitCommand
+	PodEnv(cfg SparkConfig) []envVar
+	PodVolumes(cfg SparkConfig) ([]volume, []volumeMount)
+	SparkConfs(cfg SparkConfig) []string
+}
+
+// transformsMu guards transforms against concurrent access (e.g. parallel tests).
+var transformsMu sync.RWMutex
+
+// transforms is the global registry populated by each cloud's init().
+var transforms = map[model.Cloud]CloudSparkTransform{}
+
+// RegisterTransform registers a CloudSparkTransform for the given cloud.
+// Called from init() in aws_transform.go, azure_transform.go, gcp_transform.go.
+func RegisterTransform(c model.Cloud, t CloudSparkTransform) {
+	transformsMu.Lock()
+	defer transformsMu.Unlock()
+	transforms[c] = t
+}
+
+// selectTransform returns the registered transform for cloud c.
+// Returns an error for unknown clouds (defensive; config validates at startup).
+func selectTransform(c model.Cloud) (CloudSparkTransform, error) {
+	transformsMu.RLock()
+	defer transformsMu.RUnlock()
+	t, ok := transforms[c]
+	if !ok {
+		return nil, fmt.Errorf("spark: no transform registered for cloud %q", c)
+	}
+	return t, nil
+}
+
+// rewriteURIs applies t.Rewrite(uri, cfg) to every element of args.
+func rewriteURIs(t CloudSparkTransform, args []string, cfg SparkConfig) []string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		out[i] = t.Rewrite(a, cfg)
+	}
+	return out
+}
+
+// rewriteS3aToABFS rewrites s3a://bucket/key → abfss://bucket@account.dfs.core.windows.net/key.
+// Used by the Azure transform.
+func rewriteS3aToABFS(uri, storageAccount string) string {
+	const prefix = "s3a://"
+	if !strings.HasPrefix(uri, prefix) {
+		return uri
+	}
+	rest := strings.TrimPrefix(uri, prefix)
+	bucket, path, _ := strings.Cut(rest, "/")
+	host := bucket + "@" + storageAccount + ".dfs.core.windows.net"
+	if path != "" {
+		return "abfss://" + host + "/" + path
+	}
+	return "abfss://" + host
+}
+
+// rewriteS3aToGCS rewrites s3a://bucket/key → gs://bucket/key.
+// Used by the GCP transform.
+func rewriteS3aToGCS(uri string) string {
+	const prefix = "s3a://"
+	if !strings.HasPrefix(uri, prefix) {
+		return uri
+	}
+	return "gs://" + strings.TrimPrefix(uri, prefix)
+}
+
+// gcpSAVolumeName is the K8s volume name for the GCP service-account key Secret.
+const gcpSAVolumeName = "jaiscloud-gcp-sa-key"
+
+// azureIdentityVolumeName is the K8s volume name for the Azure Workload Identity projection.
+const azureIdentityVolumeName = "jaiscloud-azure-identity"
+
+// toEnvVars converts a string map to a []envVar slice.
+func toEnvVars(m map[string]string) []k8stypes.EnvVar {
+	out := make([]k8stypes.EnvVar, 0, len(m))
+	for k, v := range m {
+		out = append(out, k8stypes.EnvVar{Name: k, Value: v})
+	}
+	return out
+}

--- a/internal/executor/spark/cloud_transform_test.go
+++ b/internal/executor/spark/cloud_transform_test.go
@@ -1,0 +1,102 @@
+package spark
+
+import (
+	"strings"
+	"testing"
+
+	"jaiscloud/internal/model"
+)
+
+func TestSelectTransform_Registered(t *testing.T) {
+	for _, cloud := range []model.Cloud{model.CloudAWS, model.CloudAzure, model.CloudGCP} {
+		t.Run(string(cloud), func(t *testing.T) {
+			tr, err := selectTransform(cloud)
+			if err != nil {
+				t.Fatalf("selectTransform(%q): %v", cloud, err)
+			}
+			if tr.Cloud() != cloud {
+				t.Errorf("Cloud() = %q, want %q", tr.Cloud(), cloud)
+			}
+		})
+	}
+}
+
+func TestSelectTransform_Unknown(t *testing.T) {
+	_, err := selectTransform(model.Cloud("nublar"))
+	if err == nil {
+		t.Fatal("expected error for unknown cloud, got nil")
+	}
+}
+
+func TestRewriteS3aToABFS_WithBucket(t *testing.T) {
+	got := rewriteS3aToABFS("s3a://mybucket/some/key.parquet", "mystorageacct")
+	want := "abfss://mybucket@mystorageacct.dfs.core.windows.net/some/key.parquet"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewriteS3aToABFS_BucketOnly(t *testing.T) {
+	got := rewriteS3aToABFS("s3a://mybucket", "acct")
+	want := "abfss://mybucket@acct.dfs.core.windows.net"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewriteS3aToABFS_NonS3APassthrough(t *testing.T) {
+	uri := "gs://bucket/key"
+	if got := rewriteS3aToABFS(uri, "acct"); got != uri {
+		t.Errorf("non-s3a URI should pass through unchanged, got %q", got)
+	}
+}
+
+func TestRewriteS3aToABFS_PlainArgPassthrough(t *testing.T) {
+	arg := "--master"
+	if got := rewriteS3aToABFS(arg, "acct"); got != arg {
+		t.Errorf("plain arg should pass through unchanged, got %q", got)
+	}
+}
+
+func TestRewriteS3aToGCS(t *testing.T) {
+	got := rewriteS3aToGCS("s3a://bucket/path/to/file.jar")
+	want := "gs://bucket/path/to/file.jar"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRewriteS3aToGCS_NonS3APassthrough(t *testing.T) {
+	uri := "abfss://bucket@acct.dfs.core.windows.net/key"
+	if got := rewriteS3aToGCS(uri); got != uri {
+		t.Errorf("non-s3a URI should pass through unchanged, got %q", got)
+	}
+}
+
+func TestRewriteURIs_GCP(t *testing.T) {
+	tr, _ := selectTransform(model.CloudGCP)
+	args := []string{"--class", "com.example.Main", "s3a://bucket/app.jar", "s3a://bucket/data"}
+	got := rewriteURIs(tr, args, SparkConfig{})
+	for i, a := range got {
+		if strings.HasPrefix(a, "s3a://") {
+			t.Errorf("arg[%d] still has s3a:// prefix after rewrite: %q", i, a)
+		}
+	}
+	if got[0] != "--class" {
+		t.Errorf("non-URI arg[0] changed: got %q, want %q", got[0], "--class")
+	}
+	if got[2] != "gs://bucket/app.jar" {
+		t.Errorf("arg[2]: got %q, want %q", got[2], "gs://bucket/app.jar")
+	}
+}
+
+func TestRewriteURIs_AWS_Passthrough(t *testing.T) {
+	tr, _ := selectTransform(model.CloudAWS)
+	args := []string{"s3a://bucket/app.jar", "--master", "local[*]"}
+	got := rewriteURIs(tr, args, SparkConfig{})
+	for i := range args {
+		if got[i] != args[i] {
+			t.Errorf("AWS rewrite should be identity; arg[%d]: got %q, want %q", i, got[i], args[i])
+		}
+	}
+}

--- a/internal/executor/spark/config.go
+++ b/internal/executor/spark/config.go
@@ -1,6 +1,10 @@
 package spark
 
-import "os"
+import (
+	"os"
+
+	"jaiscloud/internal/model"
+)
 
 // ClusterSize is a named resource profile for Spark jobs.
 type ClusterSize string
@@ -108,6 +112,26 @@ type SparkConfig struct {
 	// AWSSecretKey is the AWS secret access key injected into Spark pods.
 	// Defaults to JAISCLOUD_AWS_SECRET_ACCESS_KEY or "test".
 	AWSSecretKey string
+
+	// ExtraSparkConfs are additional --conf flags layered after cloud-transform confs.
+	ExtraSparkConfs []string
+
+	// Cloud identifies which cloud transform to apply when building K8s manifests.
+	Cloud model.Cloud
+
+	// Azure-specific
+	AzureStorageAccount  string
+	AzureStorageKey      string
+	AzureClientID        string
+	AzureClientSecret    string
+	AzureTenantID        string
+	AzureStorageEndpoint string
+
+	// GCP-specific
+	GCPProjectID             string
+	GCPServiceAccountKeyPath string
+	GCPServiceAccountSecret  string
+	GCPStorageEndpoint       string
 }
 
 // SparkConfigFrom builds a SparkConfig from the executor mode and optional overrides.
@@ -148,6 +172,21 @@ func SparkConfigFrom(mode string, size ClusterSize, overrides ...func(*SparkConf
 	if v := os.Getenv("JAISCLOUD_AWS_SECRET_ACCESS_KEY"); v != "" {
 		cfg.AWSSecretKey = v
 	}
+
+	// Azure
+	cfg.AzureStorageAccount = os.Getenv("JAISCLOUD_AZURE_STORAGE_ACCOUNT")
+	cfg.AzureStorageKey = os.Getenv("JAISCLOUD_AZURE_STORAGE_KEY")
+	cfg.AzureClientID = os.Getenv("JAISCLOUD_AZURE_CLIENT_ID")
+	cfg.AzureClientSecret = os.Getenv("JAISCLOUD_AZURE_CLIENT_SECRET")
+	cfg.AzureTenantID = os.Getenv("JAISCLOUD_AZURE_TENANT_ID")
+	cfg.AzureStorageEndpoint = os.Getenv("JAISCLOUD_AZURE_STORAGE_ENDPOINT")
+
+	// GCP
+	cfg.GCPProjectID = os.Getenv("JAISCLOUD_GCP_PROJECT_ID")
+	cfg.GCPServiceAccountKeyPath = os.Getenv("JAISCLOUD_GCP_SERVICE_ACCOUNT_KEY_PATH")
+	cfg.GCPServiceAccountSecret = os.Getenv("JAISCLOUD_GCP_SERVICE_ACCOUNT_SECRET")
+	cfg.GCPStorageEndpoint = os.Getenv("JAISCLOUD_GCP_STORAGE_ENDPOINT")
+
 	for _, o := range overrides {
 		o(&cfg)
 	}

--- a/internal/executor/spark/docker.go
+++ b/internal/executor/spark/docker.go
@@ -3,8 +3,11 @@ package spark
 import (
 	"bytes"
 	"context"
+	"log/slog"
 	"os/exec"
 	"sync"
+
+	"jaiscloud/internal/platform"
 )
 
 // dockerJob tracks a running Docker container's state.
@@ -18,30 +21,27 @@ type dockerJob struct {
 // DockerExecutor runs spark-submit inside a Docker container (docker run --rm).
 // It requires the Docker daemon to be running and the specified image to be
 // available locally or pullable.
-//
-// The image is resolved in this order:
-//  1. job.SparkConf["spark.kubernetes.container.image"] (per-job override)
-//  2. cfg.Image passed to NewDockerExecutor (executor-level default)
-//  3. DefaultImage
-//
-// When S3Endpoint is set, AWS credential env vars and --network host are injected
-// so spark-submit can reach JaisCloud's S3 endpoint from inside the container.
 type DockerExecutor struct {
-	cfg  SparkConfig
-	jobs sync.Map // jobID → *dockerJob
+	cfg      SparkConfig
+	platform *platform.PlatformConfig
+	jobs     sync.Map // jobID → *dockerJob
 }
 
-// NewDockerExecutor creates a DockerExecutor. cfg.Image is the default Spark image.
-func NewDockerExecutor(cfg SparkConfig) *DockerExecutor {
+// NewDockerExecutor creates a DockerExecutor. plat may be nil.
+func NewDockerExecutor(cfg SparkConfig, plat *platform.PlatformConfig) *DockerExecutor {
 	if cfg.Image == "" {
 		cfg.Image = DefaultImage
 	}
-	return &DockerExecutor{cfg: cfg}
+	return &DockerExecutor{cfg: cfg, platform: plat}
 }
 
 // Submit launches a Docker container running spark-submit asynchronously.
 func (e *DockerExecutor) Submit(ctx context.Context, job SparkJob) error {
-	resolved := AWSResolveSparkCommand(job, e.cfg)
+	transform, err := selectTransform(e.cfg.Cloud)
+	if err != nil {
+		return err
+	}
+	resolved := transform.ResolveCommand(job, e.cfg)
 
 	dj := &dockerJob{state: StateRunning}
 	runCtx, cancel := context.WithCancel(context.Background())
@@ -52,15 +52,22 @@ func (e *DockerExecutor) Submit(ctx context.Context, job SparkJob) error {
 		defer cancel()
 
 		dockerArgs := []string{"run", "--rm", "--network", "host"}
-		if e.cfg.S3Endpoint != "" {
-			dockerArgs = append(dockerArgs,
-				"-e", "AWS_ENDPOINT_URL="+e.cfg.S3Endpoint,
-				"-e", "AWS_REGION="+e.cfg.Region,
-				"-e", "AWS_ACCESS_KEY_ID="+e.cfg.AWSAccessKey,
-				"-e", "AWS_SECRET_ACCESS_KEY="+e.cfg.AWSSecretKey,
-			)
+
+		// Cloud-specific env vars.
+		for _, ev := range transform.PodEnv(e.cfg) {
+			dockerArgs = append(dockerArgs, "-e", ev.Name+"="+ev.Value)
 		}
-		// Pass binary + args after image name (overrides CMD in container).
+
+		// Platform layer: TLS PEM bundle + extra volumes + extra env.
+		if e.platform != nil {
+			volArgs, envArgs, err := platform.ApplyDocker(e.platform)
+			if err != nil {
+				slog.Warn("spark docker: platform apply failed", "err", err)
+			}
+			dockerArgs = append(dockerArgs, volArgs...)
+			dockerArgs = append(dockerArgs, envArgs...)
+		}
+
 		dockerArgs = append(dockerArgs, resolved.Image, resolved.Binary)
 		dockerArgs = append(dockerArgs, resolved.Args...)
 
@@ -73,7 +80,7 @@ func (e *DockerExecutor) Submit(ctx context.Context, job SparkJob) error {
 		dj.mu.Lock()
 		defer dj.mu.Unlock()
 		if dj.state == StateCancelled {
-			return // Cancel() already set terminal state
+			return
 		}
 		if err != nil {
 			dj.state = StateFailed

--- a/internal/executor/spark/executor.go
+++ b/internal/executor/spark/executor.go
@@ -73,12 +73,14 @@ type SparkExecutor interface {
 
 // NewExecutor creates a SparkExecutor for the given mode.
 // mode: "mock" (default), "k8s", "local", "docker", "remote".
+// For K8s/Docker executors with a platform config, use NewK8sExecutor /
+// NewDockerExecutor directly.
 func NewExecutor(mode string, cfg SparkConfig) SparkExecutor {
 	switch mode {
 	case "k8s":
-		return NewK8sExecutor(cfg)
+		return NewK8sExecutor(cfg, nil)
 	case "docker":
-		return NewDockerExecutor(cfg)
+		return NewDockerExecutor(cfg, nil)
 	default:
 		return NewMockExecutor()
 	}

--- a/internal/executor/spark/gcp_transform.go
+++ b/internal/executor/spark/gcp_transform.go
@@ -1,0 +1,64 @@
+package spark
+
+import (
+	"jaiscloud/internal/k8stypes"
+	"jaiscloud/internal/model"
+)
+
+const gcpSAMountPath = "/etc/gcp"
+
+type gcpTransform struct{}
+
+func init() { RegisterTransform(model.CloudGCP, gcpTransform{}) }
+
+func (gcpTransform) Cloud() model.Cloud { return model.CloudGCP }
+
+func (gcpTransform) Rewrite(uri string, _ SparkConfig) string { return rewriteS3aToGCS(uri) }
+
+func (gcpTransform) ResolveCommand(job SparkJob, cfg SparkConfig) SparkSubmitCommand {
+	image := resolveImage(job, cfg)
+	binary := resolveContainerBinary("spark-submit")
+	args := rewriteSparkMaster(SparkSubmitArgs(job))
+	return SparkSubmitCommand{Binary: binary, Args: args, Image: image}
+}
+
+func (gcpTransform) PodEnv(cfg SparkConfig) []k8stypes.EnvVar {
+	m := map[string]string{
+		"GOOGLE_CLOUD_PROJECT": cfg.GCPProjectID,
+	}
+	if cfg.GCPServiceAccountKeyPath != "" {
+		m["GOOGLE_APPLICATION_CREDENTIALS"] = cfg.GCPServiceAccountKeyPath
+	} else if cfg.GCPServiceAccountSecret != "" {
+		m["GOOGLE_APPLICATION_CREDENTIALS"] = gcpSAMountPath + "/key.json"
+	}
+	return toEnvVars(m)
+}
+
+func (gcpTransform) PodVolumes(cfg SparkConfig) ([]k8stypes.Volume, []k8stypes.VolumeMount) {
+	if cfg.GCPServiceAccountSecret == "" {
+		return nil, nil
+	}
+	vol := k8stypes.Volume{
+		Name:   gcpSAVolumeName,
+		Secret: &k8stypes.SecretVol{SecretName: cfg.GCPServiceAccountSecret},
+	}
+	mount := k8stypes.VolumeMount{
+		Name:      gcpSAVolumeName,
+		MountPath: gcpSAMountPath,
+		ReadOnly:  true,
+	}
+	return []k8stypes.Volume{vol}, []k8stypes.VolumeMount{mount}
+}
+
+func (gcpTransform) SparkConfs(cfg SparkConfig) []string {
+	confs := []string{
+		"--conf", "spark.hadoop.google.cloud.auth.service.account.enable=true",
+	}
+	if cfg.GCPProjectID != "" {
+		confs = append(confs, "--conf", "spark.hadoop.fs.gs.project.id="+cfg.GCPProjectID)
+	}
+	if cfg.GCPStorageEndpoint != "" {
+		confs = append(confs, "--conf", "spark.hadoop.fs.gs.storage.root.url="+cfg.GCPStorageEndpoint)
+	}
+	return confs
+}

--- a/internal/executor/spark/gcp_transform_test.go
+++ b/internal/executor/spark/gcp_transform_test.go
@@ -1,0 +1,111 @@
+package spark
+
+import (
+	"strings"
+	"testing"
+)
+
+func gcpCfgWithSecret() SparkConfig {
+	cfg := SparkConfigFrom("k8s", SizeSmall)
+	cfg.GCPProjectID = "my-project"
+	cfg.GCPServiceAccountSecret = "gcp-sa-key-secret"
+	return cfg
+}
+
+func gcpCfgWithKeyPath() SparkConfig {
+	cfg := SparkConfigFrom("k8s", SizeSmall)
+	cfg.GCPProjectID = "my-project"
+	cfg.GCPServiceAccountKeyPath = "/etc/gcp/key.json"
+	return cfg
+}
+
+func TestGCPTransform_PodEnv_WithKeyPath(t *testing.T) {
+	envs := gcpTransform{}.PodEnv(gcpCfgWithKeyPath())
+	names := make(map[string]string, len(envs))
+	for _, e := range envs {
+		names[e.Name] = e.Value
+	}
+	if names["GOOGLE_CLOUD_PROJECT"] != "my-project" {
+		t.Errorf("GOOGLE_CLOUD_PROJECT: got %q", names["GOOGLE_CLOUD_PROJECT"])
+	}
+	if names["GOOGLE_APPLICATION_CREDENTIALS"] != "/etc/gcp/key.json" {
+		t.Errorf("GOOGLE_APPLICATION_CREDENTIALS: got %q", names["GOOGLE_APPLICATION_CREDENTIALS"])
+	}
+}
+
+func TestGCPTransform_PodEnv_WithSecret(t *testing.T) {
+	envs := gcpTransform{}.PodEnv(gcpCfgWithSecret())
+	names := make(map[string]string, len(envs))
+	for _, e := range envs {
+		names[e.Name] = e.Value
+	}
+	wantCreds := gcpSAMountPath + "/key.json"
+	if names["GOOGLE_APPLICATION_CREDENTIALS"] != wantCreds {
+		t.Errorf("GOOGLE_APPLICATION_CREDENTIALS: got %q, want %q", names["GOOGLE_APPLICATION_CREDENTIALS"], wantCreds)
+	}
+}
+
+func TestGCPTransform_PodVolumes_WithSecret(t *testing.T) {
+	vols, mounts := gcpTransform{}.PodVolumes(gcpCfgWithSecret())
+	if len(vols) != 1 {
+		t.Fatalf("expected 1 volume; got %d", len(vols))
+	}
+	if vols[0].Name != gcpSAVolumeName {
+		t.Errorf("volume name: got %q, want %q", vols[0].Name, gcpSAVolumeName)
+	}
+	if vols[0].Secret == nil || vols[0].Secret.SecretName != "gcp-sa-key-secret" {
+		t.Errorf("volume should be a secret named gcp-sa-key-secret; got %+v", vols[0])
+	}
+	if len(mounts) != 1 || mounts[0].MountPath != gcpSAMountPath {
+		t.Errorf("mount path: got %+v", mounts)
+	}
+	if !mounts[0].ReadOnly {
+		t.Error("SA key mount should be read-only")
+	}
+}
+
+func TestGCPTransform_PodVolumes_NoSecret(t *testing.T) {
+	cfg := gcpCfgWithKeyPath() // key path set, no secret
+	vols, mounts := gcpTransform{}.PodVolumes(cfg)
+	if len(vols) != 0 || len(mounts) != 0 {
+		t.Errorf("no secret should produce no volumes/mounts; got %d vols, %d mounts", len(vols), len(mounts))
+	}
+}
+
+func TestGCPTransform_SparkConfs_AlwaysIncludesAuth(t *testing.T) {
+	cfg := gcpCfgWithSecret()
+	confs := gcpTransform{}.SparkConfs(cfg)
+	confsStr := strings.Join(confs, " ")
+	if !strings.Contains(confsStr, "google.cloud.auth.service.account.enable=true") {
+		t.Error("GCP confs should always include service account auth enable")
+	}
+	if !strings.Contains(confsStr, "fs.gs.project.id=my-project") {
+		t.Error("GCP confs should include project ID")
+	}
+	if len(confs)%2 != 0 {
+		t.Errorf("confs must have even length; got %d: %v", len(confs), confs)
+	}
+	for i := 0; i < len(confs); i += 2 {
+		if confs[i] != "--conf" {
+			t.Errorf("confs[%d] should be --conf, got %q", i, confs[i])
+		}
+	}
+}
+
+func TestGCPTransform_SparkConfs_StorageEndpoint(t *testing.T) {
+	cfg := gcpCfgWithSecret()
+	cfg.GCPStorageEndpoint = "https://storage.googleapis.com"
+	confs := gcpTransform{}.SparkConfs(cfg)
+	confsStr := strings.Join(confs, " ")
+	if !strings.Contains(confsStr, "fs.gs.storage.root.url=https://storage.googleapis.com") {
+		t.Error("GCP confs should include custom storage endpoint")
+	}
+}
+
+func TestGCPTransform_Rewrite(t *testing.T) {
+	got := gcpTransform{}.Rewrite("s3a://my-bucket/data/file.parquet", SparkConfig{})
+	want := "gs://my-bucket/data/file.parquet"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/internal/executor/spark/k8s.go
+++ b/internal/executor/spark/k8s.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"jaiscloud/internal/platform"
 )
 
 // dnsNameRe matches characters that are NOT allowed in a K8s DNS label.
@@ -24,14 +26,15 @@ var dnsNameRe = regexp.MustCompile(`[^a-z0-9-]`)
 //  2. In-cluster service account at /var/run/secrets/kubernetes.io/serviceaccount/
 //  3. Unauthenticated (development only)
 type K8sExecutor struct {
-	cfg    SparkConfig
-	client *k8sClient
-	jobs   sync.Map // jobID (string) → k8s Job name (string)
+	cfg      SparkConfig
+	platform *platform.PlatformConfig
+	client   *k8sClient
+	jobs     sync.Map // jobID (string) → k8s Job name (string)
 }
 
 // NewK8sExecutor builds a K8sExecutor. Auth and TLS config are resolved from
-// env vars and in-cluster service account files.
-func NewK8sExecutor(cfg SparkConfig) *K8sExecutor {
+// env vars and in-cluster service account files. plat may be nil.
+func NewK8sExecutor(cfg SparkConfig, plat *platform.PlatformConfig) *K8sExecutor {
 	apiURL := cfg.APIServer
 	if apiURL == "" {
 		apiURL = DefaultAPIServer
@@ -49,7 +52,7 @@ func NewK8sExecutor(cfg SparkConfig) *K8sExecutor {
 		fmt.Fprintf(os.Stderr, "[K8sExecutor] init error: %v\n", err)
 		return &K8sExecutor{cfg: cfg}
 	}
-	e := &K8sExecutor{cfg: cfg, client: client}
+	e := &K8sExecutor{cfg: cfg, platform: plat, client: client}
 	go e.cleanupOrphans()
 	return e
 }
@@ -93,7 +96,10 @@ func (e *K8sExecutor) Submit(ctx context.Context, job SparkJob) error {
 	}
 
 	jobName := k8sJobName(job.JobID)
-	manifest := e.buildJobManifest(jobName, job)
+	manifest, err := e.buildJobManifest(jobName, job)
+	if err != nil {
+		return fmt.Errorf("K8sExecutor: build manifest: %w", err)
+	}
 
 	if err := e.client.createJob(ctx, manifest); err != nil {
 		return fmt.Errorf("K8sExecutor: create job %s: %w", jobName, err)
@@ -385,50 +391,53 @@ func jobFailureMessage(s batchJobStatus) string {
 }
 
 // buildJobManifest constructs a batch/v1 Job that runs spark-submit.
-func (e *K8sExecutor) buildJobManifest(jobName string, job SparkJob) batchJob {
+func (e *K8sExecutor) buildJobManifest(jobName string, job SparkJob) (batchJob, error) {
 	backoffLimit := 0
 	ttl := 3600
 
-	resolved := AWSResolveSparkCommand(job, e.cfg)
+	transform, err := selectTransform(e.cfg.Cloud)
+	if err != nil {
+		return batchJob{}, err
+	}
+
+	cmd := transform.ResolveCommand(job, e.cfg)
+
+	// URI rewriting applied once across all argument sources.
+	cmd.Args = rewriteURIs(transform, cmd.Args, e.cfg)
+	cloudConfs := rewriteURIs(transform, transform.SparkConfs(e.cfg), e.cfg)
+	extraConfs := rewriteURIs(transform, e.cfg.ExtraSparkConfs, e.cfg)
+
+	cmd.Args = insertBeforeJar(cmd.Args, cloudConfs)
+	cmd.Args = insertBeforeJar(cmd.Args, extraConfs)
+
+	cloudVols, cloudMounts := transform.PodVolumes(e.cfg)
 
 	ctr := container{
-		Name:    "spark-submit",
-		Image:   resolved.Image,
-		Command: []string{resolved.Binary},
-		Args:    resolved.Args,
+		Name:            "spark-submit",
+		Image:           cmd.Image,
+		Command:         []string{cmd.Binary},
+		Args:            cmd.Args,
+		ImagePullPolicy: "Never",
+		Env:             transform.PodEnv(e.cfg),
+		VolumeMounts:    cloudMounts,
 	}
 
-	spec := podSpec{
-		RestartPolicy: "Never",
+	spec := podSpec{RestartPolicy: "Never"}
+	if e.cfg.ServiceAccount != "" {
+		spec.ServiceAccountName = e.cfg.ServiceAccount
 	}
+	spec.Volumes = append(spec.Volumes, cloudVols...)
 
-	if e.cfg.S3Endpoint != "" {
-		ctr.ImagePullPolicy = "Never"
-		ctr.Env = []envVar{
-			{Name: "AWS_ENDPOINT_URL", Value: e.cfg.S3Endpoint},
-			{Name: "AWS_REGION", Value: e.cfg.Region},
-			{Name: "AWS_ACCESS_KEY_ID", Value: e.cfg.AWSAccessKey},
-			{Name: "AWS_SECRET_ACCESS_KEY", Value: e.cfg.AWSSecretKey},
-		}
-		ctr.VolumeMounts = []volumeMount{{
-			Name:      "jaiscloud-aws-credentials",
-			MountPath: "/etc/aws",
-			ReadOnly:  true,
-		}}
-		spec.Volumes = []volume{{
-			Name:      "jaiscloud-aws-credentials",
-			ConfigMap: &configMapRef{Name: "jaiscloud-aws-credentials"},
-		}}
+	// Platform layer: TLS, generic volumes, env — applied after cloud contributions.
+	if err := platform.ApplyK8s(&spec, &ctr, e.platform); err != nil {
+		return batchJob{}, fmt.Errorf("platform apply: %w", err)
 	}
 
 	spec.Containers = []container{ctr}
 
-	if e.cfg.ServiceAccount != "" {
-		spec.ServiceAccountName = e.cfg.ServiceAccount
-	}
-
 	labels := map[string]string{
 		"app.kubernetes.io/managed-by": "jaiscloud",
+		"jaiscloud-cloud":              string(e.cfg.Cloud),
 		"jaiscloud-job-id":             sanitizeLabel(job.JobID),
 	}
 
@@ -448,5 +457,5 @@ func (e *K8sExecutor) buildJobManifest(jobName string, job SparkJob) batchJob {
 				Spec:     spec,
 			},
 		},
-	}
+	}, nil
 }

--- a/internal/executor/spark/k8s_test.go
+++ b/internal/executor/spark/k8s_test.go
@@ -96,6 +96,7 @@ func newTestK8sExecutor(t *testing.T, fk *fakeK8s) *K8sExecutor {
 	cfg := SparkConfigFrom("k8s", SizeSmall)
 	cfg.Image = "apache/spark:3.5.0"
 	cfg.Namespace = "default"
+	cfg.Cloud = "aws"
 	return &K8sExecutor{cfg: cfg, client: fk.client}
 }
 

--- a/internal/executor/spark/k8sclient.go
+++ b/internal/executor/spark/k8sclient.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"os"
 	"strings"
+
+	"jaiscloud/internal/k8stypes"
 )
 
 const (
@@ -123,14 +125,24 @@ func newInClusterClient(namespace string) (*k8sClient, error) {
 	return newK8sClient(DefaultAPIServer, inClusterTokenFile, inClusterCAFile, "", "", namespace)
 }
 
-// ── Minimal K8s type stubs ──────────────────────────────────────────────────
+// ── Type aliases from k8stypes (pod-spec wire types shared across executors) ─
+
+type (
+	podSpec     = k8stypes.PodSpec
+	container   = k8stypes.Container
+	volume      = k8stypes.Volume
+	volumeMount = k8stypes.VolumeMount
+	envVar      = k8stypes.EnvVar
+)
+
+// ── Batch-job types (Spark-specific) ────────────────────────────────────────
 
 type batchJob struct {
-	APIVersion string          `json:"apiVersion"`
-	Kind       string          `json:"kind"`
-	Metadata   jobMeta         `json:"metadata"`
-	Spec       jobSpec         `json:"spec"`
-	Status     batchJobStatus  `json:"status,omitempty"`
+	APIVersion string         `json:"apiVersion"`
+	Kind       string         `json:"kind"`
+	Metadata   jobMeta        `json:"metadata"`
+	Spec       jobSpec        `json:"spec"`
+	Status     batchJobStatus `json:"status,omitempty"`
 }
 
 type jobMeta struct {
@@ -153,43 +165,6 @@ type podTemplate struct {
 
 type podMeta struct {
 	Labels map[string]string `json:"labels,omitempty"`
-}
-
-type volume struct {
-	Name      string        `json:"name"`
-	ConfigMap *configMapRef `json:"configMap,omitempty"`
-}
-
-type configMapRef struct {
-	Name string `json:"name"`
-}
-
-type volumeMount struct {
-	Name      string `json:"name"`
-	MountPath string `json:"mountPath"`
-	ReadOnly  bool   `json:"readOnly,omitempty"`
-}
-
-type envVar struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
-}
-
-type podSpec struct {
-	RestartPolicy      string      `json:"restartPolicy"`
-	ServiceAccountName string      `json:"serviceAccountName,omitempty"`
-	Containers         []container `json:"containers"`
-	Volumes            []volume    `json:"volumes,omitempty"`
-}
-
-type container struct {
-	Name            string        `json:"name"`
-	Image           string        `json:"image"`
-	ImagePullPolicy string        `json:"imagePullPolicy,omitempty"`
-	Command         []string      `json:"command"`
-	Args            []string      `json:"args,omitempty"`
-	Env             []envVar      `json:"env,omitempty"`
-	VolumeMounts    []volumeMount `json:"volumeMounts,omitempty"`
 }
 
 type batchJobStatus struct {

--- a/internal/k8stypes/types.go
+++ b/internal/k8stypes/types.go
@@ -1,0 +1,217 @@
+// Package k8stypes contains the minimal Kubernetes API type stubs used by
+// JaisCloud executors (Spark, Lambda) and the platform apply helpers.
+// Hand-rolled to avoid a client-go dependency; field names and JSON tags
+// match the k8s.io/api/core/v1 wire format exactly.
+package k8stypes
+
+// ── Pod / container types ──────────────────────────────────────────────────
+
+type PodSpec struct {
+	RestartPolicy              string                   `json:"restartPolicy,omitempty"`
+	ServiceAccountName         string                   `json:"serviceAccountName,omitempty"`
+	InitContainers             []Container              `json:"initContainers,omitempty"`
+	Containers                 []Container              `json:"containers"`
+	Volumes                    []Volume                 `json:"volumes,omitempty"`
+	NodeSelector               map[string]string        `json:"nodeSelector,omitempty"`
+	Tolerations                []Toleration             `json:"tolerations,omitempty"`
+	Affinity                   *Affinity                `json:"affinity,omitempty"`
+	TopologySpreadConstraints  []TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+	SecurityContext            *PodSecurityContext      `json:"securityContext,omitempty"`
+}
+
+type Container struct {
+	Name            string          `json:"name"`
+	Image           string          `json:"image"`
+	ImagePullPolicy string          `json:"imagePullPolicy,omitempty"`
+	Command         []string        `json:"command,omitempty"`
+	Args            []string        `json:"args,omitempty"`
+	Env             []EnvVar        `json:"env,omitempty"`
+	VolumeMounts    []VolumeMount   `json:"volumeMounts,omitempty"`
+	Resources       *Resources      `json:"resources,omitempty"`
+	Ports           []ContainerPort `json:"ports,omitempty"`
+	SecurityContext *SecurityContext `json:"securityContext,omitempty"`
+	ReadinessProbe  *Probe          `json:"readinessProbe,omitempty"`
+	LivenessProbe   *Probe          `json:"livenessProbe,omitempty"`
+}
+
+type EnvVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type VolumeMount struct {
+	Name      string `json:"name"`
+	MountPath string `json:"mountPath"`
+	SubPath   string `json:"subPath,omitempty"`
+	ReadOnly  bool   `json:"readOnly,omitempty"`
+}
+
+type ContainerPort struct {
+	ContainerPort int    `json:"containerPort"`
+	Protocol      string `json:"protocol,omitempty"`
+}
+
+type Resources struct {
+	Requests map[string]string `json:"requests,omitempty"`
+	Limits   map[string]string `json:"limits,omitempty"`
+}
+
+type Probe struct {
+	TCPSocket           *TCPSocketAction `json:"tcpSocket,omitempty"`
+	InitialDelaySeconds int              `json:"initialDelaySeconds,omitempty"`
+	PeriodSeconds       int              `json:"periodSeconds,omitempty"`
+	FailureThreshold    int              `json:"failureThreshold,omitempty"`
+}
+
+type TCPSocketAction struct {
+	Port int `json:"port"`
+}
+
+// ── Volume types ───────────────────────────────────────────────────────────
+
+type Volume struct {
+	Name      string             `json:"name"`
+	ConfigMap *ConfigMapVol      `json:"configMap,omitempty"`
+	Secret    *SecretVol         `json:"secret,omitempty"`
+	EmptyDir  *EmptyDirVol       `json:"emptyDir,omitempty"`
+	Projected *ProjectedVol      `json:"projected,omitempty"`
+	PVC       *PVCVol            `json:"persistentVolumeClaim,omitempty"`
+	CSI       *CSIVol            `json:"csi,omitempty"`
+	HostPath  *HostPathVol       `json:"hostPath,omitempty"`
+}
+
+type ConfigMapVol struct {
+	Name        string       `json:"name"`
+	DefaultMode *int32       `json:"defaultMode,omitempty"`
+	Items       []KeyToPath  `json:"items,omitempty"`
+	Optional    *bool        `json:"optional,omitempty"`
+}
+
+type SecretVol struct {
+	SecretName  string       `json:"secretName"`
+	DefaultMode *int32       `json:"defaultMode,omitempty"`
+	Items       []KeyToPath  `json:"items,omitempty"`
+	Optional    *bool        `json:"optional,omitempty"`
+}
+
+type EmptyDirVol struct {
+	Medium    string `json:"medium,omitempty"`
+	SizeLimit string `json:"sizeLimit,omitempty"`
+}
+
+type ProjectedVol struct {
+	Sources     []ProjectionElement `json:"sources"`
+	DefaultMode *int32              `json:"defaultMode,omitempty"`
+}
+
+type ProjectionElement struct {
+	ServiceAccountToken *SATokenProjection     `json:"serviceAccountToken,omitempty"`
+	Secret              *ConfigMapVol          `json:"secret,omitempty"`
+	ConfigMap           *ConfigMapVol          `json:"configMap,omitempty"`
+	DownwardAPI         *DownwardAPIProjection `json:"downwardAPI,omitempty"`
+}
+
+type SATokenProjection struct {
+	Audience          string `json:"audience"`
+	ExpirationSeconds int64  `json:"expirationSeconds,omitempty"`
+	Path              string `json:"path"`
+}
+
+type DownwardAPIProjection struct {
+	Items []DownwardAPIItem `json:"items"`
+}
+
+type DownwardAPIItem struct {
+	Path     string               `json:"path"`
+	FieldRef *ObjectFieldSelector `json:"fieldRef,omitempty"`
+}
+
+type ObjectFieldSelector struct {
+	FieldPath string `json:"fieldPath"`
+}
+
+type PVCVol struct {
+	ClaimName string `json:"claimName"`
+	ReadOnly  bool   `json:"readOnly,omitempty"`
+}
+
+type CSIVol struct {
+	Driver           string            `json:"driver"`
+	ReadOnly         bool              `json:"readOnly,omitempty"`
+	FSType           string            `json:"fsType,omitempty"`
+	VolumeAttributes map[string]string `json:"volumeAttributes,omitempty"`
+}
+
+type HostPathVol struct {
+	Path string `json:"path"`
+	Type string `json:"type,omitempty"`
+}
+
+type KeyToPath struct {
+	Key  string `json:"key"`
+	Path string `json:"path"`
+	Mode *int32 `json:"mode,omitempty"`
+}
+
+// ── Scheduling / security types ────────────────────────────────────────────
+
+type Toleration struct {
+	Key               string `json:"key,omitempty"`
+	Operator          string `json:"operator,omitempty"`
+	Value             string `json:"value,omitempty"`
+	Effect            string `json:"effect,omitempty"`
+	TolerationSeconds *int64 `json:"tolerationSeconds,omitempty"`
+}
+
+type Affinity struct {
+	NodeAffinity    *NodeAffinity    `json:"nodeAffinity,omitempty"`
+	PodAffinity     *PodAffinity     `json:"podAffinity,omitempty"`
+	PodAntiAffinity *PodAntiAffinity `json:"podAntiAffinity,omitempty"`
+}
+
+type NodeAffinity struct {
+	RequiredDuringSchedulingIgnoredDuringExecution  *NodeSelector `json:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
+}
+
+type NodeSelector struct {
+	NodeSelectorTerms []NodeSelectorTerm `json:"nodeSelectorTerms"`
+}
+
+type NodeSelectorTerm struct {
+	MatchExpressions []NodeSelectorRequirement `json:"matchExpressions,omitempty"`
+}
+
+type NodeSelectorRequirement struct {
+	Key      string   `json:"key"`
+	Operator string   `json:"operator"`
+	Values   []string `json:"values,omitempty"`
+}
+
+type PodAffinity struct{}
+type PodAntiAffinity struct{}
+
+type TopologySpreadConstraint struct {
+	MaxSkew           int               `json:"maxSkew"`
+	TopologyKey       string            `json:"topologyKey"`
+	WhenUnsatisfiable string            `json:"whenUnsatisfiable"`
+	LabelSelector     *LabelSelector    `json:"labelSelector,omitempty"`
+}
+
+type LabelSelector struct {
+	MatchLabels map[string]string `json:"matchLabels,omitempty"`
+}
+
+type PodSecurityContext struct {
+	RunAsUser    *int64 `json:"runAsUser,omitempty"`
+	RunAsGroup   *int64 `json:"runAsGroup,omitempty"`
+	RunAsNonRoot *bool  `json:"runAsNonRoot,omitempty"`
+	FSGroup      *int64 `json:"fsGroup,omitempty"`
+}
+
+type SecurityContext struct {
+	RunAsUser                *int64 `json:"runAsUser,omitempty"`
+	RunAsGroup               *int64 `json:"runAsGroup,omitempty"`
+	RunAsNonRoot             *bool  `json:"runAsNonRoot,omitempty"`
+	AllowPrivilegeEscalation *bool  `json:"allowPrivilegeEscalation,omitempty"`
+	ReadOnlyRootFilesystem   *bool  `json:"readOnlyRootFilesystem,omitempty"`
+}

--- a/internal/platform/config.go
+++ b/internal/platform/config.go
@@ -1,0 +1,367 @@
+package platform
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PlatformConfig holds runtime configuration applied to every JaisCloud-managed
+// workload. Populated once at startup via LoadFromEnv and injected by pointer
+// into executor constructors — never embedded inside workload-specific config.
+type PlatformConfig struct {
+	TLS               TLSConfig
+	Volumes           []VolumeSpec
+	Env               map[string]string
+	HostPathAllowlist []string // allowed hostPath prefixes; empty = hostPath disabled
+
+	// bundle caches the Docker-mode PEM bundle; scoped here so different
+	// PlatformConfig instances (e.g. in tests) get independent caches.
+	bundle pemBundleCache
+}
+
+// pemBundleCache holds the result of materialising CA sources to a host-side
+// PEM file. It is written exactly once per PlatformConfig via sync.Once.
+type pemBundleCache struct {
+	once sync.Once
+	path string
+	err  error
+}
+
+// LoadFromEnv reads and validates platform configuration from environment
+// variables (and optional _FILE variants). Returns a ready-to-use *PlatformConfig.
+// Errors are fatal — callers should exit with "platform config: <err>".
+func LoadFromEnv() (*PlatformConfig, error) {
+	cfg := &PlatformConfig{
+		TLS: TLSConfig{
+			Enabled:            true,
+			TruststorePassword: "changeit",
+		},
+		Env: map[string]string{},
+	}
+
+	// ── TLS enabled flag ─────────────────────────────────────────────────────
+	if v := os.Getenv("JAISCLOUD_PLATFORM_TLS_ENABLED"); v == "false" {
+		cfg.TLS.Enabled = false
+	}
+
+	// ── CA sources ───────────────────────────────────────────────────────────
+	caSources, err := loadSlice[CASource]("JAISCLOUD_PLATFORM_TLS_CA_SOURCES")
+	if err != nil {
+		return nil, err
+	}
+	if len(caSources) == 0 {
+		// Default: the JaisCloud CA ConfigMap shipped with the Helm chart.
+		caSources = []CASource{{
+			Name:   "jaiscloud",
+			Source: CASourceRef{Kind: "configMap", Name: "jaiscloud-ca-cert", Key: "ca.crt"},
+		}}
+	}
+	cfg.TLS.CASources = caSources
+
+	// ── Client cert (optional) ───────────────────────────────────────────────
+	clientCert, err := loadSingle[CASource]("JAISCLOUD_PLATFORM_TLS_CLIENT_CERT")
+	if err != nil {
+		return nil, err
+	}
+	cfg.TLS.ClientCert = clientCert
+
+	// ── Truststore password ──────────────────────────────────────────────────
+	if v := os.Getenv("JAISCLOUD_PLATFORM_TLS_PASSWORD"); v != "" {
+		cfg.TLS.TruststorePassword = v
+	}
+
+	// ── Volumes ──────────────────────────────────────────────────────────────
+	rawVolumes, err := loadSlice[rawVolumeSpec]("JAISCLOUD_PLATFORM_VOLUMES")
+	if err != nil {
+		return nil, err
+	}
+	cfg.Volumes, err = canonicaliseVolumes(rawVolumes)
+	if err != nil {
+		return nil, err
+	}
+
+	// ── Extra env ────────────────────────────────────────────────────────────
+	envMap, err := loadSingle[map[string]string]("JAISCLOUD_PLATFORM_ENV")
+	if err != nil {
+		return nil, err
+	}
+	if envMap != nil {
+		cfg.Env = *envMap
+	}
+
+	// ── HostPath allowlist ───────────────────────────────────────────────────
+	if v := os.Getenv("JAISCLOUD_PLATFORM_HOSTPATH_ALLOWLIST"); v != "" {
+		for _, p := range strings.Split(v, ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				cfg.HostPathAllowlist = append(cfg.HostPathAllowlist, p)
+			}
+		}
+	}
+
+	if err := validate(cfg); err != nil {
+		return nil, err
+	}
+
+	logStartup(cfg)
+	return cfg, nil
+}
+
+// ── validation ─────────────────────────────────────────────────────────────
+
+func validate(cfg *PlatformConfig) error {
+	// CA source alias uniqueness.
+	seen := map[string]struct{}{}
+	for _, ca := range cfg.TLS.CASources {
+		if _, dup := seen[ca.Name]; dup {
+			return fmt.Errorf("CA source alias %q duplicated", ca.Name)
+		}
+		seen[ca.Name] = struct{}{}
+		if err := validateCASourceRef(ca.Source); err != nil {
+			return fmt.Errorf("CA source %q: %w", ca.Name, err)
+		}
+	}
+
+	// Volume name uniqueness + kind validation.
+	vnames := map[string]struct{}{}
+	for _, vs := range cfg.Volumes {
+		if _, dup := vnames[vs.Name]; dup {
+			return fmt.Errorf("volume %q name duplicated", vs.Name)
+		}
+		vnames[vs.Name] = struct{}{}
+		if err := validateVolumeSource(vs.Source, cfg.HostPathAllowlist); err != nil {
+			return fmt.Errorf("volume %q: %w", vs.Name, err)
+		}
+	}
+
+	// Warn when TLS disabled but sources configured.
+	if !cfg.TLS.Enabled && len(cfg.TLS.CASources) > 0 {
+		slog.Warn("platform tls: Enabled=false but CA sources configured — CA imports will be skipped",
+			"ca-sources", len(cfg.TLS.CASources))
+	}
+
+	return nil
+}
+
+func validateCASourceRef(ref CASourceRef) error {
+	if ref.Kind != "configMap" && ref.Kind != "secret" {
+		return fmt.Errorf("source kind %q must be configMap or secret", ref.Kind)
+	}
+	if ref.Name == "" {
+		return fmt.Errorf("source name is required")
+	}
+	if ref.Key == "" {
+		return fmt.Errorf("source key is required")
+	}
+	return nil
+}
+
+func validateVolumeSource(src VolumeSource, allowlist []string) error {
+	validKinds := map[string]bool{
+		"secret": true, "configMap": true, "emptyDir": true,
+		"projected": true, "pvc": true, "csi": true, "hostPath": true,
+	}
+	if !validKinds[src.Kind] {
+		return fmt.Errorf("unknown volume kind %q", src.Kind)
+	}
+	if src.Kind == "hostPath" {
+		if src.HostPath == nil {
+			return fmt.Errorf("hostPath source missing")
+		}
+		if !hostPathAllowed(src.HostPath.Path, allowlist) {
+			prefixes := strings.Join(allowlist, ", ")
+			if prefixes == "" {
+				prefixes = "(none)"
+			}
+			return fmt.Errorf("hostPath %q not in HOSTPATH_ALLOWLIST [%s]", src.HostPath.Path, prefixes)
+		}
+	}
+	return nil
+}
+
+func hostPathAllowed(path string, allowlist []string) bool {
+	for _, prefix := range allowlist {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// ── startup log ────────────────────────────────────────────────────────────
+
+func logStartup(cfg *PlatformConfig) {
+	aliases := make([]string, len(cfg.TLS.CASources))
+	for i, ca := range cfg.TLS.CASources {
+		aliases[i] = ca.Name
+	}
+	clientCert := cfg.TLS.ClientCert != nil
+	slog.Info("platform tls",
+		"enabled", cfg.TLS.Enabled,
+		"materializers", []string{"jvm-truststore", "pem-bundle"},
+		"ca-sources", aliases,
+		"client-cert", clientCert,
+	)
+}
+
+// ── short-form canonicalisation ────────────────────────────────────────────
+
+// rawVolumeSpec is the union of short-form and long-form volume JSON shapes.
+type rawVolumeSpec struct {
+	// Long form
+	Name   string      `json:"name"   yaml:"name"`
+	Source *rawSource  `json:"source" yaml:"source"`
+	Mounts []MountSpec `json:"mounts" yaml:"mounts"`
+
+	// Short-form convenience fields
+	ConfigMap string `json:"configMap" yaml:"configMap"`
+	Secret    string `json:"secret"    yaml:"secret"`
+	PVC       string `json:"pvc"       yaml:"pvc"`
+	EmptyDir  bool   `json:"emptyDir"  yaml:"emptyDir"`
+	MountPath string `json:"mountPath" yaml:"mountPath"`
+	ReadOnly  bool   `json:"readOnly"  yaml:"readOnly"`
+}
+
+type rawSource struct {
+	Kind      string           `json:"kind"      yaml:"kind"`
+	Name      string           `json:"name"      yaml:"name"`
+	Secret    *SecretSource    `json:"secret"    yaml:"secret"`
+	ConfigMap *ConfigMapSource `json:"configMap" yaml:"configMap"`
+	EmptyDir  *EmptyDirSource  `json:"emptyDir"  yaml:"emptyDir"`
+	Projected *ProjectedSource `json:"projected" yaml:"projected"`
+	PVC       *PVCSource       `json:"pvc"       yaml:"pvc"`
+	CSI       *CSISource       `json:"csi"       yaml:"csi"`
+	HostPath  *HostPathSource  `json:"hostPath"  yaml:"hostPath"`
+}
+
+func canonicaliseVolumes(raws []rawVolumeSpec) ([]VolumeSpec, error) {
+	out := make([]VolumeSpec, 0, len(raws))
+	for _, r := range raws {
+		vs, err := canonicalise(r)
+		if err != nil {
+			return nil, fmt.Errorf("volume %q: %w", r.Name, err)
+		}
+		out = append(out, vs)
+	}
+	return out, nil
+}
+
+func canonicalise(r rawVolumeSpec) (VolumeSpec, error) {
+	if r.Name == "" {
+		return VolumeSpec{}, fmt.Errorf("volume has no name")
+	}
+
+	// Long form — source field present.
+	if r.Source != nil {
+		src := VolumeSource{
+			Kind:      r.Source.Kind,
+			Secret:    r.Source.Secret,
+			ConfigMap: r.Source.ConfigMap,
+			EmptyDir:  r.Source.EmptyDir,
+			Projected: r.Source.Projected,
+			PVC:       r.Source.PVC,
+			CSI:       r.Source.CSI,
+			HostPath:  r.Source.HostPath,
+		}
+		// Populate sub-fields from the flat source fields if kind-specific pointer is nil.
+		if src.Kind == "configMap" && src.ConfigMap == nil && r.Source.Name != "" {
+			src.ConfigMap = &ConfigMapSource{Name: r.Source.Name}
+		}
+		if src.Kind == "secret" && src.Secret == nil && r.Source.Name != "" {
+			src.Secret = &SecretSource{Name: r.Source.Name}
+		}
+		if src.Kind == "pvc" && src.PVC == nil && r.Source.Name != "" {
+			src.PVC = &PVCSource{ClaimName: r.Source.Name}
+		}
+		mounts := r.Mounts
+		if len(mounts) == 0 && r.MountPath != "" {
+			mounts = []MountSpec{{MountPath: r.MountPath, ReadOnly: r.ReadOnly}}
+		}
+		return VolumeSpec{Name: r.Name, Source: src, Mounts: mounts}, nil
+	}
+
+	// Short form — derive source from convenience fields.
+	var src VolumeSource
+	switch {
+	case r.ConfigMap != "":
+		src = VolumeSource{Kind: "configMap", ConfigMap: &ConfigMapSource{Name: r.ConfigMap}}
+	case r.Secret != "":
+		src = VolumeSource{Kind: "secret", Secret: &SecretSource{Name: r.Secret}}
+	case r.PVC != "":
+		src = VolumeSource{Kind: "pvc", PVC: &PVCSource{ClaimName: r.PVC}}
+	case r.EmptyDir:
+		src = VolumeSource{Kind: "emptyDir", EmptyDir: &EmptyDirSource{}}
+	default:
+		return VolumeSpec{}, fmt.Errorf("has no source field and no recognised short-form key (configMap/secret/pvc/emptyDir)")
+	}
+
+	if r.MountPath == "" {
+		return VolumeSpec{}, fmt.Errorf("short-form volume requires mountPath")
+	}
+	mounts := []MountSpec{{MountPath: r.MountPath, ReadOnly: r.ReadOnly}}
+	return VolumeSpec{Name: r.Name, Source: src, Mounts: mounts}, nil
+}
+
+// ── generic env-var loader helpers ─────────────────────────────────────────
+
+// loadSlice reads a JSON/YAML array from <envKey> or <envKey>_FILE.
+func loadSlice[T any](envKey string) ([]T, error) {
+	raw, err := readEnvOrFile(envKey)
+	if err != nil || raw == "" {
+		return nil, err
+	}
+	var out []T
+	if err := unmarshalAuto(raw, &out); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", envKey, err)
+	}
+	return out, nil
+}
+
+// loadSingle reads a JSON/YAML object from <envKey> or <envKey>_FILE.
+// Returns nil (no error) when the env var is unset.
+func loadSingle[T any](envKey string) (*T, error) {
+	raw, err := readEnvOrFile(envKey)
+	if err != nil || raw == "" {
+		return nil, err
+	}
+	var out T
+	if err := unmarshalAuto(raw, &out); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", envKey, err)
+	}
+	return &out, nil
+}
+
+// readEnvOrFile returns the raw string content for envKey, preferring _FILE.
+func readEnvOrFile(envKey string) (string, error) {
+	fileKey := envKey + "_FILE"
+	filePath := os.Getenv(fileKey)
+	jsonVal := os.Getenv(envKey)
+
+	if filePath != "" && jsonVal != "" {
+		slog.Warn("platform config: both env and _FILE set; using file",
+			"env", envKey, "file", filePath)
+	}
+	if filePath != "" {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return "", fmt.Errorf("read %s=%s: %w", fileKey, filePath, err)
+		}
+		return string(data), nil
+	}
+	return jsonVal, nil
+}
+
+// unmarshalAuto detects JSON vs YAML by file extension or content prefix.
+func unmarshalAuto(raw string, out any) error {
+	trimmed := strings.TrimSpace(raw)
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		return json.Unmarshal([]byte(trimmed), out)
+	}
+	return yaml.Unmarshal([]byte(trimmed), out)
+}

--- a/internal/platform/config_test.go
+++ b/internal/platform/config_test.go
@@ -1,0 +1,231 @@
+package platform
+
+import (
+	"testing"
+)
+
+func TestLoadFromEnv_Defaults(t *testing.T) {
+	// Clear relevant env vars so we get defaults.
+	t.Setenv("JAISCLOUD_PLATFORM_TLS_ENABLED", "")
+	t.Setenv("JAISCLOUD_PLATFORM_TLS_CA_SOURCES", "")
+	t.Setenv("JAISCLOUD_PLATFORM_VOLUMES", "")
+	t.Setenv("JAISCLOUD_PLATFORM_ENV", "")
+
+	cfg, err := LoadFromEnv()
+	if err != nil {
+		t.Fatalf("LoadFromEnv: %v", err)
+	}
+	if !cfg.TLS.Enabled {
+		t.Error("TLS should be enabled by default")
+	}
+	if len(cfg.TLS.CASources) == 0 {
+		t.Error("default CA sources should be non-empty")
+	}
+	if cfg.TLS.TruststorePassword != "changeit" {
+		t.Errorf("default truststore password: got %q, want %q", cfg.TLS.TruststorePassword, "changeit")
+	}
+}
+
+func TestLoadFromEnv_TLSDisabled(t *testing.T) {
+	t.Setenv("JAISCLOUD_PLATFORM_TLS_ENABLED", "false")
+	t.Setenv("JAISCLOUD_PLATFORM_TLS_CA_SOURCES", "")
+	t.Setenv("JAISCLOUD_PLATFORM_VOLUMES", "")
+	t.Setenv("JAISCLOUD_PLATFORM_ENV", "")
+
+	cfg, err := LoadFromEnv()
+	if err != nil {
+		t.Fatalf("LoadFromEnv: %v", err)
+	}
+	if cfg.TLS.Enabled {
+		t.Error("TLS should be disabled")
+	}
+}
+
+func TestLoadFromEnv_ExtraEnv(t *testing.T) {
+	t.Setenv("JAISCLOUD_PLATFORM_TLS_ENABLED", "false")
+	t.Setenv("JAISCLOUD_PLATFORM_TLS_CA_SOURCES", "")
+	t.Setenv("JAISCLOUD_PLATFORM_VOLUMES", "")
+	t.Setenv("JAISCLOUD_PLATFORM_ENV", `{"MY_VAR":"hello","OTHER":"world"}`)
+
+	cfg, err := LoadFromEnv()
+	if err != nil {
+		t.Fatalf("LoadFromEnv: %v", err)
+	}
+	if cfg.Env["MY_VAR"] != "hello" {
+		t.Errorf("MY_VAR: got %q", cfg.Env["MY_VAR"])
+	}
+	if cfg.Env["OTHER"] != "world" {
+		t.Errorf("OTHER: got %q", cfg.Env["OTHER"])
+	}
+}
+
+func TestCanonicalise_ShortFormConfigMap(t *testing.T) {
+	r := rawVolumeSpec{Name: "my-cm", ConfigMap: "my-configmap", MountPath: "/etc/conf"}
+	vs, err := canonicalise(r)
+	if err != nil {
+		t.Fatalf("canonicalise: %v", err)
+	}
+	if vs.Source.Kind != "configMap" {
+		t.Errorf("kind: got %q, want configMap", vs.Source.Kind)
+	}
+	if vs.Source.ConfigMap == nil || vs.Source.ConfigMap.Name != "my-configmap" {
+		t.Errorf("ConfigMap.Name: got %+v", vs.Source.ConfigMap)
+	}
+	if len(vs.Mounts) != 1 || vs.Mounts[0].MountPath != "/etc/conf" {
+		t.Errorf("mounts: got %+v", vs.Mounts)
+	}
+}
+
+func TestCanonicalise_ShortFormSecret(t *testing.T) {
+	r := rawVolumeSpec{Name: "my-secret", Secret: "my-secret-name", MountPath: "/etc/secret", ReadOnly: true}
+	vs, err := canonicalise(r)
+	if err != nil {
+		t.Fatalf("canonicalise: %v", err)
+	}
+	if vs.Source.Kind != "secret" {
+		t.Errorf("kind: got %q", vs.Source.Kind)
+	}
+	if vs.Mounts[0].ReadOnly != true {
+		t.Error("mount should be read-only")
+	}
+}
+
+func TestCanonicalise_ShortFormEmptyDir(t *testing.T) {
+	r := rawVolumeSpec{Name: "scratch", EmptyDir: true, MountPath: "/tmp/scratch"}
+	vs, err := canonicalise(r)
+	if err != nil {
+		t.Fatalf("canonicalise: %v", err)
+	}
+	if vs.Source.Kind != "emptyDir" {
+		t.Errorf("kind: got %q", vs.Source.Kind)
+	}
+}
+
+func TestCanonicalise_ShortFormPVC(t *testing.T) {
+	r := rawVolumeSpec{Name: "data", PVC: "my-pvc", MountPath: "/data"}
+	vs, err := canonicalise(r)
+	if err != nil {
+		t.Fatalf("canonicalise: %v", err)
+	}
+	if vs.Source.Kind != "pvc" {
+		t.Errorf("kind: got %q", vs.Source.Kind)
+	}
+	if vs.Source.PVC == nil || vs.Source.PVC.ClaimName != "my-pvc" {
+		t.Errorf("PVC.ClaimName: got %+v", vs.Source.PVC)
+	}
+}
+
+func TestCanonicalise_NoName_Error(t *testing.T) {
+	r := rawVolumeSpec{ConfigMap: "cm", MountPath: "/etc/cm"}
+	_, err := canonicalise(r)
+	if err == nil {
+		t.Error("expected error for missing name")
+	}
+}
+
+func TestCanonicalise_NoMountPath_Error(t *testing.T) {
+	r := rawVolumeSpec{Name: "cm-vol", ConfigMap: "cm-name"}
+	_, err := canonicalise(r)
+	if err == nil {
+		t.Error("expected error for missing mountPath")
+	}
+}
+
+func TestCanonicalise_NoSource_Error(t *testing.T) {
+	r := rawVolumeSpec{Name: "bad-vol", MountPath: "/mnt"}
+	_, err := canonicalise(r)
+	if err == nil {
+		t.Error("expected error when no source provided")
+	}
+}
+
+func TestValidate_DuplicateCAAlias(t *testing.T) {
+	cfg := &PlatformConfig{
+		TLS: TLSConfig{
+			Enabled: true,
+			CASources: []CASource{
+				{Name: "dup", Source: CASourceRef{Kind: "configMap", Name: "cm", Key: "ca.crt"}},
+				{Name: "dup", Source: CASourceRef{Kind: "configMap", Name: "cm2", Key: "ca.crt"}},
+			},
+		},
+		Env: map[string]string{},
+	}
+	if err := validate(cfg); err == nil {
+		t.Error("expected error for duplicate CA alias")
+	}
+}
+
+func TestValidate_DuplicateVolumeName(t *testing.T) {
+	cfg := &PlatformConfig{
+		TLS: TLSConfig{
+			Enabled: false,
+			CASources: []CASource{
+				{Name: "ca", Source: CASourceRef{Kind: "configMap", Name: "cm", Key: "ca.crt"}},
+			},
+		},
+		Volumes: []VolumeSpec{
+			{Name: "dup-vol", Source: VolumeSource{Kind: "emptyDir", EmptyDir: &EmptyDirSource{}}},
+			{Name: "dup-vol", Source: VolumeSource{Kind: "emptyDir", EmptyDir: &EmptyDirSource{}}},
+		},
+		Env: map[string]string{},
+	}
+	if err := validate(cfg); err == nil {
+		t.Error("expected error for duplicate volume name")
+	}
+}
+
+func TestValidate_HostPathNotAllowed(t *testing.T) {
+	cfg := &PlatformConfig{
+		TLS:               TLSConfig{Enabled: false},
+		HostPathAllowlist: []string{"/allowed"},
+		Volumes: []VolumeSpec{{
+			Name: "hp",
+			Source: VolumeSource{
+				Kind:     "hostPath",
+				HostPath: &HostPathSource{Path: "/forbidden/path"},
+			},
+		}},
+		Env: map[string]string{},
+	}
+	if err := validate(cfg); err == nil {
+		t.Error("expected error for hostPath not in allowlist")
+	}
+}
+
+func TestValidate_HostPathAllowed(t *testing.T) {
+	cfg := &PlatformConfig{
+		TLS:               TLSConfig{Enabled: false},
+		HostPathAllowlist: []string{"/allowed"},
+		Volumes: []VolumeSpec{{
+			Name: "hp",
+			Source: VolumeSource{
+				Kind:     "hostPath",
+				HostPath: &HostPathSource{Path: "/allowed/subdir"},
+			},
+		}},
+		Env: map[string]string{},
+	}
+	if err := validate(cfg); err != nil {
+		t.Errorf("unexpected error for allowed hostPath: %v", err)
+	}
+}
+
+func TestUnmarshalAuto_JSON(t *testing.T) {
+	var m map[string]string
+	if err := unmarshalAuto(`{"key":"val"}`, &m); err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	if m["key"] != "val" {
+		t.Errorf("got %q", m["key"])
+	}
+}
+
+func TestUnmarshalAuto_YAML(t *testing.T) {
+	var m map[string]string
+	if err := unmarshalAuto("key: val", &m); err != nil {
+		t.Fatalf("YAML: %v", err)
+	}
+	if m["key"] != "val" {
+		t.Errorf("got %q", m["key"])
+	}
+}

--- a/internal/platform/conflicts.go
+++ b/internal/platform/conflicts.go
@@ -1,0 +1,23 @@
+package platform
+
+import (
+	"fmt"
+
+	"jaiscloud/internal/k8stypes"
+)
+
+// checkVolumeConflicts returns an error if any volume in incoming has the same
+// name as a volume already in existing. Called after cloud-transform volumes
+// are on the spec and before platform volumes are appended.
+func checkVolumeConflicts(existing, incoming []k8stypes.Volume) error {
+	names := make(map[string]struct{}, len(existing))
+	for _, v := range existing {
+		names[v.Name] = struct{}{}
+	}
+	for _, v := range incoming {
+		if _, ok := names[v.Name]; ok {
+			return fmt.Errorf("platform: volume name conflict %q — already present on pod spec", v.Name)
+		}
+	}
+	return nil
+}

--- a/internal/platform/conflicts_test.go
+++ b/internal/platform/conflicts_test.go
@@ -1,0 +1,36 @@
+package platform
+
+import (
+	"testing"
+
+	"jaiscloud/internal/k8stypes"
+)
+
+func TestCheckVolumeConflicts_NoConflict(t *testing.T) {
+	existing := []k8stypes.Volume{{Name: "vol-a"}}
+	incoming := []k8stypes.Volume{{Name: "vol-b"}}
+	if err := checkVolumeConflicts(existing, incoming); err != nil {
+		t.Errorf("unexpected conflict error: %v", err)
+	}
+}
+
+func TestCheckVolumeConflicts_Conflict(t *testing.T) {
+	existing := []k8stypes.Volume{{Name: "shared-vol"}}
+	incoming := []k8stypes.Volume{{Name: "shared-vol"}}
+	if err := checkVolumeConflicts(existing, incoming); err == nil {
+		t.Error("expected conflict error, got nil")
+	}
+}
+
+func TestCheckVolumeConflicts_EmptyIncoming(t *testing.T) {
+	existing := []k8stypes.Volume{{Name: "vol-a"}}
+	if err := checkVolumeConflicts(existing, nil); err != nil {
+		t.Errorf("empty incoming should not conflict: %v", err)
+	}
+}
+
+func TestCheckVolumeConflicts_BothEmpty(t *testing.T) {
+	if err := checkVolumeConflicts(nil, nil); err != nil {
+		t.Errorf("both empty should not conflict: %v", err)
+	}
+}

--- a/internal/platform/doc.go
+++ b/internal/platform/doc.go
@@ -1,0 +1,6 @@
+// Package platform provides runtime configuration applied uniformly to every
+// JaisCloud-managed container or pod, irrespective of workload or cloud.
+// This includes TLS trust (CA import, PEM bundle), extra volumes, and
+// extra environment variables. Executors call ApplyK8s or ApplyDocker to
+// materialise these knobs onto their pod spec or docker-run args.
+package platform

--- a/internal/platform/docker.go
+++ b/internal/platform/docker.go
@@ -1,0 +1,55 @@
+package platform
+
+import (
+	"fmt"
+	"log/slog"
+)
+
+// ApplyDocker returns additional -v and -e args for `docker run` based on
+// platform config. TLS is handled by materialising the PEM bundle to a host
+// temp file once at startup and bind-mounting it read-only into every container.
+//
+// Note: only CA sources with kind="file" can be materialised on the host.
+// K8s ConfigMap/Secret sources are silently skipped — they are K8s-only.
+// Validate that Docker-mode deployments use kind="file" CA sources.
+func ApplyDocker(cfg *PlatformConfig) (volumeArgs, envArgs []string, err error) {
+	if cfg == nil || !cfg.TLS.Enabled {
+		return nil, nil, nil
+	}
+
+	bundlePath, err := cfg.materializePEMBundle()
+	if err != nil {
+		return nil, nil, fmt.Errorf("platform docker: materialize PEM bundle: %w", err)
+	}
+
+	if bundlePath != "" {
+		volumeArgs = append(volumeArgs,
+			"-v", bundlePath+":/etc/ssl/certs/jaiscloud-ca.pem:ro",
+		)
+		for _, name := range nonJVMEnvVars {
+			envArgs = append(envArgs, "-e", name+"=/etc/ssl/certs/jaiscloud-ca.pem")
+		}
+	}
+
+	// Extra volumes.
+	for _, vs := range cfg.Volumes {
+		for _, mnt := range vs.Mounts {
+			// Only hostPath volumes can be bind-mounted in Docker mode.
+			if vs.Source.Kind == "hostPath" && vs.Source.HostPath != nil {
+				volumeArgs = append(volumeArgs, "-v",
+					fmt.Sprintf("%s:%s:ro", vs.Source.HostPath.Path, mnt.MountPath),
+				)
+			} else {
+				slog.Warn("platform docker: volume source cannot be bind-mounted, skipping",
+					"kind", vs.Source.Kind, "mountPath", mnt.MountPath)
+			}
+		}
+	}
+
+	// Extra env.
+	for k, v := range cfg.Env {
+		envArgs = append(envArgs, "-e", k+"="+v)
+	}
+
+	return volumeArgs, envArgs, nil
+}

--- a/internal/platform/docker_test.go
+++ b/internal/platform/docker_test.go
@@ -1,0 +1,126 @@
+package platform
+
+import (
+	"testing"
+)
+
+func TestApplyDocker_NilCfg(t *testing.T) {
+	vols, envs, err := ApplyDocker(nil)
+	if err != nil || len(vols) != 0 || len(envs) != 0 {
+		t.Errorf("nil cfg should return empty args; got vols=%v envs=%v err=%v", vols, envs, err)
+	}
+}
+
+func TestApplyDocker_TLSDisabled(t *testing.T) {
+	cfg := &PlatformConfig{TLS: TLSConfig{Enabled: false}, Env: map[string]string{}}
+	vols, envs, err := ApplyDocker(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vols) != 0 || len(envs) != 0 {
+		t.Errorf("TLS disabled should return no args; got vols=%v envs=%v", vols, envs)
+	}
+}
+
+func TestApplyDocker_TLSEnabled_ConfigMapSources_NoBundle(t *testing.T) {
+	// ConfigMap-sourced CAs cannot be materialised on the Docker host — no bundle created.
+	cfg := &PlatformConfig{
+		TLS: TLSConfig{
+			Enabled: true,
+			CASources: []CASource{{
+				Name:   "jaiscloud",
+				Source: CASourceRef{Kind: "configMap", Name: "jaiscloud-ca-cert", Key: "ca.crt"},
+			}},
+		},
+		Env: map[string]string{},
+	}
+	vols, envs, err := ApplyDocker(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// No file-based CAs → no bundle → no volume/env added.
+	if len(vols) != 0 {
+		t.Errorf("expected no volume args for configMap CA source; got %v", vols)
+	}
+	if len(envs) != 0 {
+		t.Errorf("expected no env args for configMap CA source; got %v", envs)
+	}
+}
+
+// tlsEnabledCfg returns a PlatformConfig with TLS enabled using a ConfigMap CA source
+// (which produces no host-side PEM bundle, so no TLS volume args are emitted).
+// This lets tests for extra-env and extra-volumes reach the code past the TLS guard.
+func tlsEnabledCfg(extra map[string]string, vols []VolumeSpec) *PlatformConfig {
+	return &PlatformConfig{
+		TLS: TLSConfig{
+			Enabled: true,
+			CASources: []CASource{{
+				Name:   "jaiscloud",
+				Source: CASourceRef{Kind: "configMap", Name: "jaiscloud-ca-cert", Key: "ca.crt"},
+			}},
+		},
+		Volumes: vols,
+		Env:     extra,
+	}
+}
+
+func TestApplyDocker_ExtraEnv(t *testing.T) {
+	cfg := tlsEnabledCfg(map[string]string{"MY_VAR": "hello"}, nil)
+	_, envArgs, err := ApplyDocker(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for i := 0; i+1 < len(envArgs); i += 2 {
+		if envArgs[i] == "-e" && envArgs[i+1] == "MY_VAR=hello" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("MY_VAR=hello not found in envArgs: %v", envArgs)
+	}
+}
+
+func TestApplyDocker_HostPathVolume(t *testing.T) {
+	vols := []VolumeSpec{{
+		Name: "my-host-vol",
+		Source: VolumeSource{
+			Kind:     "hostPath",
+			HostPath: &HostPathSource{Path: "/tmp/certs"},
+		},
+		Mounts: []MountSpec{{MountPath: "/etc/certs"}},
+	}}
+	cfg := tlsEnabledCfg(map[string]string{}, vols)
+	volArgs, _, err := ApplyDocker(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	found := false
+	for i := 0; i+1 < len(volArgs); i += 2 {
+		if volArgs[i] == "-v" && volArgs[i+1] == "/tmp/certs:/etc/certs:ro" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("hostPath bind-mount not found in volArgs: %v", volArgs)
+	}
+}
+
+func TestApplyDocker_ConfigMapVolume_NotBindMounted(t *testing.T) {
+	vols := []VolumeSpec{{
+		Name:   "my-cm",
+		Source: VolumeSource{Kind: "configMap", ConfigMap: &ConfigMapSource{Name: "my-configmap"}},
+		Mounts: []MountSpec{{MountPath: "/etc/conf"}},
+	}}
+	cfg := tlsEnabledCfg(map[string]string{}, vols)
+	volArgs, _, err := ApplyDocker(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// ConfigMap volumes cannot be bind-mounted in Docker mode; only hostPath can be.
+	for i := 0; i+1 < len(volArgs); i += 2 {
+		if volArgs[i] == "-v" {
+			t.Errorf("configMap volume should not produce docker -v args; got %q", volArgs[i+1])
+		}
+	}
+}

--- a/internal/platform/env.go
+++ b/internal/platform/env.go
@@ -1,0 +1,38 @@
+package platform
+
+import (
+	"sort"
+
+	"jaiscloud/internal/k8stypes"
+)
+
+// ExtraEnv converts a string map to EnvVar entries sorted by key for
+// deterministic manifest output.
+func ExtraEnv(m map[string]string) []k8stypes.EnvVar {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	envs := make([]k8stypes.EnvVar, len(keys))
+	for i, k := range keys {
+		envs[i] = k8stypes.EnvVar{Name: k, Value: m[k]}
+	}
+	return envs
+}
+
+// MergeEnv appends src entries into dst with first-wins deduplication,
+// matching K8s behaviour for duplicate names in a single container.
+func MergeEnv(dst, src []k8stypes.EnvVar) []k8stypes.EnvVar {
+	seen := make(map[string]struct{}, len(dst))
+	for _, e := range dst {
+		seen[e.Name] = struct{}{}
+	}
+	for _, e := range src {
+		if _, ok := seen[e.Name]; !ok {
+			dst = append(dst, e)
+			seen[e.Name] = struct{}{}
+		}
+	}
+	return dst
+}

--- a/internal/platform/env_test.go
+++ b/internal/platform/env_test.go
@@ -1,0 +1,71 @@
+package platform
+
+import (
+	"testing"
+
+	"jaiscloud/internal/k8stypes"
+)
+
+func TestExtraEnv_SortedOutput(t *testing.T) {
+	m := map[string]string{"Z_VAR": "z", "A_VAR": "a", "M_VAR": "m"}
+	envs := ExtraEnv(m)
+	if len(envs) != 3 {
+		t.Fatalf("expected 3 envs, got %d", len(envs))
+	}
+	if envs[0].Name != "A_VAR" || envs[1].Name != "M_VAR" || envs[2].Name != "Z_VAR" {
+		t.Errorf("not sorted: %v", envs)
+	}
+}
+
+func TestExtraEnv_Empty(t *testing.T) {
+	envs := ExtraEnv(nil)
+	if len(envs) != 0 {
+		t.Errorf("expected empty, got %d", len(envs))
+	}
+}
+
+func TestMergeEnv_FirstWins(t *testing.T) {
+	dst := []k8stypes.EnvVar{{Name: "FOO", Value: "original"}}
+	src := []k8stypes.EnvVar{{Name: "FOO", Value: "override"}, {Name: "BAR", Value: "bar"}}
+	result := MergeEnv(dst, src)
+	fooVal := ""
+	for _, e := range result {
+		if e.Name == "FOO" {
+			fooVal = e.Value
+		}
+	}
+	if fooVal != "original" {
+		t.Errorf("FOO should keep dst value %q, got %q", "original", fooVal)
+	}
+	barFound := false
+	for _, e := range result {
+		if e.Name == "BAR" {
+			barFound = true
+		}
+	}
+	if !barFound {
+		t.Error("BAR from src should be present after merge")
+	}
+}
+
+func TestMergeEnv_EmptyDst(t *testing.T) {
+	src := []k8stypes.EnvVar{{Name: "X", Value: "1"}}
+	result := MergeEnv(nil, src)
+	if len(result) != 1 || result[0].Name != "X" {
+		t.Errorf("expected X=1, got %v", result)
+	}
+}
+
+func TestMergeEnv_NoDuplicates(t *testing.T) {
+	src := []k8stypes.EnvVar{{Name: "A", Value: "1"}, {Name: "A", Value: "2"}}
+	result := MergeEnv(nil, src)
+	count := 0
+	for _, e := range result {
+		if e.Name == "A" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 A entry, got %d", count)
+	}
+}

--- a/internal/platform/k8s.go
+++ b/internal/platform/k8s.go
@@ -1,0 +1,151 @@
+package platform
+
+import (
+	"jaiscloud/internal/k8stypes"
+)
+
+// ApplyK8s mutates spec and ctr to inject TLS materializers, platform volumes,
+// mounts, and env. Ordering: TLS init containers + volumes + env first, then
+// platform extra volumes + env. Fails fast on volume name conflicts.
+// Call this after cloud-specific contributions are already on the spec.
+func ApplyK8s(spec *k8stypes.PodSpec, ctr *k8stypes.Container, cfg *PlatformConfig) error {
+	if cfg == nil {
+		return nil
+	}
+
+	// ── TLS materializers ─────────────────────────────────────────────────────
+	if cfg.TLS.Enabled && len(cfg.TLS.CASources) > 0 {
+		// Volumes for all CA sources (needed by both materializers).
+		caVols := caVolumes(cfg.TLS.CASources)
+		if cfg.TLS.ClientCert != nil {
+			caVols = append(caVols, caVolumes([]CASource{*cfg.TLS.ClientCert})...)
+		}
+		if err := checkVolumeConflicts(spec.Volumes, caVols); err != nil {
+			return err
+		}
+		spec.Volumes = append(spec.Volumes, caVols...)
+
+		for _, m := range materializers {
+			// Init container.
+			if ic := m.InitContainer(&cfg.TLS, ""); ic != nil {
+				mVols := m.Volumes()
+				if err := checkVolumeConflicts(spec.Volumes, mVols); err != nil {
+					return err
+				}
+				spec.Volumes = append(spec.Volumes, mVols...)
+				spec.InitContainers = append(spec.InitContainers, *ic)
+			}
+			// Main container env + mounts.
+			ctr.Env = MergeEnv(ctr.Env, m.ContainerEnv(&cfg.TLS))
+			ctr.VolumeMounts = append(ctr.VolumeMounts, m.VolumeMounts()...)
+		}
+	}
+
+	// ── Platform extra volumes ────────────────────────────────────────────────
+	platformVols := platformVolumes(cfg.Volumes)
+	if err := checkVolumeConflicts(spec.Volumes, platformVols); err != nil {
+		return err
+	}
+	spec.Volumes = append(spec.Volumes, platformVols...)
+
+	for _, vs := range cfg.Volumes {
+		for _, mnt := range vs.Mounts {
+			ctr.VolumeMounts = append(ctr.VolumeMounts, k8stypes.VolumeMount{
+				Name:      vs.Name,
+				MountPath: mnt.MountPath,
+				SubPath:   mnt.SubPath,
+				ReadOnly:  mnt.ReadOnly,
+			})
+		}
+	}
+
+	// ── Platform extra env ────────────────────────────────────────────────────
+	ctr.Env = MergeEnv(ctr.Env, ExtraEnv(cfg.Env))
+
+	return nil
+}
+
+// platformVolumes converts []VolumeSpec to []k8stypes.Volume for the pod spec.
+func platformVolumes(specs []VolumeSpec) []k8stypes.Volume {
+	vols := make([]k8stypes.Volume, 0, len(specs))
+	for _, vs := range specs {
+		vols = append(vols, toK8sVolume(vs))
+	}
+	return vols
+}
+
+// toK8sVolume maps a platform VolumeSpec to a k8stypes.Volume wire type.
+func toK8sVolume(vs VolumeSpec) k8stypes.Volume {
+	v := k8stypes.Volume{Name: vs.Name}
+	src := vs.Source
+	switch src.Kind {
+	case "configMap":
+		if src.ConfigMap != nil {
+			v.ConfigMap = &k8stypes.ConfigMapVol{Name: src.ConfigMap.Name}
+		}
+	case "secret":
+		if src.Secret != nil {
+			v.Secret = &k8stypes.SecretVol{SecretName: src.Secret.Name}
+		}
+	case "emptyDir":
+		v.EmptyDir = &k8stypes.EmptyDirVol{}
+		if src.EmptyDir != nil {
+			v.EmptyDir.Medium = src.EmptyDir.Medium
+			v.EmptyDir.SizeLimit = src.EmptyDir.SizeLimit
+		}
+	case "pvc":
+		if src.PVC != nil {
+			v.PVC = &k8stypes.PVCVol{ClaimName: src.PVC.ClaimName, ReadOnly: src.PVC.ReadOnly}
+		}
+	case "csi":
+		if src.CSI != nil {
+			v.CSI = &k8stypes.CSIVol{
+				Driver:           src.CSI.Driver,
+				ReadOnly:         src.CSI.ReadOnly,
+				FSType:           src.CSI.FSType,
+				VolumeAttributes: src.CSI.VolumeAttributes,
+			}
+		}
+	case "hostPath":
+		if src.HostPath != nil {
+			v.HostPath = &k8stypes.HostPathVol{Path: src.HostPath.Path, Type: src.HostPath.Type}
+		}
+	case "projected":
+		if src.Projected != nil {
+			v.Projected = toK8sProjected(src.Projected)
+		}
+	}
+	return v
+}
+
+func toK8sProjected(p *ProjectedSource) *k8stypes.ProjectedVol {
+	pv := &k8stypes.ProjectedVol{DefaultMode: p.DefaultMode}
+	for _, el := range p.Sources {
+		kEl := k8stypes.ProjectionElement{}
+		if el.ServiceAccountToken != nil {
+			kEl.ServiceAccountToken = &k8stypes.SATokenProjection{
+				Audience:          el.ServiceAccountToken.Audience,
+				ExpirationSeconds: el.ServiceAccountToken.ExpirationSeconds,
+				Path:              el.ServiceAccountToken.Path,
+			}
+		}
+		if el.ConfigMap != nil {
+			kEl.ConfigMap = &k8stypes.ConfigMapVol{Name: el.ConfigMap.Name}
+		}
+		if el.Secret != nil {
+			kEl.Secret = &k8stypes.ConfigMapVol{Name: el.Secret.Name}
+		}
+		if el.DownwardAPI != nil {
+			items := make([]k8stypes.DownwardAPIItem, len(el.DownwardAPI.Items))
+			for i, it := range el.DownwardAPI.Items {
+				items[i] = k8stypes.DownwardAPIItem{Path: it.Path}
+				if it.FieldRef != nil {
+					items[i].FieldRef = &k8stypes.ObjectFieldSelector{FieldPath: it.FieldRef.FieldPath}
+				}
+			}
+			kEl.DownwardAPI = &k8stypes.DownwardAPIProjection{Items: items}
+		}
+		pv.Sources = append(pv.Sources, kEl)
+	}
+	return pv
+}

--- a/internal/platform/k8s_test.go
+++ b/internal/platform/k8s_test.go
@@ -1,0 +1,164 @@
+package platform
+
+import (
+	"testing"
+
+	"jaiscloud/internal/k8stypes"
+)
+
+func minimalSpec() *k8stypes.PodSpec {
+	return &k8stypes.PodSpec{
+		Containers: []k8stypes.Container{{Name: "main", Image: "alpine"}},
+	}
+}
+
+func TestApplyK8s_NilCfg(t *testing.T) {
+	spec := minimalSpec()
+	ctr := &spec.Containers[0]
+	if err := ApplyK8s(spec, ctr, nil); err != nil {
+		t.Errorf("nil cfg should be a no-op; got %v", err)
+	}
+	if len(spec.Volumes) != 0 {
+		t.Errorf("no volumes should be added for nil cfg; got %v", spec.Volumes)
+	}
+}
+
+func TestApplyK8s_TLSDisabled_ExtraVolsAndEnv(t *testing.T) {
+	cfg := &PlatformConfig{
+		TLS: TLSConfig{Enabled: false},
+		Volumes: []VolumeSpec{{
+			Name:   "extra-vol",
+			Source: VolumeSource{Kind: "emptyDir", EmptyDir: &EmptyDirSource{}},
+			Mounts: []MountSpec{{MountPath: "/tmp/extra"}},
+		}},
+		Env: map[string]string{"EXTRA_VAR": "value"},
+	}
+	spec := minimalSpec()
+	ctr := &spec.Containers[0]
+	if err := ApplyK8s(spec, ctr, cfg); err != nil {
+		t.Fatalf("ApplyK8s: %v", err)
+	}
+	if len(spec.Volumes) != 1 || spec.Volumes[0].Name != "extra-vol" {
+		t.Errorf("extra volume not added: %v", spec.Volumes)
+	}
+	found := false
+	for _, e := range ctr.Env {
+		if e.Name == "EXTRA_VAR" && e.Value == "value" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("EXTRA_VAR not in container env: %v", ctr.Env)
+	}
+	if len(ctr.VolumeMounts) != 1 || ctr.VolumeMounts[0].MountPath != "/tmp/extra" {
+		t.Errorf("volume mount not added: %v", ctr.VolumeMounts)
+	}
+}
+
+func TestApplyK8s_VolumeConflict(t *testing.T) {
+	spec := minimalSpec()
+	spec.Volumes = []k8stypes.Volume{{Name: "conflict-vol"}}
+	cfg := &PlatformConfig{
+		TLS: TLSConfig{Enabled: false},
+		Volumes: []VolumeSpec{{
+			Name:   "conflict-vol",
+			Source: VolumeSource{Kind: "emptyDir", EmptyDir: &EmptyDirSource{}},
+			Mounts: []MountSpec{{MountPath: "/tmp"}},
+		}},
+		Env: map[string]string{},
+	}
+	ctr := &spec.Containers[0]
+	if err := ApplyK8s(spec, ctr, cfg); err == nil {
+		t.Error("expected conflict error, got nil")
+	}
+}
+
+func TestApplyK8s_EnvMerge_ExistingEnvPreserved(t *testing.T) {
+	spec := minimalSpec()
+	spec.Containers[0].Env = []k8stypes.EnvVar{{Name: "EXISTING", Value: "keep"}}
+	cfg := &PlatformConfig{
+		TLS: TLSConfig{Enabled: false},
+		Env: map[string]string{"NEW_VAR": "new"},
+	}
+	ctr := &spec.Containers[0]
+	if err := ApplyK8s(spec, ctr, cfg); err != nil {
+		t.Fatalf("ApplyK8s: %v", err)
+	}
+	names := make(map[string]string)
+	for _, e := range ctr.Env {
+		names[e.Name] = e.Value
+	}
+	if names["EXISTING"] != "keep" {
+		t.Errorf("EXISTING env should be preserved; got %q", names["EXISTING"])
+	}
+	if names["NEW_VAR"] != "new" {
+		t.Errorf("NEW_VAR should be added; got %q", names["NEW_VAR"])
+	}
+}
+
+func TestApplyK8s_TLSEnabled_InjectsVolumesAndEnv(t *testing.T) {
+	cfg := &PlatformConfig{
+		TLS: TLSConfig{
+			Enabled: true,
+			CASources: []CASource{{
+				Name:   "corp-ca",
+				Source: CASourceRef{Kind: "configMap", Name: "corp-ca-cm"},
+			}},
+		},
+	}
+	spec := minimalSpec()
+	ctr := &spec.Containers[0]
+	if err := ApplyK8s(spec, ctr, cfg); err != nil {
+		t.Fatalf("ApplyK8s with TLS: %v", err)
+	}
+	// At least one CA volume should be present.
+	if len(spec.Volumes) == 0 {
+		t.Error("TLS enabled: expected CA volumes on pod spec, got none")
+	}
+	// At least one init container should be present (JVM truststore or PEM bundle materializer).
+	if len(spec.InitContainers) == 0 {
+		t.Error("TLS enabled: expected init containers, got none")
+	}
+	// Container env should have SSL_CERT_FILE or JAVA_TOOL_OPTIONS (from materializers).
+	envNames := make(map[string]bool)
+	for _, e := range ctr.Env {
+		envNames[e.Name] = true
+	}
+	if !envNames["SSL_CERT_FILE"] && !envNames["JAVA_TOOL_OPTIONS"] {
+		t.Errorf("TLS enabled: expected SSL_CERT_FILE or JAVA_TOOL_OPTIONS in container env; got %v", ctr.Env)
+	}
+	// Container should have volume mounts from materializers.
+	if len(ctr.VolumeMounts) == 0 {
+		t.Error("TLS enabled: expected volume mounts on container, got none")
+	}
+}
+
+func TestApplyK8s_MultipleVolumes(t *testing.T) {
+	cfg := &PlatformConfig{
+		TLS: TLSConfig{Enabled: false},
+		Volumes: []VolumeSpec{
+			{
+				Name:   "vol-a",
+				Source: VolumeSource{Kind: "emptyDir", EmptyDir: &EmptyDirSource{}},
+				Mounts: []MountSpec{{MountPath: "/a"}},
+			},
+			{
+				Name:   "vol-b",
+				Source: VolumeSource{Kind: "configMap", ConfigMap: &ConfigMapSource{Name: "my-cm"}},
+				Mounts: []MountSpec{{MountPath: "/b"}},
+			},
+		},
+		Env: map[string]string{},
+	}
+	spec := minimalSpec()
+	ctr := &spec.Containers[0]
+	if err := ApplyK8s(spec, ctr, cfg); err != nil {
+		t.Fatalf("ApplyK8s: %v", err)
+	}
+	if len(spec.Volumes) != 2 {
+		t.Errorf("expected 2 volumes; got %d", len(spec.Volumes))
+	}
+	if len(ctr.VolumeMounts) != 2 {
+		t.Errorf("expected 2 mounts; got %d", len(ctr.VolumeMounts))
+	}
+}

--- a/internal/platform/pem_materialize.go
+++ b/internal/platform/pem_materialize.go
@@ -1,0 +1,52 @@
+package platform
+
+import (
+	"fmt"
+	"os"
+)
+
+// materializePEMBundle writes all CA sources available as local files into a
+// single PEM bundle on the host filesystem. The result is cached on cfg so
+// each PlatformConfig instance gets its own independent cache (allowing tests
+// and multiple server instances to use different CA sets without interference).
+// Returns ("", nil) when no file-kind CA sources are present — Docker TLS is
+// then a no-op.
+func (cfg *PlatformConfig) materializePEMBundle() (string, error) {
+	cfg.bundle.once.Do(func() {
+		cfg.bundle.path, cfg.bundle.err = writePEMBundle(cfg.TLS.CASources)
+	})
+	return cfg.bundle.path, cfg.bundle.err
+}
+
+func writePEMBundle(sources []CASource) (string, error) {
+	f, err := os.CreateTemp("", "jaiscloud-ca-bundle-*.pem")
+	if err != nil {
+		return "", fmt.Errorf("platform: create PEM bundle temp file: %w", err)
+	}
+	defer f.Close()
+
+	wrote := 0
+	for _, ca := range sources {
+		// Only local file sources are readable by the host process.
+		// K8s ConfigMap/Secret sources are skipped; they are handled inside
+		// the pod via the pem-bundle init container.
+		if ca.Source.Kind != "file" {
+			continue
+		}
+		data, err := os.ReadFile(ca.Source.Key)
+		if err != nil {
+			return "", fmt.Errorf("platform: read CA file %s: %w", ca.Source.Key, err)
+		}
+		if _, err := f.Write(data); err != nil {
+			return "", fmt.Errorf("platform: write PEM bundle: %w", err)
+		}
+		wrote++
+	}
+
+	if wrote == 0 {
+		// No local CA files — return empty path; Docker TLS will be a no-op.
+		os.Remove(f.Name())
+		return "", nil
+	}
+	return f.Name(), nil
+}

--- a/internal/platform/tls.go
+++ b/internal/platform/tls.go
@@ -1,0 +1,41 @@
+package platform
+
+import "jaiscloud/internal/k8stypes"
+
+// TLSConfig holds generic TLS trust configuration. When Enabled=true both
+// jvm-truststore and pem-bundle materializers always run.
+type TLSConfig struct {
+	Enabled             bool
+	CASources           []CASource
+	ClientCert          *CASource
+	TruststorePassword  string // default "changeit"; embedded in JAVA_TOOL_OPTIONS only
+}
+
+// CASource references a CA certificate stored in a K8s Secret or ConfigMap.
+type CASource struct {
+	Name   string    // unique alias used as keytool alias and label
+	Source CASourceRef
+}
+
+// CASourceRef discriminates between a ConfigMap and a Secret source.
+type CASourceRef struct {
+	Kind string // "configMap" | "secret"
+	Name string
+	Key  string
+}
+
+// TLSMaterializer converts TLSConfig into pod fragments for a specific runtime format.
+type TLSMaterializer interface {
+	Name() string
+	InitContainer(cfg *TLSConfig, image string) *k8stypes.Container
+	ContainerEnv(cfg *TLSConfig) []k8stypes.EnvVar
+	Volumes() []k8stypes.Volume
+	VolumeMounts() []k8stypes.VolumeMount
+}
+
+// materializers lists the materializers applied when TLS.Enabled=true.
+// Order: jvm-truststore first, pem-bundle second — both always run.
+var materializers = []TLSMaterializer{
+	jvmTruststoreMaterializer{},
+	pemBundleMaterializer{},
+}

--- a/internal/platform/tls_jvm.go
+++ b/internal/platform/tls_jvm.go
@@ -1,0 +1,141 @@
+package platform
+
+import (
+	"fmt"
+	"strings"
+
+	"jaiscloud/internal/k8stypes"
+)
+
+const (
+	truststoreVolName = "jaiscloud-truststore"
+	truststoreMount   = "/tmp/truststore"
+	truststorePath    = "/tmp/truststore/cacerts"
+	clientP12Path     = "/tmp/truststore/client.p12"
+	jvmInitImage      = "eclipse-temurin:21-jre"
+)
+
+type jvmTruststoreMaterializer struct{}
+
+func (jvmTruststoreMaterializer) Name() string { return "jvm-truststore" }
+
+func (jvmTruststoreMaterializer) InitContainer(cfg *TLSConfig, _ string) *k8stypes.Container {
+	password := cfg.TruststorePassword
+	if password == "" {
+		password = "changeit"
+	}
+
+	// Step 1: copy the default cacerts from the JRE.
+	script := fmt.Sprintf("set -e; cp $JAVA_HOME/lib/security/cacerts %s; ", truststorePath)
+
+	// Step 2: import each CA.
+	for _, ca := range cfg.CASources {
+		mountPath := pemCAMountPath(ca.Name)
+		script += fmt.Sprintf(
+			"keytool -importcert -noprompt -trustcacerts -alias %s -file %s/%s -keystore %s -storepass %s; ",
+			ca.Name, mountPath, ca.Source.Key, truststorePath, password,
+		)
+	}
+
+	// Step 3: convert client cert to PKCS12 if provided.
+	if cfg.ClientCert != nil {
+		mountPath := pemCAMountPath(cfg.ClientCert.Name)
+		script += fmt.Sprintf(
+			"keytool -importkeystore -noprompt -srckeystore %s/%s -srcstoretype PKCS12 -destkeystore %s -deststoretype PKCS12 -deststorepass %s; ",
+			mountPath, cfg.ClientCert.Source.Key, clientP12Path, password,
+		)
+	}
+
+	mounts := append(
+		caMountSpecs(cfg.CASources),
+		k8stypes.VolumeMount{Name: truststoreVolName, MountPath: truststoreMount},
+	)
+	if cfg.ClientCert != nil {
+		mounts = append(mounts, k8stypes.VolumeMount{
+			Name:      caVolumeName(cfg.ClientCert.Name),
+			MountPath: pemCAMountPath(cfg.ClientCert.Name),
+			ReadOnly:  true,
+		})
+	}
+
+	return &k8stypes.Container{
+		Name:         "jvm-truststore-init",
+		Image:        jvmInitImage,
+		Command:      []string{"sh", "-c", script},
+		VolumeMounts: mounts,
+	}
+}
+
+func (jvmTruststoreMaterializer) ContainerEnv(cfg *TLSConfig) []k8stypes.EnvVar {
+	password := cfg.TruststorePassword
+	if password == "" {
+		password = "changeit"
+	}
+
+	jvmOpts := fmt.Sprintf(
+		"-Djavax.net.ssl.trustStore=%s -Djavax.net.ssl.trustStorePassword=%s",
+		truststorePath, password,
+	)
+	if cfg.ClientCert != nil {
+		jvmOpts += fmt.Sprintf(
+			" -Djavax.net.ssl.keyStore=%s -Djavax.net.ssl.keyStoreType=PKCS12 -Djavax.net.ssl.keyStorePassword=%s",
+			clientP12Path, password,
+		)
+	}
+
+	return []k8stypes.EnvVar{{
+		Name:  "JAVA_TOOL_OPTIONS",
+		Value: jvmOpts,
+	}}
+}
+
+func (jvmTruststoreMaterializer) Volumes() []k8stypes.Volume {
+	return []k8stypes.Volume{{
+		Name:     truststoreVolName,
+		EmptyDir: &k8stypes.EmptyDirVol{},
+	}}
+}
+
+func (jvmTruststoreMaterializer) VolumeMounts() []k8stypes.VolumeMount {
+	return []k8stypes.VolumeMount{{
+		Name:      truststoreVolName,
+		MountPath: truststoreMount,
+	}}
+}
+
+// ── shared helpers ─────────────────────────────────────────────────────────
+
+// caVolumeName returns a deterministic K8s volume name for a CA source alias.
+func caVolumeName(alias string) string {
+	return "jaiscloud-ca-" + strings.ToLower(strings.ReplaceAll(alias, "_", "-"))
+}
+
+// caMountSpecs returns volumeMount entries for each CASource, mounting them
+// read-only into the init container.
+func caMountSpecs(sources []CASource) []k8stypes.VolumeMount {
+	mounts := make([]k8stypes.VolumeMount, len(sources))
+	for i, ca := range sources {
+		mounts[i] = k8stypes.VolumeMount{
+			Name:      caVolumeName(ca.Name),
+			MountPath: pemCAMountPath(ca.Name),
+			ReadOnly:  true,
+		}
+	}
+	return mounts
+}
+
+// caVolumes returns volume definitions for each CASource (ConfigMap or Secret).
+func caVolumes(sources []CASource) []k8stypes.Volume {
+	vols := make([]k8stypes.Volume, len(sources))
+	for i, ca := range sources {
+		vol := k8stypes.Volume{Name: caVolumeName(ca.Name)}
+		switch ca.Source.Kind {
+		case "configMap":
+			vol.ConfigMap = &k8stypes.ConfigMapVol{Name: ca.Source.Name}
+		case "secret":
+			vol.Secret = &k8stypes.SecretVol{SecretName: ca.Source.Name}
+		}
+		vols[i] = vol
+	}
+	return vols
+}

--- a/internal/platform/tls_pem.go
+++ b/internal/platform/tls_pem.go
@@ -1,0 +1,75 @@
+package platform
+
+import "jaiscloud/internal/k8stypes"
+
+// nonJVMEnvVars lists the env vars that point every non-JVM runtime at the
+// PEM bundle. Each runtime checks a different var and does not fall back.
+var nonJVMEnvVars = []string{
+	"SSL_CERT_FILE",       // OpenSSL, libcurl, Go net/http, Rust rustls-native-certs
+	"REQUESTS_CA_BUNDLE",  // Python requests
+	"NODE_EXTRA_CA_CERTS", // Node.js (does not read SSL_CERT_FILE)
+	"AWS_CA_BUNDLE",       // AWS CLI + all AWS SDKs
+	"GIT_SSL_CAINFO",      // git CLI (spark-submit --packages, pip install git+https)
+	"CURL_CA_BUNDLE",      // curl on RHEL/UBI images
+}
+
+const (
+	pemBundlePath      = "/etc/ssl/certs/jaiscloud-ca-bundle.pem"
+	pemScratchVolName  = "jaiscloud-pem-scratch"
+	pemScratchMount    = "/tmp/jaiscloud-pem-build"
+	pemInitImage       = "busybox:1.36"
+)
+
+type pemBundleMaterializer struct{}
+
+func (pemBundleMaterializer) Name() string { return "pem-bundle" }
+
+func (pemBundleMaterializer) InitContainer(cfg *TLSConfig, _ string) *k8stypes.Container {
+	// Build a shell command that cat-concatenates each CA file into the bundle.
+	cmd := "set -e; "
+	for _, ca := range cfg.CASources {
+		mountPath := pemCAMountPath(ca.Name)
+		cmd += "cat " + mountPath + "/" + ca.Source.Key + " >> " + pemBundlePath + "; "
+	}
+
+	return &k8stypes.Container{
+		Name:    "pem-bundle-init",
+		Image:   pemInitImage,
+		Command: []string{"sh", "-c", cmd},
+		VolumeMounts: append(
+			caMountSpecs(cfg.CASources),
+			k8stypes.VolumeMount{
+				Name:      pemScratchVolName,
+				MountPath: "/etc/ssl/certs",
+			},
+		),
+	}
+}
+
+func (pemBundleMaterializer) ContainerEnv(cfg *TLSConfig) []k8stypes.EnvVar {
+	env := make([]k8stypes.EnvVar, 0, len(nonJVMEnvVars))
+	for _, name := range nonJVMEnvVars {
+		env = append(env, k8stypes.EnvVar{Name: name, Value: pemBundlePath})
+	}
+	return env
+}
+
+func (pemBundleMaterializer) Volumes() []k8stypes.Volume {
+	return []k8stypes.Volume{{
+		Name:     pemScratchVolName,
+		EmptyDir: &k8stypes.EmptyDirVol{},
+	}}
+}
+
+func (pemBundleMaterializer) VolumeMounts() []k8stypes.VolumeMount {
+	return []k8stypes.VolumeMount{{
+		Name:      pemScratchVolName,
+		MountPath: "/etc/ssl/certs",
+	}}
+}
+
+// pemCAMountPath returns the directory path inside the init container where a
+// CA source is mounted.
+func pemCAMountPath(alias string) string {
+	return "/tmp/jaiscloud-ca/" + alias
+}

--- a/internal/platform/volumes.go
+++ b/internal/platform/volumes.go
@@ -1,0 +1,100 @@
+package platform
+
+// VolumeSpec describes a volume and its mounts injected into every managed pod.
+type VolumeSpec struct {
+	Name   string       `json:"name"`
+	Source VolumeSource `json:"source"`
+	Mounts []MountSpec  `json:"mounts"`
+}
+
+// VolumeSource is a discriminated union over K8s volume kinds.
+// Exactly one pointer field must be non-nil, matching Kind.
+type VolumeSource struct {
+	Kind      string           `json:"kind"` // "secret"|"configMap"|"emptyDir"|"projected"|"pvc"|"csi"|"hostPath"
+	Secret    *SecretSource    `json:"secret,omitempty"`
+	ConfigMap *ConfigMapSource `json:"configMap,omitempty"`
+	EmptyDir  *EmptyDirSource  `json:"emptyDir,omitempty"`
+	Projected *ProjectedSource `json:"projected,omitempty"`
+	PVC       *PVCSource       `json:"pvc,omitempty"`
+	CSI       *CSISource       `json:"csi,omitempty"`
+	HostPath  *HostPathSource  `json:"hostPath,omitempty"`
+}
+
+type SecretSource struct {
+	Name        string      `json:"name"`
+	DefaultMode *int32      `json:"defaultMode,omitempty"`
+	Items       []KeyToPath `json:"items,omitempty"`
+	Optional    *bool       `json:"optional,omitempty"`
+}
+
+type ConfigMapSource struct {
+	Name        string      `json:"name"`
+	DefaultMode *int32      `json:"defaultMode,omitempty"`
+	Items       []KeyToPath `json:"items,omitempty"`
+	Optional    *bool       `json:"optional,omitempty"`
+}
+
+type EmptyDirSource struct {
+	Medium    string `json:"medium,omitempty"`
+	SizeLimit string `json:"sizeLimit,omitempty"`
+}
+
+type ProjectedSource struct {
+	Sources     []ProjectionElement `json:"sources"`
+	DefaultMode *int32              `json:"defaultMode,omitempty"`
+}
+
+type ProjectionElement struct {
+	ServiceAccountToken *SATokenProjection     `json:"serviceAccountToken,omitempty"`
+	Secret              *ConfigMapSource       `json:"secret,omitempty"`
+	ConfigMap           *ConfigMapSource       `json:"configMap,omitempty"`
+	DownwardAPI         *DownwardAPIProjection `json:"downwardAPI,omitempty"`
+}
+
+type SATokenProjection struct {
+	Audience          string `json:"audience"`
+	ExpirationSeconds int64  `json:"expirationSeconds,omitempty"`
+	Path              string `json:"path"`
+}
+
+type DownwardAPIProjection struct {
+	Items []DownwardAPIItem `json:"items"`
+}
+
+type DownwardAPIItem struct {
+	Path     string               `json:"path"`
+	FieldRef *ObjectFieldSelector `json:"fieldRef,omitempty"`
+}
+
+type ObjectFieldSelector struct {
+	FieldPath string `json:"fieldPath"`
+}
+
+type PVCSource struct {
+	ClaimName string `json:"claimName"`
+	ReadOnly  bool   `json:"readOnly,omitempty"`
+}
+
+type CSISource struct {
+	Driver           string            `json:"driver"`
+	ReadOnly         bool              `json:"readOnly,omitempty"`
+	FSType           string            `json:"fsType,omitempty"`
+	VolumeAttributes map[string]string `json:"volumeAttributes,omitempty"`
+}
+
+type HostPathSource struct {
+	Path string `json:"path"`
+	Type string `json:"type,omitempty"`
+}
+
+type KeyToPath struct {
+	Key  string `json:"key"`
+	Path string `json:"path"`
+	Mode *int32 `json:"mode,omitempty"`
+}
+
+type MountSpec struct {
+	MountPath string `json:"mountPath"`
+	SubPath   string `json:"subPath,omitempty"`
+	ReadOnly  bool   `json:"readOnly,omitempty"`
+}


### PR DESCRIPTION
## Summary

- Introduce `internal/platform/` — a startup-loaded config layer that injects TLS trust, volumes, and env uniformly into every JaisCloud-managed container or pod, without coupling it to any specific executor
- Introduce `internal/k8stypes/` — shared Go types for Kubernetes pod-spec wire format, eliminating duplicate `map[string]any` definitions across Lambda and Spark K8s executors
- Add a `CloudSparkTransform` registry (AWS, Azure, GCP) so Spark K8s/Docker executors are cloud-aware without hardcoding AWS logic in the executor itself
- Migrate Lambda K8s executor from `map[string]any` pod construction to typed `k8stypes.PodSpec` structs, enabling `platform.ApplyK8s` injection
- Wire `platform.LoadFromEnv()` at server startup; pass `*PlatformConfig` to all executor constructors

---

## Changes

### New packages

- `internal/k8stypes/` — exported K8s pod-spec types shared by `spark`, `lambda`, and `platform` packages
- `internal/platform/` — `PlatformConfig`, `LoadFromEnv`, `ApplyK8s`, `ApplyDocker`; TLS materializers (JVM truststore, PEM bundle); volume and env injection; conflict detection

### Spark executor

- `cloud_transform.go` — `CloudSparkTransform` interface + `init()`-based registry
- `aws_transform.go` — refactored to implement the interface; all existing AWS logic preserved
- `azure_transform.go` — Azure SharedKey and OAuth/Workload Identity transforms
- `gcp_transform.go` — GCP service-account key transforms
- `k8s.go` — `buildJobManifest` now returns `(batchJob, error)` and applies cloud transform + platform layer
- `docker.go` — `Submit` uses cloud transform; `NewDockerExecutor` accepts `*platform.PlatformConfig`
- `config.go` — added `Cloud`, `ExtraSparkConfs`, and cloud-specific credential fields
- `k8sclient.go` — replaced local type defs with `k8stypes` aliases

### Lambda executor

- `k8s.go` — migrated pod construction to `k8stypes.PodSpec`; `NewK8sExecutor` accepts `*platform.PlatformConfig`
- `docker.go` — `NewDockerExecutor` accepts `*platform.PlatformConfig`; calls `platform.ApplyDocker`

### Main wiring

- `buildRegistry` loads `platform.LoadFromEnv()` at startup
- `buildSparkExecutor` sets `cfg.Cloud` and uses direct constructors (`NewK8sExecutor`/`NewDockerExecutor`) instead of the generic factory
- Lambda executor construction switched to mode-specific constructors, passing `platformCfg`

### Bug fixes

- `azure_transform.go` `SparkConfs`: `fmt.Sprintf("--conf", ...)` was silently dropping all arguments (format string had no verbs); fixed to emit correct `--conf KEY=VAL` pairs
- `azure_transform.go` `SparkConfs`: SharedKey auth type was incorrectly emitted in OAuth mode
- `lambda/docker.go` `gcOnce`: GC goroutine could evict cold-start sentinels (zero `lastUsed`); now skips entries with empty `id`
- `main.go`: `platformCfg` now loaded before `buildRegistry` with proper error propagation instead of `os.Exit(1)` inside the function (which bypassed `defer cleanup()`)
- `cloud_transform.go`: `transforms` map now protected by `sync.RWMutex` for race-safe parallel test execution
- `cloud_transform.go` `toEnvVars`: removed silent filter that dropped empty-string env var values
- `platform/docker.go`: non-hostPath volumes now emit a `slog.Warn` instead of being silently skipped
- `platform/config.go`: removed dead `unmarshalFile` function

---

## Test plan

- [ x] `go test -race ./internal/platform/...` — all platform tests pass (env, conflicts, config, docker, k8s)
- [x ] `go test -race ./internal/executor/spark/...` — all spark tests pass including new `cloud_transform`, `azure`, `gcp` transform tests
- [x ] `go build ./...` — clean build with no import errors
- [x ] `JAISCLOUD_EXECUTOR_MODE=docker ./jaiscloud start` — verify startup log shows platform TLS info and `lambda executor mode=docker`
- [ x] `JAISCLOUD_EXECUTOR_MODE=k8s ./jaiscloud start` — verify Spark and Lambda K8s executors initialize correctly
