### PR TITLE
EMR Bootstrap Actions as K8s Init Containers and Spark cluster mode support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ JaisCloud is a local multi-cloud emulator written in Go. It speaks native AWS wi
 **Phase 1 (complete):** IAM/STS, SNS, DynamoDB, S3, Lambda; BlobFS; PostgreSQL stores; export/import; Prometheus metrics.  
 **Phase 2 (complete):** ResourceManager with deletion guards; Multi-cloud adapter model (AWS default, Azure/GCP stubs); EMR/EMR-on-EKS built-in providers with SparkExecutor (mock + k8s); Prometheus cloud label.  
 **Phase 2.5 (complete):** KMS (envelope crypto, grants, rotation); SecretsManager (AES-GCM at rest via KMS); SSM Parameter Store (SecureString via KMS); API Gateway REST management plane + execute-api invoke plane (MOCK, AWS_PROXY, HTTP_PROXY); Lambda Docker/K8s executors; CloudFormation with full intrinsics engine (Ref, Fn::GetAtt, Fn::Sub, Fn::Join, conditions, mappings), topological sort, and real resource dispatch for 9 AWS resource types.  
-**Phase 2.5 patch (complete):** Lambda K8s executor rewritten to warm-pod-per-function model (matching Docker executor); Spark K8s executor `Close()` suspends tracked Jobs instead of deleting them; `cleanupOrphans()` re-adopts running/suspended Jobs on restart; HTTPS server with auto-generated cloud-aware TLS cert (ECDSA P-256, 10-year, DNS SANs per cloud); S3 virtual-hosted-style parsing (`mybucket.s3.<region>.amazonaws.com`); IAM `AssumeRole`/`GetFederationToken` `PackedPolicySize` computed correctly; SSM `GetParameterHistory` now decrypts SecureString values; `DeleteFunction` tears down warm container/pod; `LambdaExecutor` interface extended with `DeleteFunction` + `Reset`; test suite reorganised under `tests/full_mode/aws/`; `docker-compose.yml` + K8s RBAC manifest + Lambda echo image added.
+**Phase 2.5 patch (complete):** Lambda K8s executor rewritten to warm-pod-per-function model (matching Docker executor); Spark K8s executor `Close()` suspends tracked Jobs instead of deleting them; `cleanupOrphans()` re-adopts running/suspended Jobs on restart; HTTPS server with auto-generated cloud-aware TLS cert (ECDSA P-256, 10-year, DNS SANs per cloud); S3 virtual-hosted-style parsing (`mybucket.s3.<region>.amazonaws.com`); IAM `AssumeRole`/`GetFederationToken` `PackedPolicySize` computed correctly; SSM `GetParameterHistory` now decrypts SecureString values; `DeleteFunction` tears down warm container/pod; `LambdaExecutor` interface extended with `DeleteFunction` + `Reset`; test suite reorganised under `tests/full_mode/aws/`; `docker-compose.yml` + K8s RBAC manifest + Lambda echo image added.  
+**Phase 2.5 patch 2 (complete):** EMR classic bootstrap actions (`RunJobFlow.BootstrapActions`) materialised as Kubernetes init containers when `EXECUTOR_MODE=k8s`; `BlobFetcher` interface + `S3BlobFetcher` in `blobfs` so bootstrap scripts are fetched from the S3 store; `k8stypes.EnvVar.ValueFrom` support (SecretKeyRef, ConfigMapKeyRef, FieldRef); `SparkJob` extended with `ExtraInitContainers`, `ExtraVolumes`, `ExtraMainMounts` fragment fields so the EMR provider can inject bootstrap fragments without importing the executor package; host-package-manager commands (`yum`, `apt-get`, `systemctl`, etc.) automatically commented out from bootstrap scripts; DynamoDB `Query` `LastEvaluatedKey` pagination bug fixed (`len(matched)` → `len(all)`).
 
 ---
 
@@ -73,6 +74,7 @@ internal/
   admin/                # /_jaiscloud/* endpoints
                         # Resetter, Snapshotter interfaces
   blobfs/               # BlobStore interface: MemoryBlobStore, LocalFSBlobStore
+                        # BlobFetcher interface: S3BlobFetcher (fetches bootstrap scripts by s3:// URI)
   clock/                # Clock interface: RealClock, FixedClock, OffsetClock
   config/               # Config struct; Viper loading; env prefix JAISCLOUD_
   events/               # In-process EventBus (subscribe/publish)
@@ -89,6 +91,7 @@ internal/
     container/          # ECS provider
     dns/                # Route53 provider
     emr/                # EMRProvider — RunJobFlow, steps, tags; wires SparkExecutor + StatusPoller
+                        # bootstrap.go — Resolve() fetches + scrubs bootstrap scripts → init containers
     emroneks/           # EMRContainersProvider — virtual clusters, job runs; wires SparkExecutor
     function/           # FunctionProvider — Lambda (echo/Docker/K8s invoke)
     iam/                # IAMProvider + STS (roles, policies, users, access keys)
@@ -345,6 +348,25 @@ spec:
 
 The `StatusPoller` goroutine polls the Job every `SparkConfig.PollInterval` (default 5 s) and fires `OnStateChange` to update the EMR step state (`PENDING → RUNNING → COMPLETED / FAILED`).
 
+**Bootstrap actions:** When `RunJobFlow` includes `BootstrapActions` and `EXECUTOR_MODE=k8s`, the EMR provider calls `bootstrap.Resolve()` before submitting. Each bootstrap action becomes a K8s init container that runs before `spark-submit`:
+
+```yaml
+initContainers:
+  - name: bootstrap-{sanitized-action-name}
+    image: amazon/aws-cli:2.18          # JAISCLOUD_BOOTSTRAP_IMAGE
+    command: ["/bin/sh", "-c"]
+    args: ["printf '%s' '<b64-script>' | base64 -d | /bin/sh -s -- <args>"]
+    securityContext:
+      runAsUser: 0                       # root so scripts can write to /etc/pki, /home/hadoop
+    volumeMounts:
+      - name: bootstrap-prefix-etc-pki
+        mountPath: /etc/pki
+      - name: bootstrap-prefix-home-hadoop
+        mountPath: /home/hadoop
+```
+
+One `emptyDir` volume is created per prefix (`JAISCLOUD_BOOTSTRAP_RELOCATE_PREFIXES`, default `/etc/pki,/home/hadoop`) and mounted into both init containers and the main `spark-submit` container. Host-only commands (`yum`, `apt-get`, `dnf`, `rpm`, `systemctl`, `service`, `chkconfig`, `update-rc.d`) are automatically commented out with `# [jaiscloud-skip]`. If bootstrap script fetch or resolution fails the step is immediately marked `FAILED`.
+
 **Suspend/resume lifecycle:** `K8sExecutor.Close()` suspends all tracked Jobs (strategic-merge-patch `spec.suspend: true`) instead of deleting them, preserving partial progress across server restarts. On startup, `cleanupOrphans()` lists all `app.kubernetes.io/managed-by=jaiscloud` Jobs: terminal Jobs are deleted, suspended Jobs are unsuspended and re-adopted into the live jobs map, running Jobs are adopted directly.
 
 ---
@@ -374,6 +396,8 @@ S3 object **bodies** are stored in `BlobStore`, separate from the metadata in Po
 | Full (when wired) | `LocalFSBlobStore` | `JAISCLOUD_BLOB_DIR` on local filesystem |
 
 `LocalFSBlobStore` is fully implemented at [internal/blobfs/](internal/blobfs/) but the `main.go` wire-up still uses `MemoryBlobStore`. Swap `NewMemoryBlobStore()` for `NewLocalFSBlobStore(cfg.BlobDir)` in `startCmd` to enable persistent blob storage.
+
+**`BlobFetcher` interface** (`internal/blobfs/blobfetch.go`) provides URI-addressed read-only access to the blob store. `S3BlobFetcher` parses `s3://` and `s3a://` URIs and delegates to the underlying `BlobStore`. Used by the EMR bootstrap resolver to fetch bootstrap scripts by their S3 path without importing the S3 provider.
 
 ---
 
@@ -423,6 +447,10 @@ JAISCLOUD_LAMBDA_KEEPALIVE_SECS=300  # Docker warm container idle timeout
 JAISCLOUD_KMS_MASTER_KEY=    # 32-byte hex KEK; if unset DEK stored plaintext (dev only)
 JAISCLOUD_APIGW_PROXY_TIMEOUT=30s    # HTTP_PROXY integration timeout
 JAISCLOUD_APIGW_ALLOW_PRIVATE_HOSTS= # true to allow RFC-1918 HTTP_PROXY targets
+# EMR bootstrap actions (K8s executor only)
+JAISCLOUD_BOOTSTRAP_IMAGE=amazon/aws-cli:2.18  # init container image for bootstrap scripts
+JAISCLOUD_BOOTSTRAP_SCRIPT_MAX_BYTES=1048576   # max size per bootstrap script (default 1 MiB)
+JAISCLOUD_BOOTSTRAP_RELOCATE_PREFIXES=/etc/pki,/home/hadoop  # comma-separated emptyDir mount paths
 ```
 
 > **Config loading:** `config.Load()` reads from the global Viper instance. All `viper.BindPFlag(...)` calls in `startCmd` must use the global `viper` package (not a local `viper.New()` instance) or flags will be silently ignored and defaults used.
@@ -521,6 +549,7 @@ The `SparkExecutor` interface drives EMR step execution and EMR-on-EKS job runs:
 - **`K8sExecutor`** — submits real `batch/v1 Jobs` to Kubernetes via stdlib HTTP (no client-go). Reads auth from in-cluster service account or `JAISCLOUD_K8S_*` env vars. `Close()` **suspends** (not deletes) tracked Jobs; `cleanupOrphans()` on startup re-adopts or deletes orphaned Jobs.
 - **`StatusPoller`** — single background goroutine; polls non-terminal jobs at a configurable interval; fires `OnStateChange` callbacks. `Stop()` is safe to call multiple times (`sync.Once`).
 - **`SparkSubmitArgs`** — builds the full `spark-submit` argument list including `--master k8s://`, `--deploy-mode cluster`, container image, namespace, service account, resource profile, and S3 event-log args.
+- **`SparkJob` fragment fields** — `ExtraInitContainers`, `ExtraVolumes`, `ExtraMainMounts` carry pre-built K8s fragments from the EMR provider (bootstrap init containers + emptyDir volumes). The executor injects them into the pod spec in `buildJobManifest` after cloud/platform layers are applied. Volume name conflicts are detected via `checkVolumeConflicts` and cause `buildJobManifest` to return an error.
 
 EMR and EMRContainers providers accept a `WithExecutor(exec, cfg)` option. When an executor is wired, `AddJobFlowSteps` / `StartJobRun` call `Submit`, and state changes from the `StatusPoller` feed back via `OnStateChange`. Without an executor, steps complete instantly (mock behaviour).
 
@@ -626,6 +655,10 @@ S3 and Lambda are always detected via SigV4 (REST, no `Action` param).
 ### DynamoDB pagination determinism
 
 Both `MemoryDynamoDBItemStore` and `PostgresDynamoDBItemStore` sort all matching items by `itemPKHash` (a stable string key derived from sorted attribute name=value pairs) before applying `ExclusiveStartKey` / `Limit`. This guarantees consistent cursor behaviour across requests regardless of map iteration order or Postgres heap scan order. The postgres implementation uses `ORDER BY pk_hash` in SQL and delegates page slicing to the same `paginateItems` helper used by the memory store.
+
+### DynamoDB `LastEvaluatedKey` — page-full check
+
+`MemoryDynamoDBItemStore.Query` sets `LastEvaluatedKey` when the returned **page** is full (`len(all) == q.Limit`), not when the pre-pagination match count equals the limit. The distinction matters: if 5 items match a key condition and `Limit=2`, `paginateItems` returns 2 items (`all`); the pre-pagination slice (`matched`) has 5. Checking `len(matched) == q.Limit` would be `5 == 2 → false`, suppressing `LastEvaluatedKey` incorrectly. `Scan` and both Postgres paths already used `len(all)` — only the memory `Query` path had the bug.
 
 ### DynamoDB wire protocol: x-amz-crc32
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -477,6 +477,28 @@ export JAISCLOUD_K8S_SA=spark-sa
 | `JAISCLOUD_K8S_CA_FILE` | in-cluster CA path | PEM CA cert. Unset = system roots. |
 | `JAISCLOUD_K8S_NAMESPACE` | `jaiscloud` | Namespace for Jobs and Pods |
 | `JAISCLOUD_K8S_SA` | _(none)_ | Service account for the spark-submit Pod |
+| `JAISCLOUD_BOOTSTRAP_IMAGE` | `amazon/aws-cli:2.18` | Init container image used to run EMR bootstrap scripts |
+| `JAISCLOUD_BOOTSTRAP_SCRIPT_MAX_BYTES` | `1048576` | Maximum allowed size per bootstrap script (1 MiB) |
+| `JAISCLOUD_BOOTSTRAP_RELOCATE_PREFIXES` | `/etc/pki,/home/hadoop` | Comma-separated filesystem prefixes made writable by bootstrap init containers (one `emptyDir` volume per prefix) |
+
+### EMR bootstrap actions (K8s mode)
+
+When a `RunJobFlow` request includes `BootstrapActions` and `EXECUTOR_MODE=k8s`, JaisCloud materialises each action as a K8s **init container** that runs before the `spark-submit` container. Scripts are fetched from the S3 store via the `BlobFetcher` interface (`s3://` and `s3a://` URIs supported).
+
+**What happens at `AddJobFlowSteps` time:**
+
+1. Each bootstrap script is fetched from the local S3 store by its `S3Path`.
+2. Host-package-manager commands (`yum`, `apt-get`, `apt`, `dnf`, `rpm`) and init-system commands (`systemctl`, `service`, `chkconfig`) are commented out with `# [jaiscloud-skip]` — they are no-ops inside a container.
+3. The patched script is base64-encoded and wrapped in a shell one-liner:
+   ```
+   printf '%s' '<b64>' | base64 -d | /bin/sh -s -- <action-args>
+   ```
+4. One `emptyDir` volume is created per prefix in `JAISCLOUD_BOOTSTRAP_RELOCATE_PREFIXES` and mounted into every init container and the main `spark-submit` container so files written by bootstrap scripts are visible at job runtime.
+5. Init containers run as `runAsUser: 0` (root) so they can write to protected paths like `/etc/pki`.
+6. If any bootstrap script fails to fetch or exceeds `JAISCLOUD_BOOTSTRAP_SCRIPT_MAX_BYTES`, the step is immediately marked `FAILED`.
+
+**Volume naming:** `/etc/pki` → `bootstrap-prefix-etc-pki`, `/home/hadoop` → `bootstrap-prefix-home-hadoop`.  
+**Name conflicts:** If a bootstrap-injected volume name collides with a platform-injected volume, `buildJobManifest` returns an error and the step is marked `FAILED`.
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ s3.create_bucket(Bucket="my-bucket")
 |---|---|---|
 | Amazon S3 | ✅ Full | Buckets, objects, multipart, batch delete, chunked encoding, Iceberg/S3A compatible |
 | Amazon SQS | ✅ Full | All 17 operations, FIFO, DLQ, JSON + Query/XML protocols |
-| Amazon DynamoDB | ✅ Full | CRUD, expressions, batch ops, streams, composite keys |
+| Amazon DynamoDB | ✅ Full | CRUD, expressions, batch ops, streams, composite keys, cursor pagination |
 | Amazon SNS | ✅ Full | Topics, subscriptions, SQS fan-out with MessageAttributes |
 | Amazon EventBridge | ✅ Full | Rules, targets, event pattern matching, SQS delivery |
 | AWS IAM + STS | ✅ Full | Roles, policies, users, access keys, AssumeRole, GetCallerIdentity |
 | AWS Lambda | ✅ Full | Echo / Docker warm pool / K8s warm pod (Pod + ClusterIP Service per function) |
 | AWS Glue Data Catalog | ✅ Full | Databases, tables, partitions, Iceberg metadata CAS |
-| Amazon EMR (on EC2) | ✅ Full | Clusters, steps, instance fleets/groups; mock or real K8s Spark |
+| Amazon EMR (on EC2) | ✅ Full | Clusters, steps, instance fleets/groups; bootstrap actions as K8s init containers; mock or real K8s Spark |
 | Amazon EMR on EKS | ✅ Full | Virtual clusters, job runs, managed endpoints; mock or real K8s |
 | AWS KMS | ✅ Full | Keys, aliases, grants, envelope crypto (AES-256-GCM), rotation |
 | AWS Secrets Manager | ✅ Full | Secrets, versions, rotation, KMS-encrypted at rest |

--- a/cmd/jaiscloud/main.go
+++ b/cmd/jaiscloud/main.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -276,8 +277,39 @@ func buildRegistry(ctx context.Context, cfg *config.Config, s appStores, dek []b
 		slog.Info("spark executor enabled", "mode", cfg.ExecutorMode)
 	}
 
+	// Bootstrap resolver — wired into the EMR provider so AddJobFlowSteps can
+	// inject bootstrap scripts as init containers when using the K8s executor.
+	s3Fetcher := blobfs.NewS3BlobFetcher(s.blobs)
+	bootstrapPrefixes := []string{"/etc/pki", "/home/hadoop"}
+	if v := os.Getenv("JAISCLOUD_BOOTSTRAP_RELOCATE_PREFIXES"); v != "" {
+		bootstrapPrefixes = nil
+		for _, p := range strings.Split(v, ",") {
+			if p = strings.TrimSpace(p); p != "" {
+				bootstrapPrefixes = append(bootstrapPrefixes, p)
+			}
+		}
+	}
+	bootstrapImage := "amazon/aws-cli:2.18"
+	if v := os.Getenv("JAISCLOUD_BOOTSTRAP_IMAGE"); v != "" {
+		bootstrapImage = v
+	}
+	bootstrapMaxBytes := int64(1024 * 1024)
+	if v := os.Getenv("JAISCLOUD_BOOTSTRAP_SCRIPT_MAX_BYTES"); v != "" {
+		if n, parseErr := strconv.ParseInt(v, 10, 64); parseErr == nil {
+			bootstrapMaxBytes = n
+		} else {
+			slog.Warn("invalid JAISCLOUD_BOOTSTRAP_SCRIPT_MAX_BYTES; using default 1 MiB", "value", v, "err", parseErr)
+		}
+	}
+	bootstrapCfg := emrprovider.BootstrapConfig{
+		Image:    bootstrapImage,
+		MaxBytes: bootstrapMaxBytes,
+		Prefixes: bootstrapPrefixes,
+	}
+
 	var emrOpts []emrprovider.Option
 	var emrcOpts []emrcontainersprovider.Option
+	emrOpts = append(emrOpts, emrprovider.WithBootstrap(s3Fetcher, bootstrapCfg))
 	if sparkExec != nil {
 		emrOpts = append(emrOpts, emrprovider.WithExecutor(sparkExec, sparkCfg))
 		emrcOpts = append(emrcOpts, emrcontainersprovider.WithExecutor(sparkExec, sparkCfg))

--- a/internal/blobfs/blobfetch.go
+++ b/internal/blobfs/blobfetch.go
@@ -1,0 +1,73 @@
+package blobfs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// BlobFetcher fetches raw bytes from a URI-addressed object store.
+// Only s3:// and s3a:// URIs are currently supported.
+type BlobFetcher interface {
+	Fetch(ctx context.Context, uri string) ([]byte, error)
+}
+
+// S3BlobFetcher implements BlobFetcher using a BlobStore (bucket="s3").
+type S3BlobFetcher struct {
+	store BlobStore
+}
+
+// NewS3BlobFetcher returns a BlobFetcher backed by store.
+// The bucket and key are parsed from each s3:// or s3a:// URI at Fetch time.
+func NewS3BlobFetcher(store BlobStore) *S3BlobFetcher {
+	return &S3BlobFetcher{store: store}
+}
+
+// Fetch retrieves the object at uri. Accepts s3:// and s3a:// schemes.
+func (f *S3BlobFetcher) Fetch(ctx context.Context, uri string) ([]byte, error) {
+	bucket, key, err := parseS3URI(uri)
+	if err != nil {
+		return nil, err
+	}
+	data, err := f.store.Get(ctx, bucket, key)
+	if err != nil {
+		return nil, fmt.Errorf("blobfetch %s: %w", uri, err)
+	}
+	return data, nil
+}
+
+// parseS3URI parses an s3:// or s3a:// URI into (bucket, key).
+func parseS3URI(uri string) (bucket, key string, err error) {
+	var rest string
+	switch {
+	case strings.HasPrefix(uri, "s3a://"):
+		rest = uri[len("s3a://"):]
+	case strings.HasPrefix(uri, "s3://"):
+		rest = uri[len("s3://"):]
+	default:
+		scheme := uri
+		if idx := strings.Index(uri, "://"); idx >= 0 {
+			scheme = uri[:idx]
+		}
+		return "", "", fmt.Errorf("blobfetch: unsupported URI scheme %q (want s3:// or s3a://)", scheme)
+	}
+
+	idx := strings.IndexByte(rest, '/')
+	if idx < 0 {
+		// URI has bucket but no key (e.g. s3://mybucket)
+		bucket = rest
+		if bucket == "" {
+			return "", "", fmt.Errorf("blobfetch: empty bucket in URI %q", uri)
+		}
+		return bucket, "", fmt.Errorf("blobfetch: missing key in URI %q", uri)
+	}
+	bucket = rest[:idx]
+	key = rest[idx+1:]
+	if bucket == "" {
+		return "", "", fmt.Errorf("blobfetch: empty bucket in URI %q", uri)
+	}
+	if key == "" {
+		return "", "", fmt.Errorf("blobfetch: empty key in URI %q", uri)
+	}
+	return bucket, key, nil
+}

--- a/internal/blobfs/blobfetch_test.go
+++ b/internal/blobfs/blobfetch_test.go
@@ -1,0 +1,80 @@
+package blobfs
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestS3BlobFetcher_HappyPath(t *testing.T) {
+	store := NewMemoryBlobStore()
+	store.Put(context.Background(), "my-bucket", "scripts/stage.sh", []byte("#!/bin/sh\necho ok"))
+	f := NewS3BlobFetcher(store)
+	data, err := f.Fetch(context.Background(), "s3://my-bucket/scripts/stage.sh")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != "#!/bin/sh\necho ok" {
+		t.Errorf("unexpected data: %q", data)
+	}
+}
+
+func TestS3BlobFetcher_S3aScheme(t *testing.T) {
+	store := NewMemoryBlobStore()
+	store.Put(context.Background(), "my-bucket", "file.txt", []byte("hello"))
+	f := NewS3BlobFetcher(store)
+	data, err := f.Fetch(context.Background(), "s3a://my-bucket/file.txt")
+	if err != nil {
+		t.Fatalf("s3a:// should be accepted: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Errorf("unexpected data: %q", data)
+	}
+}
+
+func TestS3BlobFetcher_MissingObject(t *testing.T) {
+	store := NewMemoryBlobStore()
+	f := NewS3BlobFetcher(store)
+	_, err := f.Fetch(context.Background(), "s3://bucket/missing.sh")
+	if err == nil {
+		t.Fatal("expected error for missing object")
+	}
+}
+
+func TestS3BlobFetcher_UnsupportedScheme_GS(t *testing.T) {
+	f := NewS3BlobFetcher(NewMemoryBlobStore())
+	_, err := f.Fetch(context.Background(), "gs://bucket/file")
+	if err == nil {
+		t.Fatal("expected error for gs:// scheme")
+	}
+	if !strings.Contains(err.Error(), "gs") {
+		t.Errorf("error should mention scheme; got: %v", err)
+	}
+}
+
+func TestS3BlobFetcher_UnsupportedScheme_ABFSS(t *testing.T) {
+	f := NewS3BlobFetcher(NewMemoryBlobStore())
+	_, err := f.Fetch(context.Background(), "abfss://container@account.dfs.core.windows.net/file")
+	if err == nil {
+		t.Fatal("expected error for abfss:// scheme")
+	}
+	if !strings.Contains(err.Error(), "abfss") {
+		t.Errorf("error should mention scheme; got: %v", err)
+	}
+}
+
+func TestS3BlobFetcher_EmptyBucket(t *testing.T) {
+	f := NewS3BlobFetcher(NewMemoryBlobStore())
+	_, err := f.Fetch(context.Background(), "s3:///key")
+	if err == nil {
+		t.Fatal("expected error for empty bucket")
+	}
+}
+
+func TestS3BlobFetcher_EmptyKey(t *testing.T) {
+	f := NewS3BlobFetcher(NewMemoryBlobStore())
+	_, err := f.Fetch(context.Background(), "s3://bucket/")
+	if err == nil {
+		t.Fatal("expected error for empty key")
+	}
+}

--- a/internal/executor/spark/executor.go
+++ b/internal/executor/spark/executor.go
@@ -2,7 +2,11 @@
 // running Spark jobs in various environments (mock, k8s, local, docker, remote).
 package spark
 
-import "context"
+import (
+	"context"
+
+	"jaiscloud/internal/k8stypes"
+)
 
 // SparkState mirrors EMR step/job-run states.
 type SparkState string
@@ -44,6 +48,23 @@ type SparkJob struct {
 
 	// Config is the resolved executor configuration for this job.
 	Config SparkConfig
+
+	// Bootstrap fragments — set by the EMR provider after resolving bootstrap
+	// actions. Executor reads these and injects them into the batch Job manifest.
+	// All nil when no bootstrap actions are configured.
+	ExtraInitContainers []k8stypes.Container
+	ExtraVolumes        []k8stypes.Volume
+	ExtraMainMounts     []k8stypes.VolumeMount
+
+	// Pod template bytes — pre-merged by the EMRContainers provider.
+	// Executor writes each to a ConfigMap and injects configmap:// spark confs.
+	// Nil when no pod template is configured.
+	DriverTemplateBytes   []byte
+	ExecutorTemplateBytes []byte
+
+	// AllowClusterMode enables Spark cluster-deploy-mode (driver runs as K8s Pod).
+	// When false (default), spark-submit is rewritten to local[*] client mode.
+	AllowClusterMode bool
 }
 
 // SparkStatus is the current status of a submitted job.

--- a/internal/executor/spark/k8s.go
+++ b/internal/executor/spark/k8s.go
@@ -390,6 +390,21 @@ func jobFailureMessage(s batchJobStatus) string {
 	return ""
 }
 
+// checkVolumeConflicts returns an error if any volume in extra shares a name
+// with an existing volume in spec.Volumes.
+func checkVolumeConflicts(existing, extra []volume) error {
+	names := make(map[string]struct{}, len(existing))
+	for _, v := range existing {
+		names[v.Name] = struct{}{}
+	}
+	for _, v := range extra {
+		if _, dup := names[v.Name]; dup {
+			return fmt.Errorf("volume name conflict: %q already exists in pod spec", v.Name)
+		}
+	}
+	return nil
+}
+
 // buildJobManifest constructs a batch/v1 Job that runs spark-submit.
 func (e *K8sExecutor) buildJobManifest(jobName string, job SparkJob) (batchJob, error) {
 	backoffLimit := 0
@@ -434,6 +449,18 @@ func (e *K8sExecutor) buildJobManifest(jobName string, job SparkJob) (batchJob, 
 	}
 
 	spec.Containers = []container{ctr}
+
+	// Inject provider-resolved bootstrap fragments (classic EMR bootstrap actions).
+	// Only present when the EMR provider called Resolve; zero cost otherwise.
+	if len(job.ExtraInitContainers) > 0 {
+		if err := checkVolumeConflicts(spec.Volumes, job.ExtraVolumes); err != nil {
+			return batchJob{}, fmt.Errorf("bootstrap volume conflict: %w", err)
+		}
+		// Prepend: bootstrap runs before any cloud-transform or platform init containers.
+		spec.InitContainers = append(job.ExtraInitContainers, spec.InitContainers...)
+		spec.Volumes = append(spec.Volumes, job.ExtraVolumes...)
+		spec.Containers[0].VolumeMounts = append(spec.Containers[0].VolumeMounts, job.ExtraMainMounts...)
+	}
 
 	labels := map[string]string{
 		"app.kubernetes.io/managed-by": "jaiscloud",

--- a/internal/executor/spark/k8s_test.go
+++ b/internal/executor/spark/k8s_test.go
@@ -7,6 +7,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"jaiscloud/internal/k8stypes"
+	"jaiscloud/internal/platform"
 )
 
 // fakeK8s runs an httptest.TLSServer that fakes the K8s batch/v1 Jobs API.
@@ -516,6 +519,189 @@ func TestK8sExecutor_CleanupOrphans_ResumesSuspendedJobs(t *testing.T) {
 	}
 	if _, ok := exec.jobs.Load("job-susp-1"); !ok {
 		t.Error("resumed job should be adopted in jobs map")
+	}
+}
+
+// ── buildJobManifest: bootstrap fragment injection ────────────────────────────
+
+func makeInitCtr(name string) container {
+	zero := int64(0)
+	return container{
+		Name:    name,
+		Image:   "amazon/aws-cli:2.18",
+		Command: []string{"/bin/sh", "-c"},
+		Args:    []string{"echo " + name},
+		SecurityContext: &k8stypes.SecurityContext{RunAsUser: &zero},
+	}
+}
+
+func TestBuildJobManifest_Bootstrap_NoExtras(t *testing.T) {
+	fk := newFakeK8s(t)
+	exec := newTestK8sExecutor(t, fk)
+	job := SparkJob{JobID: "j-1", JarURI: "s3://b/app.jar", Config: exec.cfg}
+
+	manifest, err := exec.buildJobManifest("spark-j-1", job)
+	if err != nil {
+		t.Fatalf("buildJobManifest: %v", err)
+	}
+	if len(manifest.Spec.Template.Spec.InitContainers) != 0 {
+		t.Errorf("expected no init containers when no extras; got %d", len(manifest.Spec.Template.Spec.InitContainers))
+	}
+}
+
+func TestBuildJobManifest_Bootstrap_InitContainersPrepended(t *testing.T) {
+	fk := newFakeK8s(t)
+	exec := newTestK8sExecutor(t, fk)
+
+	job := SparkJob{
+		JobID:  "j-boot",
+		JarURI: "s3://b/app.jar",
+		Config: exec.cfg,
+		ExtraInitContainers: []container{
+			makeInitCtr("bootstrap-stage-certs"),
+			makeInitCtr("bootstrap-init-hadoop"),
+		},
+		ExtraVolumes: []volume{
+			{Name: "bootstrap-prefix-etc-pki", EmptyDir: &k8stypes.EmptyDirVol{}},
+			{Name: "bootstrap-prefix-home-hadoop", EmptyDir: &k8stypes.EmptyDirVol{}},
+		},
+		ExtraMainMounts: []volumeMount{
+			{Name: "bootstrap-prefix-etc-pki", MountPath: "/etc/pki"},
+			{Name: "bootstrap-prefix-home-hadoop", MountPath: "/home/hadoop"},
+		},
+	}
+
+	manifest, err := exec.buildJobManifest("spark-j-boot", job)
+	if err != nil {
+		t.Fatalf("buildJobManifest: %v", err)
+	}
+
+	spec := manifest.Spec.Template.Spec
+	if len(spec.InitContainers) != 2 {
+		t.Fatalf("expected 2 init containers; got %d", len(spec.InitContainers))
+	}
+	if spec.InitContainers[0].Name != "bootstrap-stage-certs" {
+		t.Errorf("first init container should be bootstrap-stage-certs; got %q", spec.InitContainers[0].Name)
+	}
+	if spec.InitContainers[1].Name != "bootstrap-init-hadoop" {
+		t.Errorf("second init container should be bootstrap-init-hadoop; got %q", spec.InitContainers[1].Name)
+	}
+}
+
+func TestBuildJobManifest_Bootstrap_VolumesAppended(t *testing.T) {
+	fk := newFakeK8s(t)
+	exec := newTestK8sExecutor(t, fk)
+
+	job := SparkJob{
+		JobID:  "j-vols",
+		JarURI: "s3://b/app.jar",
+		Config: exec.cfg,
+		ExtraInitContainers: []container{makeInitCtr("bootstrap-test")},
+		ExtraVolumes: []volume{
+			{Name: "bootstrap-prefix-etc-pki", EmptyDir: &k8stypes.EmptyDirVol{}},
+		},
+	}
+
+	manifest, err := exec.buildJobManifest("spark-j-vols", job)
+	if err != nil {
+		t.Fatalf("buildJobManifest: %v", err)
+	}
+
+	found := false
+	for _, v := range manifest.Spec.Template.Spec.Volumes {
+		if v.Name == "bootstrap-prefix-etc-pki" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("extra volume not found in manifest volumes: %v", manifest.Spec.Template.Spec.Volumes)
+	}
+}
+
+func TestBuildJobManifest_Bootstrap_MainMountsAppended(t *testing.T) {
+	fk := newFakeK8s(t)
+	exec := newTestK8sExecutor(t, fk)
+
+	job := SparkJob{
+		JobID:  "j-mounts",
+		JarURI: "s3://b/app.jar",
+		Config: exec.cfg,
+		ExtraInitContainers: []container{makeInitCtr("bootstrap-test")},
+		ExtraVolumes:        []volume{{Name: "bootstrap-prefix-etc-pki", EmptyDir: &k8stypes.EmptyDirVol{}}},
+		ExtraMainMounts:     []volumeMount{{Name: "bootstrap-prefix-etc-pki", MountPath: "/etc/pki"}},
+	}
+
+	manifest, err := exec.buildJobManifest("spark-j-mounts", job)
+	if err != nil {
+		t.Fatalf("buildJobManifest: %v", err)
+	}
+
+	found := false
+	for _, m := range manifest.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if m.MountPath == "/etc/pki" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("extra main mount not found in container volumeMounts: %v", manifest.Spec.Template.Spec.Containers[0].VolumeMounts)
+	}
+}
+
+func TestBuildJobManifest_Bootstrap_VolumeConflict(t *testing.T) {
+	fk := newFakeK8s(t)
+	exec := newTestK8sExecutor(t, fk)
+	// Inject a platform volume named "conflict-vol" so buildJobManifest populates
+	// spec.Volumes before the ExtraVolumes conflict check runs.
+	exec.platform = &platform.PlatformConfig{
+		TLS: platform.TLSConfig{Enabled: false},
+		Volumes: []platform.VolumeSpec{{
+			Name:   "conflict-vol",
+			Source: platform.VolumeSource{Kind: "emptyDir", EmptyDir: &platform.EmptyDirSource{}},
+			Mounts: []platform.MountSpec{{MountPath: "/conflict"}},
+		}},
+	}
+
+	job := SparkJob{
+		JobID:               "j-conflict",
+		JarURI:              "s3://b/app.jar",
+		Config:              exec.cfg,
+		ExtraInitContainers: []container{makeInitCtr("bootstrap-conflict")},
+		ExtraVolumes:        []volume{{Name: "conflict-vol", EmptyDir: &k8stypes.EmptyDirVol{}}},
+	}
+
+	if _, err := exec.buildJobManifest("spark-j-conflict", job); err == nil {
+		t.Error("expected volume conflict error from buildJobManifest; got nil")
+	}
+}
+
+func TestBuildJobManifest_Bootstrap_OrderPreserved(t *testing.T) {
+	fk := newFakeK8s(t)
+	exec := newTestK8sExecutor(t, fk)
+
+	ctrs := []container{
+		makeInitCtr("bootstrap-first"),
+		makeInitCtr("bootstrap-second"),
+		makeInitCtr("bootstrap-third"),
+	}
+	job := SparkJob{
+		JobID:               "j-order",
+		JarURI:              "s3://b/app.jar",
+		Config:              exec.cfg,
+		ExtraInitContainers: ctrs,
+		ExtraVolumes:        []volume{{Name: "bootstrap-prefix-tmp", EmptyDir: &k8stypes.EmptyDirVol{}}},
+	}
+
+	manifest, err := exec.buildJobManifest("spark-j-order", job)
+	if err != nil {
+		t.Fatalf("buildJobManifest: %v", err)
+	}
+
+	inits := manifest.Spec.Template.Spec.InitContainers
+	if len(inits) != 3 {
+		t.Fatalf("expected 3 init containers; got %d", len(inits))
+	}
+	if inits[0].Name != "bootstrap-first" || inits[1].Name != "bootstrap-second" || inits[2].Name != "bootstrap-third" {
+		t.Errorf("init container order wrong: %v", []string{inits[0].Name, inits[1].Name, inits[2].Name})
 	}
 }
 

--- a/internal/k8stypes/types.go
+++ b/internal/k8stypes/types.go
@@ -35,8 +35,27 @@ type Container struct {
 }
 
 type EnvVar struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Name      string        `json:"name"`
+	Value     string        `json:"value,omitempty"`
+	ValueFrom *EnvVarSource `json:"valueFrom,omitempty"`
+}
+
+type EnvVarSource struct {
+	SecretKeyRef    *SecretKeySelector    `json:"secretKeyRef,omitempty"`
+	ConfigMapKeyRef *ConfigMapKeySelector `json:"configMapKeyRef,omitempty"`
+	FieldRef        *ObjectFieldSelector  `json:"fieldRef,omitempty"`
+}
+
+type SecretKeySelector struct {
+	Name     string `json:"name"`
+	Key      string `json:"key"`
+	Optional *bool  `json:"optional,omitempty"`
+}
+
+type ConfigMapKeySelector struct {
+	Name     string `json:"name"`
+	Key      string `json:"key"`
+	Optional *bool  `json:"optional,omitempty"`
 }
 
 type VolumeMount struct {

--- a/internal/k8stypes/types_test.go
+++ b/internal/k8stypes/types_test.go
@@ -1,0 +1,146 @@
+package k8stypes
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func boolPtr(b bool) *bool   { return &b }
+func int64Ptr(i int64) *int64 { return &i }
+
+func TestEnvVar_PlainValue_RoundTrip(t *testing.T) {
+	e := EnvVar{Name: "FOO", Value: "bar"}
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got EnvVar
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "FOO" || got.Value != "bar" || got.ValueFrom != nil {
+		t.Errorf("plain value round-trip failed: %+v", got)
+	}
+}
+
+func TestEnvVar_ValueFrom_SecretKeyRef(t *testing.T) {
+	e := EnvVar{
+		Name: "SECRET_VAL",
+		ValueFrom: &EnvVarSource{
+			SecretKeyRef: &SecretKeySelector{Name: "my-secret", Key: "token", Optional: boolPtr(false)},
+		},
+	}
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got EnvVar
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Value != "" {
+		t.Errorf("Value should be empty when ValueFrom is set; got %q", got.Value)
+	}
+	if got.ValueFrom == nil || got.ValueFrom.SecretKeyRef == nil {
+		t.Fatal("SecretKeyRef lost after round-trip")
+	}
+	ref := got.ValueFrom.SecretKeyRef
+	if ref.Name != "my-secret" || ref.Key != "token" || ref.Optional == nil || *ref.Optional {
+		t.Errorf("SecretKeyRef fields wrong: %+v", ref)
+	}
+}
+
+func TestEnvVar_ValueFrom_ConfigMapKeyRef(t *testing.T) {
+	e := EnvVar{
+		Name: "CM_VAL",
+		ValueFrom: &EnvVarSource{
+			ConfigMapKeyRef: &ConfigMapKeySelector{Name: "my-cm", Key: "endpoint"},
+		},
+	}
+	b, _ := json.Marshal(e)
+	var got EnvVar
+	json.Unmarshal(b, &got)
+	if got.ValueFrom == nil || got.ValueFrom.ConfigMapKeyRef == nil {
+		t.Fatal("ConfigMapKeyRef lost after round-trip")
+	}
+	ref := got.ValueFrom.ConfigMapKeyRef
+	if ref.Name != "my-cm" || ref.Key != "endpoint" {
+		t.Errorf("ConfigMapKeyRef fields wrong: %+v", ref)
+	}
+}
+
+func TestEnvVar_ValueFrom_FieldRef(t *testing.T) {
+	e := EnvVar{
+		Name: "POD_NAME",
+		ValueFrom: &EnvVarSource{
+			FieldRef: &ObjectFieldSelector{FieldPath: "metadata.name"},
+		},
+	}
+	b, _ := json.Marshal(e)
+	var got EnvVar
+	json.Unmarshal(b, &got)
+	if got.ValueFrom == nil || got.ValueFrom.FieldRef == nil {
+		t.Fatal("FieldRef lost after round-trip")
+	}
+	if got.ValueFrom.FieldRef.FieldPath != "metadata.name" {
+		t.Errorf("FieldRef.FieldPath wrong: %q", got.ValueFrom.FieldRef.FieldPath)
+	}
+}
+
+func TestPodSpec_SchedulingFields_RoundTrip(t *testing.T) {
+	spec := PodSpec{
+		NodeSelector: map[string]string{"zone": "us-east-1a"},
+		Tolerations: []Toleration{{
+			Key: "key1", Operator: "Equal", Value: "val1", Effect: "NoSchedule",
+		}},
+		TopologySpreadConstraints: []TopologySpreadConstraint{{
+			MaxSkew: 1, TopologyKey: "zone", WhenUnsatisfiable: "DoNotSchedule",
+		}},
+		SecurityContext: &PodSecurityContext{
+			RunAsUser: int64Ptr(1000),
+			FSGroup:   int64Ptr(2000),
+		},
+	}
+	b, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got PodSpec
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.NodeSelector["zone"] != "us-east-1a" {
+		t.Errorf("NodeSelector lost: %v", got.NodeSelector)
+	}
+	if len(got.Tolerations) != 1 || got.Tolerations[0].Effect != "NoSchedule" {
+		t.Errorf("Tolerations lost: %v", got.Tolerations)
+	}
+	if len(got.TopologySpreadConstraints) != 1 || got.TopologySpreadConstraints[0].MaxSkew != 1 {
+		t.Errorf("TopologySpreadConstraints lost: %v", got.TopologySpreadConstraints)
+	}
+	if got.SecurityContext == nil || *got.SecurityContext.RunAsUser != 1000 {
+		t.Errorf("SecurityContext lost: %v", got.SecurityContext)
+	}
+}
+
+func TestContainerSecurityContext_RoundTrip(t *testing.T) {
+	ctr := Container{
+		Name:  "main",
+		Image: "alpine",
+		SecurityContext: &SecurityContext{
+			RunAsUser:    int64Ptr(0),
+			RunAsNonRoot: boolPtr(false),
+		},
+	}
+	b, err := json.Marshal(ctr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got Container
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.SecurityContext == nil || *got.SecurityContext.RunAsUser != 0 {
+		t.Errorf("SecurityContext lost: %v", got.SecurityContext)
+	}
+}

--- a/internal/provider/emr/bootstrap.go
+++ b/internal/provider/emr/bootstrap.go
@@ -1,0 +1,203 @@
+package emr
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"jaiscloud/internal/blobfs"
+	"jaiscloud/internal/executor/spark"
+	"jaiscloud/internal/k8stypes"
+)
+
+// BootstrapConfig configures the bootstrap resolver.
+type BootstrapConfig struct {
+	// Image is the init container image used to run bootstrap scripts (e.g. amazon/aws-cli:2.18).
+	Image string
+	// MaxBytes is the maximum allowed size for a single bootstrap script.
+	MaxBytes int64
+	// Prefixes are the filesystem prefixes that bootstrap scripts may write to
+	// (e.g. ["/etc/pki", "/home/hadoop"]). One emptyDir volume is created per prefix.
+	Prefixes []string
+}
+
+// Resolve fetches each bootstrap script via fetcher and returns k8stypes fragments
+// ready to inject into the spark-submit batch Job. Called by the EMR provider
+// before calling SparkExecutor.Submit.
+//
+// Returns (nil, nil, nil, nil) when actions is empty.
+func Resolve(
+	ctx context.Context,
+	fetcher blobfs.BlobFetcher,
+	cfg BootstrapConfig,
+	actions []BootstrapAction,
+	sparkEnv []k8stypes.EnvVar,
+) (initContainers []k8stypes.Container, volumes []k8stypes.Volume, mainMounts []k8stypes.VolumeMount, err error) {
+	if len(actions) == 0 {
+		return nil, nil, nil, nil
+	}
+
+	// One emptyDir volume per prefix, shared between init containers and the main container.
+	for _, prefix := range cfg.Prefixes {
+		volName := prefixVolumeName(prefix)
+		volumes = append(volumes, k8stypes.Volume{
+			Name:     volName,
+			EmptyDir: &k8stypes.EmptyDirVol{},
+		})
+		mainMounts = append(mainMounts, k8stypes.VolumeMount{
+			Name:      volName,
+			MountPath: prefix,
+		})
+	}
+
+	// One init container per bootstrap action.
+	for _, action := range actions {
+		data, fetchErr := fetcher.Fetch(ctx, action.S3Path)
+		if fetchErr != nil {
+			return nil, nil, nil, fmt.Errorf("bootstrap: fetch %q: %w", action.S3Path, fetchErr)
+		}
+		if cfg.MaxBytes > 0 && int64(len(data)) > cfg.MaxBytes {
+			return nil, nil, nil, fmt.Errorf("bootstrap: script %q size %d exceeds limit %d",
+				action.S3Path, len(data), cfg.MaxBytes)
+		}
+
+		patched := scrubHostCommands(data)
+		encoded := base64.StdEncoding.EncodeToString(patched)
+
+		// Build the shell invocation: decode base64 then pipe to sh with extra args.
+		shellCmd := fmt.Sprintf("printf '%%s' %q | base64 -d | /bin/sh -s -- %s",
+			encoded, shellQuoteArgs(action.Args))
+
+		// Mount every prefix volume into this init container.
+		mounts := make([]k8stypes.VolumeMount, 0, len(cfg.Prefixes))
+		for _, prefix := range cfg.Prefixes {
+			mounts = append(mounts, k8stypes.VolumeMount{
+				Name:      prefixVolumeName(prefix),
+				MountPath: prefix,
+			})
+		}
+
+		zero := int64(0)
+		ctr := k8stypes.Container{
+			Name:    "bootstrap-" + sanitizeName(action.Name),
+			Image:   cfg.Image,
+			Command: []string{"/bin/sh", "-c"},
+			Args:    []string{shellCmd},
+			Env:     sparkEnv,
+			SecurityContext: &k8stypes.SecurityContext{
+				RunAsUser: &zero,
+			},
+			VolumeMounts: mounts,
+		}
+		initContainers = append(initContainers, ctr)
+	}
+
+	return initContainers, volumes, mainMounts, nil
+}
+
+// bootstrapSparkEnv builds the env vars injected into bootstrap init containers
+// so scripts can call the JaisCloud S3 endpoint with the right credentials.
+func bootstrapSparkEnv(cfg spark.SparkConfig) []k8stypes.EnvVar {
+	var env []k8stypes.EnvVar
+	if cfg.Region != "" {
+		env = append(env,
+			k8stypes.EnvVar{Name: "AWS_DEFAULT_REGION", Value: cfg.Region},
+			k8stypes.EnvVar{Name: "AWS_REGION", Value: cfg.Region},
+		)
+	}
+	if cfg.S3Endpoint != "" {
+		env = append(env, k8stypes.EnvVar{Name: "AWS_ENDPOINT_URL", Value: cfg.S3Endpoint})
+	}
+	if cfg.AWSAccessKey != "" {
+		env = append(env, k8stypes.EnvVar{Name: "AWS_ACCESS_KEY_ID", Value: cfg.AWSAccessKey})
+	}
+	if cfg.AWSSecretKey != "" {
+		env = append(env, k8stypes.EnvVar{Name: "AWS_SECRET_ACCESS_KEY", Value: cfg.AWSSecretKey})
+	}
+	return env
+}
+
+// hostCmdPrefixes lists shell command prefixes that are no-ops (or harmful) in
+// a container context. Lines starting with any of these are commented out.
+var hostCmdPrefixes = []string{
+	"yum ", "yum\t",
+	"apt-get ", "apt-get\t",
+	"apt ", "apt\t",
+	"dnf ", "dnf\t",
+	"rpm ", "rpm\t",
+	"systemctl ", "systemctl\t",
+	"service ", "service\t",
+	"chkconfig ", "chkconfig\t",
+	"update-rc.d ", "update-rc.d\t",
+}
+
+// scrubHostCommands comments out lines that invoke host-only package managers
+// or init-system commands. Returns the patched script bytes.
+func scrubHostCommands(script []byte) []byte {
+	var out strings.Builder
+	scanner := bufio.NewScanner(strings.NewReader(string(script)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimLeft(line, " \t")
+		scrubbed := false
+		for _, prefix := range hostCmdPrefixes {
+			if strings.HasPrefix(trimmed, prefix) {
+				out.WriteString("# [jaiscloud-skip] ")
+				out.WriteString(line)
+				out.WriteByte('\n')
+				slog.Info("bootstrap: commented out host command", "line", line)
+				scrubbed = true
+				break
+			}
+		}
+		if !scrubbed {
+			out.WriteString(line)
+			out.WriteByte('\n')
+		}
+	}
+	return []byte(out.String())
+}
+
+// prefixVolumeName converts a filesystem prefix to a valid K8s volume name.
+// e.g. "/etc/pki" → "bootstrap-prefix-etc-pki"
+func prefixVolumeName(prefix string) string {
+	return "bootstrap-prefix-" + sanitizeName(prefix)
+}
+
+// sanitizeName converts an arbitrary string to a valid K8s DNS label segment.
+func sanitizeName(s string) string {
+	var b strings.Builder
+	for _, ch := range strings.ToLower(s) {
+		if ch >= 'a' && ch <= 'z' || ch >= '0' && ch <= '9' {
+			b.WriteRune(ch)
+		} else {
+			b.WriteByte('-')
+		}
+	}
+	result := strings.Trim(b.String(), "-")
+	// Collapse runs of dashes.
+	for strings.Contains(result, "--") {
+		result = strings.ReplaceAll(result, "--", "-")
+	}
+	if len(result) > 50 {
+		result = strings.TrimRight(result[:50], "-")
+	}
+	return result
+}
+
+// shellQuoteArgs returns the args as a space-separated, single-quote-escaped string.
+func shellQuoteArgs(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	quoted := make([]string, len(args))
+	for i, a := range args {
+		// Single-quote escaping: close quote, add escaped quote, reopen.
+		escaped := strings.ReplaceAll(a, "'", "'\\''")
+		quoted[i] = "'" + escaped + "'"
+	}
+	return strings.Join(quoted, " ")
+}

--- a/internal/provider/emr/bootstrap_test.go
+++ b/internal/provider/emr/bootstrap_test.go
@@ -1,0 +1,354 @@
+package emr
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+
+	"jaiscloud/internal/blobfs"
+	"jaiscloud/internal/k8stypes"
+)
+
+// fakeFetcher is a simple in-memory BlobFetcher for tests.
+type fakeFetcher struct {
+	objects map[string][]byte
+	err     error // returned for every fetch if non-nil
+}
+
+func (f *fakeFetcher) Fetch(_ context.Context, uri string) ([]byte, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	b, ok := f.objects[uri]
+	if !ok {
+		return nil, fmt.Errorf("not found: %s", uri)
+	}
+	return b, nil
+}
+
+func testFetcher(scripts map[string]string) *fakeFetcher {
+	f := &fakeFetcher{objects: make(map[string][]byte)}
+	for uri, content := range scripts {
+		f.objects[uri] = []byte(content)
+	}
+	return f
+}
+
+func defaultCfg() BootstrapConfig {
+	return BootstrapConfig{
+		Image:    "amazon/aws-cli:2.18",
+		MaxBytes: 1024 * 1024,
+		Prefixes: []string{"/etc/pki", "/home/hadoop"},
+	}
+}
+
+var testEnv = []k8stypes.EnvVar{
+	{Name: "AWS_DEFAULT_REGION", Value: "us-east-1"},
+}
+
+func TestResolve_EmptyActions(t *testing.T) {
+	inits, vols, mounts, err := Resolve(context.Background(), testFetcher(nil), defaultCfg(), nil, testEnv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inits != nil || vols != nil || mounts != nil {
+		t.Errorf("expected all nil for empty actions; got inits=%v vols=%v mounts=%v", inits, vols, mounts)
+	}
+}
+
+func TestResolve_TwoActions_InitContainerShape(t *testing.T) {
+	fetcher := testFetcher(map[string]string{
+		"s3://bucket/a.sh": "#!/bin/sh\necho a",
+		"s3://bucket/b.sh": "#!/bin/sh\necho b",
+	})
+	actions := []BootstrapAction{
+		{Name: "stage-certs", S3Path: "s3://bucket/a.sh", Args: []string{"/etc/pki/ca.crt"}},
+		{Name: "init-hadoop", S3Path: "s3://bucket/b.sh"},
+	}
+
+	inits, _, _, err := Resolve(context.Background(), fetcher, defaultCfg(), actions, testEnv)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(inits) != 2 {
+		t.Fatalf("expected 2 init containers; got %d", len(inits))
+	}
+	if inits[0].Name != "bootstrap-stage-certs" {
+		t.Errorf("unexpected name: %q", inits[0].Name)
+	}
+	if inits[0].Image != "amazon/aws-cli:2.18" {
+		t.Errorf("unexpected image: %q", inits[0].Image)
+	}
+	if len(inits[0].Command) != 2 || inits[0].Command[0] != "/bin/sh" {
+		t.Errorf("unexpected command: %v", inits[0].Command)
+	}
+}
+
+func TestResolve_InitContainer_RunAsUserZero(t *testing.T) {
+	fetcher := testFetcher(map[string]string{"s3://b/s.sh": "echo hi"})
+	actions := []BootstrapAction{{Name: "test", S3Path: "s3://b/s.sh"}}
+
+	inits, _, _, err := Resolve(context.Background(), fetcher, defaultCfg(), actions, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sc := inits[0].SecurityContext
+	if sc == nil || sc.RunAsUser == nil || *sc.RunAsUser != 0 {
+		t.Errorf("expected runAsUser=0; got %v", sc)
+	}
+}
+
+func TestResolve_VolumeMounts_PerPrefix(t *testing.T) {
+	fetcher := testFetcher(map[string]string{"s3://b/s.sh": "echo hi"})
+	actions := []BootstrapAction{{Name: "test", S3Path: "s3://b/s.sh"}}
+
+	inits, _, _, err := Resolve(context.Background(), fetcher, defaultCfg(), actions, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(inits[0].VolumeMounts) != 2 {
+		t.Fatalf("expected 2 mounts per init container; got %d", len(inits[0].VolumeMounts))
+	}
+	paths := map[string]bool{}
+	for _, m := range inits[0].VolumeMounts {
+		paths[m.MountPath] = true
+	}
+	if !paths["/etc/pki"] || !paths["/home/hadoop"] {
+		t.Errorf("expected mounts at /etc/pki and /home/hadoop; got %v", inits[0].VolumeMounts)
+	}
+}
+
+func TestResolve_MainMounts_AllPrefixes(t *testing.T) {
+	fetcher := testFetcher(map[string]string{"s3://b/s.sh": "echo hi"})
+	actions := []BootstrapAction{{Name: "test", S3Path: "s3://b/s.sh"}}
+
+	_, _, mounts, err := Resolve(context.Background(), fetcher, defaultCfg(), actions, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mounts) != 2 {
+		t.Fatalf("expected 2 main mounts; got %d", len(mounts))
+	}
+}
+
+func TestResolve_VolumeCount_MatchesPrefixes(t *testing.T) {
+	fetcher := testFetcher(map[string]string{"s3://b/s.sh": "echo hi"})
+	actions := []BootstrapAction{{Name: "test", S3Path: "s3://b/s.sh"}}
+
+	_, vols, _, err := Resolve(context.Background(), fetcher, defaultCfg(), actions, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vols) != 2 {
+		t.Fatalf("expected 2 volumes (one per prefix); got %d", len(vols))
+	}
+}
+
+func TestResolve_EmptyDirVolumeNaming(t *testing.T) {
+	fetcher := testFetcher(map[string]string{"s3://b/s.sh": "echo hi"})
+	actions := []BootstrapAction{{Name: "test", S3Path: "s3://b/s.sh"}}
+
+	_, vols, _, err := Resolve(context.Background(), fetcher, defaultCfg(), actions, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	names := map[string]bool{}
+	for _, v := range vols {
+		names[v.Name] = true
+	}
+	if !names["bootstrap-prefix-etc-pki"] {
+		t.Errorf("expected volume 'bootstrap-prefix-etc-pki'; got %v", vols)
+	}
+	if !names["bootstrap-prefix-home-hadoop"] {
+		t.Errorf("expected volume 'bootstrap-prefix-home-hadoop'; got %v", vols)
+	}
+}
+
+func TestResolve_Env_AWSVarsInjected(t *testing.T) {
+	fetcher := testFetcher(map[string]string{"s3://b/s.sh": "echo hi"})
+	actions := []BootstrapAction{{Name: "test", S3Path: "s3://b/s.sh"}}
+	env := []k8stypes.EnvVar{
+		{Name: "AWS_DEFAULT_REGION", Value: "us-east-1"},
+		{Name: "AWS_ACCESS_KEY_ID", Value: "fake"},
+	}
+
+	inits, _, _, err := Resolve(context.Background(), fetcher, defaultCfg(), actions, env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	envMap := map[string]string{}
+	for _, e := range inits[0].Env {
+		envMap[e.Name] = e.Value
+	}
+	if envMap["AWS_DEFAULT_REGION"] != "us-east-1" {
+		t.Errorf("AWS_DEFAULT_REGION not injected: %v", inits[0].Env)
+	}
+	if envMap["AWS_ACCESS_KEY_ID"] != "fake" {
+		t.Errorf("AWS_ACCESS_KEY_ID not injected: %v", inits[0].Env)
+	}
+}
+
+func TestResolve_ScriptBase64Encoded(t *testing.T) {
+	script := "#!/bin/sh\necho hello"
+	fetcher := testFetcher(map[string]string{"s3://b/s.sh": script})
+	actions := []BootstrapAction{{Name: "test", S3Path: "s3://b/s.sh"}}
+
+	inits, _, _, err := Resolve(context.Background(), fetcher, defaultCfg(), actions, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The arg should contain a base64-encoded version of the (possibly patched) script.
+	arg := inits[0].Args[0]
+	// Extract the base64 portion between the quotes.
+	start := strings.Index(arg, `"`) + 1
+	end := strings.LastIndex(arg, `"`)
+	if start <= 0 || end <= start {
+		t.Fatalf("could not find base64 in arg: %q", arg)
+	}
+	encoded := arg[start:end]
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("arg is not valid base64: %v", err)
+	}
+	if !strings.Contains(string(decoded), "echo hello") {
+		t.Errorf("decoded script missing content: %q", decoded)
+	}
+}
+
+func TestResolve_HostCommandScrubbing_Yum(t *testing.T) {
+	script := "#!/bin/sh\nyum install -y curl\necho done"
+	fetcher := testFetcher(map[string]string{"s3://b/s.sh": script})
+	actions := []BootstrapAction{{Name: "test", S3Path: "s3://b/s.sh"}}
+
+	inits, _, _, err := Resolve(context.Background(), fetcher, defaultCfg(), actions, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	arg := inits[0].Args[0]
+	start := strings.Index(arg, `"`) + 1
+	end := strings.LastIndex(arg, `"`)
+	decoded, _ := base64.StdEncoding.DecodeString(arg[start:end])
+	if !strings.Contains(string(decoded), "# [jaiscloud-skip]") {
+		t.Errorf("yum line not commented out in: %q", decoded)
+	}
+	if !strings.Contains(string(decoded), "echo done") {
+		t.Errorf("other lines should be preserved: %q", decoded)
+	}
+}
+
+func TestResolve_HostCommandScrubbing_AptGet(t *testing.T) {
+	script := "apt-get install curl"
+	fetcher := testFetcher(map[string]string{"s3://b/s.sh": script})
+	actions := []BootstrapAction{{Name: "test", S3Path: "s3://b/s.sh"}}
+	inits, _, _, err := Resolve(context.Background(), fetcher, defaultCfg(), actions, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	arg := inits[0].Args[0]
+	start := strings.Index(arg, `"`) + 1
+	end := strings.LastIndex(arg, `"`)
+	decoded, _ := base64.StdEncoding.DecodeString(arg[start:end])
+	if !strings.Contains(string(decoded), "# [jaiscloud-skip]") {
+		t.Errorf("apt-get line not scrubbed: %q", decoded)
+	}
+}
+
+func TestResolve_HostCommandScrubbing_Systemctl(t *testing.T) {
+	script := "systemctl restart nginx"
+	fetcher := testFetcher(map[string]string{"s3://b/s.sh": script})
+	actions := []BootstrapAction{{Name: "test", S3Path: "s3://b/s.sh"}}
+	inits, _, _, err := Resolve(context.Background(), fetcher, defaultCfg(), actions, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	arg := inits[0].Args[0]
+	start := strings.Index(arg, `"`) + 1
+	end := strings.LastIndex(arg, `"`)
+	decoded, _ := base64.StdEncoding.DecodeString(arg[start:end])
+	if !strings.Contains(string(decoded), "# [jaiscloud-skip]") {
+		t.Errorf("systemctl line not scrubbed: %q", decoded)
+	}
+}
+
+func TestResolve_HostCommandScrubbing_CleanLine(t *testing.T) {
+	script := "aws s3 cp s3://bucket/ca.crt /etc/pki/ca.crt"
+	fetcher := testFetcher(map[string]string{"s3://b/s.sh": script})
+	actions := []BootstrapAction{{Name: "test", S3Path: "s3://b/s.sh"}}
+	inits, _, _, err := Resolve(context.Background(), fetcher, defaultCfg(), actions, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	arg := inits[0].Args[0]
+	start := strings.Index(arg, `"`) + 1
+	end := strings.LastIndex(arg, `"`)
+	decoded, _ := base64.StdEncoding.DecodeString(arg[start:end])
+	if strings.Contains(string(decoded), "# [jaiscloud-skip]") {
+		t.Errorf("aws command should NOT be scrubbed: %q", decoded)
+	}
+}
+
+func TestResolve_ScriptExceedsMaxBytes(t *testing.T) {
+	fetcher := testFetcher(map[string]string{"s3://b/big.sh": strings.Repeat("x", 100)})
+	actions := []BootstrapAction{{Name: "test", S3Path: "s3://b/big.sh"}}
+	cfg := BootstrapConfig{Image: "img", MaxBytes: 10, Prefixes: []string{"/tmp"}}
+
+	_, _, _, err := Resolve(context.Background(), fetcher, cfg, actions, nil)
+	if err == nil {
+		t.Fatal("expected error for oversized script")
+	}
+}
+
+func TestResolve_FetcherError(t *testing.T) {
+	f := &fakeFetcher{err: fmt.Errorf("network error")}
+	actions := []BootstrapAction{{Name: "test", S3Path: "s3://b/s.sh"}}
+	_, _, _, err := Resolve(context.Background(), f, defaultCfg(), actions, nil)
+	if err == nil {
+		t.Fatal("expected error when fetcher fails")
+	}
+}
+
+func TestResolve_ActionNameSanitized(t *testing.T) {
+	fetcher := testFetcher(map[string]string{"s3://b/s.sh": "echo hi"})
+	actions := []BootstrapAction{{Name: "stage/certs here", S3Path: "s3://b/s.sh"}}
+	inits, _, _, err := Resolve(context.Background(), fetcher, defaultCfg(), actions, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	name := inits[0].Name
+	if strings.Contains(name, "/") || strings.Contains(name, " ") {
+		t.Errorf("container name not sanitized: %q", name)
+	}
+	if !strings.HasPrefix(name, "bootstrap-") {
+		t.Errorf("container name should start with 'bootstrap-': %q", name)
+	}
+}
+
+func TestResolve_ActionArgs_InShellCmd(t *testing.T) {
+	fetcher := testFetcher(map[string]string{"s3://b/s.sh": "#!/bin/sh\necho $1"})
+	actions := []BootstrapAction{{Name: "test", S3Path: "s3://b/s.sh", Args: []string{"/etc/pki/kafka.jks"}}}
+	inits, _, _, err := Resolve(context.Background(), fetcher, defaultCfg(), actions, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	arg := inits[0].Args[0]
+	if !strings.Contains(arg, "/etc/pki/kafka.jks") {
+		t.Errorf("action arg not passed to shell cmd: %q", arg)
+	}
+}
+
+func TestS3BlobFetcher_Integration(t *testing.T) {
+	store := blobfs.NewMemoryBlobStore()
+	store.Put(context.Background(), "bootstrap-bucket", "scripts/stage.sh", []byte("#!/bin/sh\necho ok"))
+	fetcher := blobfs.NewS3BlobFetcher(store)
+
+	data, err := fetcher.Fetch(context.Background(), "s3://bootstrap-bucket/scripts/stage.sh")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(data), "echo ok") {
+		t.Errorf("unexpected data: %q", data)
+	}
+}

--- a/internal/provider/emr/emr.go
+++ b/internal/provider/emr/emr.go
@@ -6,18 +6,52 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
 
+	"jaiscloud/internal/blobfs"
 	"jaiscloud/internal/events"
 	"jaiscloud/internal/executor/spark"
 	"jaiscloud/internal/model"
 	"jaiscloud/internal/provider"
 	"jaiscloud/internal/store"
 )
+
+// BootstrapAction is a typed representation of an EMR bootstrap action.
+// Parsed from the RunJobFlow request and used by the bootstrap resolver.
+type BootstrapAction struct {
+	Name   string
+	S3Path string
+	Args   []string
+}
+
+// parsedBootstrapActions converts the stored []map[string]any bootstrap
+// actions into typed BootstrapAction values for the resolver.
+func parsedBootstrapActions(raw []map[string]any) []BootstrapAction {
+	out := make([]BootstrapAction, 0, len(raw))
+	for _, ba := range raw {
+		name, _ := ba["Name"].(string)
+		script, _ := ba["ScriptBootstrapAction"].(map[string]any)
+		if script == nil {
+			script = map[string]any{}
+		}
+		path, _ := script["Path"].(string)
+		var args []string
+		if rawArgs, ok := script["Args"].([]any); ok {
+			for _, a := range rawArgs {
+				if s, ok := a.(string); ok {
+					args = append(args, s)
+				}
+			}
+		}
+		out = append(out, BootstrapAction{Name: name, S3Path: path, Args: args})
+	}
+	return out
+}
 
 // jobRef identifies the store resource a Spark job maps to and carries the
 // request context needed to publish EventBus events from async callbacks.
@@ -31,12 +65,14 @@ type jobRef struct {
 
 // EMRProvider handles EMR clusters, job flows, steps, instance groups/fleets.
 type EMRProvider struct {
-	resources   store.ResourceStore
-	bus         *events.EventBus
-	executor    spark.SparkExecutor // nil = instant completion
-	executorCfg spark.SparkConfig
-	poller      *spark.StatusPoller // nil when executor is nil
-	jobRefs     sync.Map            // jobID → jobRef
+	resources      store.ResourceStore
+	bus            *events.EventBus
+	executor       spark.SparkExecutor // nil = instant completion
+	executorCfg    spark.SparkConfig
+	poller         *spark.StatusPoller // nil when executor is nil
+	jobRefs        sync.Map            // jobID → jobRef
+	bootstrapFetch blobfs.BlobFetcher  // nil = bootstrap disabled
+	bootstrapCfg   BootstrapConfig
 }
 
 // Option configures EMRProvider.
@@ -45,6 +81,13 @@ type Option func(*EMRProvider)
 // WithExecutor attaches a SparkExecutor and its config to the provider.
 func WithExecutor(ex spark.SparkExecutor, cfg spark.SparkConfig) Option {
 	return func(p *EMRProvider) { p.executor = ex; p.executorCfg = cfg }
+}
+
+// WithBootstrap attaches a BlobFetcher and BootstrapConfig to the provider.
+// When set, AddJobFlowSteps resolves bootstrap actions into k8stypes fragments
+// and sets them on the SparkJob before calling Submit.
+func WithBootstrap(fetcher blobfs.BlobFetcher, cfg BootstrapConfig) Option {
+	return func(p *EMRProvider) { p.bootstrapFetch = fetcher; p.bootstrapCfg = cfg }
 }
 
 // WithPoller attaches a StatusPoller.
@@ -414,6 +457,23 @@ func (p *EMRProvider) AddJobFlowSteps(ctx context.Context, nr *model.NormalizedR
 			if p.executor != nil {
 				jar, mainClass, args := extractHadoopJarStep(m)
 				job := spark.BuildSparkJob(sid, jar, mainClass, args, "", p.executorCfg)
+
+				// Resolve bootstrap actions into k8stypes fragments and attach
+				// them to the job so the K8s executor can inject them into the manifest.
+				if p.bootstrapFetch != nil && len(c.BootstrapActions) > 0 {
+					sparkEnv := bootstrapSparkEnv(p.executorCfg)
+					typed := parsedBootstrapActions(c.BootstrapActions)
+					initCtrs, vols, mounts, resolveErr := Resolve(ctx, p.bootstrapFetch, p.bootstrapCfg, typed, sparkEnv)
+					if resolveErr != nil {
+						slog.Error("emr: bootstrap resolve failed, marking step FAILED", "step", sid, "err", resolveErr)
+						step["Status"].(map[string]any)["State"] = "FAILED"
+						continue
+					}
+					job.ExtraInitContainers = initCtrs
+					job.ExtraVolumes = vols
+					job.ExtraMainMounts = mounts
+				}
+
 				if submitErr := p.executor.Submit(ctx, job); submitErr != nil {
 					// Mark failed immediately — don't block the API response
 					step["Status"].(map[string]any)["State"] = "FAILED"

--- a/internal/store/aws/dynamodb/memory.go
+++ b/internal/store/aws/dynamodb/memory.go
@@ -257,7 +257,7 @@ func (s *MemoryDynamoDBItemStore) Query(_ context.Context, table string, q Query
 
 	all := paginateItems(matched, q.ExclusiveStartKey, q.Limit)
 	var lastKey string
-	if q.Limit > 0 && len(matched) == q.Limit {
+	if q.Limit > 0 && len(all) == q.Limit {
 		b, _ := json.Marshal(all[len(all)-1])
 		lastKey = string(b)
 	}


### PR DESCRIPTION

- **EMR bootstrap actions** (`RunJobFlow.BootstrapActions`) are now materialised as Kubernetes init containers when `EXECUTOR_MODE=k8s`, running before `spark-submit` to stage certificates, Hadoop config, and other cluster prerequisites.
- **`BlobFetcher` interface** added to `internal/blobfs` so bootstrap scripts are fetched from the local S3 store by URI without importing the S3 provider into the executor package.
- **`k8stypes.EnvVar.ValueFrom`** support added (SecretKeyRef, ConfigMapKeyRef, FieldRef) to allow init containers to read credentials from K8s Secrets/ConfigMaps.
- **`SparkJob` fragment fields** (`ExtraInitContainers`, `ExtraVolumes`, `ExtraMainMounts`) let the EMR provider attach pre-built K8s fragments to a job without creating an import cycle into the executor package.
- **DynamoDB `Query` `LastEvaluatedKey` bug fixed** — cursor pagination now works correctly when `Limit` truncates results.

---

## Changes

### New files

| File | Description |
|---|---|
| `internal/blobfs/blobfetch.go` | `BlobFetcher` interface + `S3BlobFetcher` (parses `s3://`/`s3a://` URIs, delegates to `BlobStore`) |
| `internal/blobfs/blobfetch_test.go` | 7 unit tests covering happy path, `s3a://` normalisation, missing object, bad schemes |
| `internal/provider/emr/bootstrap.go` | `Resolve()` — fetches scripts, scrubs host commands, builds init containers + emptyDir volumes |
| `internal/provider/emr/bootstrap_test.go` | 17 unit tests for `Resolve`, `scrubHostCommands`, `sanitizeName`, `shellQuoteArgs`, `bootstrapSparkEnv` |
| `internal/k8stypes/types_test.go` | 6 unit tests for `EnvVar` / `PodSpec` JSON round-trips |

### Modified files

| File | Change |
|---|---|
| `internal/k8stypes/types.go` | Added `EnvVar.ValueFrom` + `EnvVarSource`, `SecretKeySelector`, `ConfigMapKeySelector` types |
| `internal/executor/spark/executor.go` | `SparkJob` extended with `ExtraInitContainers`, `ExtraVolumes`, `ExtraMainMounts` fragment fields |
| `internal/executor/spark/k8s.go` | `buildJobManifest` injects bootstrap fragments after cloud/platform layers; `checkVolumeConflicts` detects name collisions |
| `internal/executor/spark/k8s_test.go` | 6 new tests: no-extras baseline, init containers prepended, volumes appended, main mounts appended, volume conflict via `buildJobManifest`, order preserved |
| `internal/provider/emr/emr.go` | Added `WithBootstrap` option; `AddJobFlowSteps` calls `Resolve` and marks step `FAILED` on error; import ordering fixed |
| `internal/store/aws/dynamodb/memory.go` | **Bug fix:** `len(matched)` → `len(all)` in `Query` `LastEvaluatedKey` check |
| `cmd/jaiscloud/main.go` | Wires `S3BlobFetcher` + `BootstrapConfig` into EMR provider; logs warning on invalid `JAISCLOUD_BOOTSTRAP_SCRIPT_MAX_BYTES` |

---

## Architecture

Bootstrap resolution is intentionally split across the boundary between the EMR provider and the Spark executor:

```
EMRProvider.AddJobFlowSteps
  │
  ├─ bootstrap.Resolve(ctx, S3BlobFetcher, BootstrapConfig, actions, sparkEnv)
  │     ├─ S3BlobFetcher.Fetch(ctx, "s3://bucket/path/script.sh")  → []byte
  │     ├─ scrubHostCommands(script)                               → patched script
  │     └─ build k8stypes.Container + k8stypes.Volume per action   → fragments
  │
  └─ SparkJob.ExtraInitContainers / ExtraVolumes / ExtraMainMounts ← fragments attached here
       │
       └─ K8sExecutor.buildJobManifest
             ├─ cloud/platform layers applied first (cloudVols, platform.ApplyK8s)
             ├─ checkVolumeConflicts(spec.Volumes, job.ExtraVolumes)
             └─ spec.InitContainers = job.ExtraInitContainers + existing
                spec.Volumes       += job.ExtraVolumes
                spec.Containers[0].VolumeMounts += job.ExtraMainMounts
```

**Key design constraint:** The executor package must not import the EMR provider (circular dependency). Fragment fields on `SparkJob` act as the decoupling point — the provider resolves EMR semantics, the executor handles K8s mechanics.

---

## Environment variables added

| Variable | Default | Description |
|---|---|---|
| `JAISCLOUD_BOOTSTRAP_IMAGE` | `amazon/aws-cli:2.18` | Init container image for bootstrap scripts |
| `JAISCLOUD_BOOTSTRAP_SCRIPT_MAX_BYTES` | `1048576` (1 MiB) | Maximum size per bootstrap script |
| `JAISCLOUD_BOOTSTRAP_RELOCATE_PREFIXES` | `/etc/pki,/home/hadoop` | Comma-separated emptyDir mount paths writable by init containers |

---

## Bootstrap script processing

1. Script fetched from local S3 store via `s3://` URI in `BootstrapAction.ScriptBootstrapAction.Path`.
2. Host-only commands commented out with `# [jaiscloud-skip]`:
   - Package managers: `yum`, `apt-get`, `apt`, `dnf`, `rpm`
   - Init system: `systemctl`, `service`, `chkconfig`, `update-rc.d`
3. Patched script base64-encoded; init container runs:
   ```sh
   printf '%s' '<b64>' | base64 -d | /bin/sh -s -- <action-args>
   ```
4. Init containers run as `runAsUser: 0` (root) — required to write to `/etc/pki`, `/home/hadoop`.
5. One `emptyDir` volume per prefix — mounted into all init containers and the main `spark-submit` container.
6. Fetch failure or size limit exceeded → step immediately marked `FAILED`.

---

## DynamoDB `LastEvaluatedKey` bug fix

**Root cause:** `MemoryDynamoDBItemStore.Query` checked `len(matched) == q.Limit` where `matched` is the full pre-pagination result set. When 5 items match and `Limit=2`, `matched` has 5 items — `5 == 2` is always false, so `LastEvaluatedKey` was never set.

**Fix:** Changed to `len(all) == q.Limit` where `all` is the output of `paginateItems` (the actual returned page). When the page is full, there may be more items, so `LastEvaluatedKey` is set to the last item in the page.

**Scope:** Memory store `Query` only. `Scan` (memory), and both Postgres paths already used `len(all)` correctly.

**Tests fixed:** `TestDynamoDB_LimitReturnsLastEvaluatedKey`, `TestDynamoDB_QueryPagination` — both now pass in the integration suite.

---
