### PR TITLE
feat(gcp): Phase 2 — Firestore emulator (REST)

### DIFF
--- a/cmd/jaiscloud-gcp/main.go
+++ b/cmd/jaiscloud-gcp/main.go
@@ -21,12 +21,14 @@ import (
 	"jaiscloud/internal/gateway"
 	gcpadapter "jaiscloud/internal/gcp/adapter"
 	"jaiscloud/internal/gcp/crypto"
+	firestoreprovider "jaiscloud/internal/gcp/provider/firestore"
 	iamprovider "jaiscloud/internal/gcp/provider/iam"
 	kmsprovider "jaiscloud/internal/gcp/provider/kms"
 	pubsubprovider "jaiscloud/internal/gcp/provider/pubsub"
 	secretmanagerprovider "jaiscloud/internal/gcp/provider/secretmanager"
 	storageprovider "jaiscloud/internal/gcp/provider/storage"
 	gcpstore "jaiscloud/internal/gcp/store"
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
 	"jaiscloud/internal/gcp/store/gcs"
 	kmsstore "jaiscloud/internal/gcp/store/kms"
 	pubsubstore "jaiscloud/internal/gcp/store/pubsub"
@@ -117,22 +119,26 @@ func startCmd() *cobra.Command {
 			kmsP := kmsprovider.New(stores.keys)
 			iamP := iamprovider.New(stores.resources)
 			pubsubP := pubsubprovider.New(stores.resources, stores.messages, crypto.NewEnvelopeEncryptor(stores.keys))
+			firestoreP := firestoreprovider.New(stores.documents, stores.resources)
 
 			reg := provider.NewRegistry().
 				Register(storageP).
 				Register(secretP).
 				Register(kmsP).
 				Register(iamP).
-				Register(pubsubP)
+				Register(pubsubP).
+				Register(firestoreP)
 
 			adminHandler := admin.NewHandler()
 			adminHandler.RegisterResetter(stores.objects)
 			adminHandler.RegisterResetter(stores.messages)
 			adminHandler.RegisterResetter(stores.secrets)
 			adminHandler.RegisterResetter(stores.keys)
+			adminHandler.RegisterResetter(stores.documents)
 			adminHandler.RegisterResetter(stores.resources)
 			adminHandler.RegisterResetter(stores.blobs)
 			adminHandler.RegisterResetter(storageP)
+			adminHandler.RegisterResetter(firestoreP)
 			if snap, ok := stores.resources.(admin.Snapshotter); ok {
 				adminHandler.RegisterSnapshotter("resources", snap)
 			}
@@ -147,6 +153,9 @@ func startCmd() *cobra.Command {
 			}
 			if snap, ok := stores.keys.(admin.Snapshotter); ok {
 				adminHandler.RegisterSnapshotter("keys", snap)
+			}
+			if snap, ok := stores.documents.(admin.Snapshotter); ok {
+				adminHandler.RegisterSnapshotter("firestore_documents", snap)
 			}
 			if sb, ok := stores.blobs.(admin.SnapshotBlobStore); ok {
 				adminHandler.RegisterBlobStore(sb)
@@ -295,6 +304,7 @@ type stores struct {
 	messages  pubsubstore.Messages
 	secrets   secretmanagerstore.Store
 	keys      kmsstore.Store
+	documents firestorestore.FirestoreStore
 	resources store.ResourceStore
 	blobs     blobfs.BlobStore
 	close     func()
@@ -320,6 +330,7 @@ func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*st
 			messages:  pubsubstore.NewPostgresMessages(pg.Pool()),
 			secrets:   secretmanagerstore.NewPostgresStore(pg.Pool()),
 			keys:      kmsstore.NewPostgresStore(pg.Pool()),
+			documents: firestorestore.NewPostgresStore(pg.Pool()),
 			resources: pg,
 			blobs:     blobs,
 			close:     func() { pg.Close() },
@@ -331,6 +342,7 @@ func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*st
 			messages:  pubsubstore.NewMemoryMessages(),
 			secrets:   secretmanagerstore.NewMemoryStore(),
 			keys:      kmsstore.NewMemoryStore(),
+			documents: firestorestore.NewMemoryStore(),
 			resources: store.NewMemoryResourceStore(),
 			blobs:     blobfs.NewMemoryBlobStore(),
 			close:     func() {},
@@ -345,6 +357,7 @@ func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*st
 		messages:  pubsubstore.NewMemoryMessages(),
 		secrets:   secretmanagerstore.NewMemoryStore(),
 		keys:      kmsstore.NewMemoryStore(),
+		documents: firestorestore.NewMemoryStore(),
 		resources: store.NewMemoryResourceStore(),
 		blobs:     blobs,
 		close:     func() {},

--- a/internal/gcp/adapter/jsoncodec.go
+++ b/internal/gcp/adapter/jsoncodec.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"jaiscloud/internal/gcp/wire"
 	"jaiscloud/internal/model"
 )
 
@@ -37,7 +38,7 @@ func (c *JSONCodec) Decode(r *http.Request, body []byte) (*model.NormalizedReque
 	}
 	rest := seg[pi+2:]
 
-	nr := &model.NormalizedRequest{Service: c.Service, Params: map[string]any{}}
+	nr := &model.NormalizedRequest{Service: c.Service, Params: map[string]any{}, Raw: r}
 	nr.Params["project"] = seg[pi+1]
 	queryToParams(r, nr.Params)
 	m, err := parseJSON(body)
@@ -90,6 +91,9 @@ func (c *JSONCodec) Encode(nr *model.NormalizedRequest, resp *model.ProviderResp
 	}
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json; charset=UTF-8")
+	if raw, ok := resp.Data[wire.RawJSONKey].(json.RawMessage); ok {
+		return status, headers, raw
+	}
 	out, err := json.Marshal(resp.Data)
 	if err != nil {
 		return http.StatusInternalServerError, headers, []byte(`{"error":{"code":500,"message":"encode failure","status":"INTERNAL"}}`)
@@ -105,11 +109,15 @@ func (c *JSONCodec) EncodeError(nr *model.NormalizedRequest, perr *model.Provide
 	}
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json; charset=UTF-8")
+	statusStr := perr.Status
+	if statusStr == "" {
+		statusStr = gcpStatusString(status)
+	}
 	env := map[string]any{
 		"error": map[string]any{
 			"code":    status,
 			"message": perr.Message,
-			"status":  gcpStatusString(status),
+			"status":  statusStr,
 		},
 	}
 	out, _ := json.Marshal(env)
@@ -130,6 +138,16 @@ func detectResourceType(segs []string) string {
 			return "subscriptions"
 		case "secrets":
 			return "secrets"
+		case "documents":
+			// Firestore document paths always contain the "documents" marker
+			// after "databases/{db}", so it wins over the generic "keys" /
+			// "serviceAccounts" cases below (a document collection could be
+			// named "keys").
+			return "documents"
+		case "indexes":
+			// Firestore composite-index admin paths
+			// (.../collectionGroups/{cg}/indexes[/{id}]).
+			return "indexes"
 		case "keys":
 			return "keys" // service account keys
 		case "cryptoKeyVersions":
@@ -246,6 +264,27 @@ func deriveAction(resourceType string, isCollection bool, name, method, custom s
 			case "signJwt":
 				return "ServiceAccountSignJwt"
 			}
+		case "documents":
+			// Custom methods POSTed to the "documents" collection marker:
+			// documents:commit, documents:runQuery, documents:batchWrite, etc.
+			switch custom {
+			case "commit":
+				return "Commit"
+			case "runQuery":
+				return "RunQuery"
+			case "runAggregationQuery":
+				return "RunAggregationQuery"
+			case "batchWrite":
+				return "BatchWrite"
+			case "batchGet":
+				return "BatchGet"
+			case "beginTransaction":
+				return "BeginTransaction"
+			case "rollback":
+				return "Rollback"
+			case "listCollectionIds":
+				return "ListCollectionIds"
+			}
 		}
 	}
 
@@ -338,6 +377,54 @@ func deriveAction(resourceType string, isCollection bool, name, method, custom s
 		case method == http.MethodDelete:
 			return "ServiceAccountKeyDelete"
 		}
+	case "documents":
+		// Firestore: an even (positive) number of segments after "documents"
+		// is a document; an odd count is a collection. Custom methods
+		// (:commit, :runQuery, :batchWrite, :beginTransaction, :rollback,
+		// :batchGet, :listCollectionIds) are handled by the custom switch
+		// above.
+		segs := segmentsAfterDocuments(name)
+		isDoc := segs > 0 && segs%2 == 0
+		switch {
+		case method == http.MethodPost && !isDoc:
+			return "CreateDocument"
+		case method == http.MethodGet && isDoc:
+			return "GetDocument"
+		case method == http.MethodGet && !isDoc:
+			// documents.list / documents.listDocuments share one wire path
+			// (GET on a collection); both are served by the ListDocuments
+			// handler.
+			return "ListDocuments"
+		case method == http.MethodPatch && isDoc:
+			return "PatchDocument"
+		case method == http.MethodDelete && isDoc:
+			return "DeleteDocument"
+		}
+	case "indexes":
+		switch {
+		case isCollection && method == http.MethodPost:
+			return "CreateIndex"
+		case isCollection && method == http.MethodGet:
+			return "ListIndexes"
+		case method == http.MethodGet:
+			return "GetIndex"
+		case method == http.MethodDelete:
+			return "DeleteIndex"
+		}
 	}
 	return ""
+}
+
+// segmentsAfterDocuments returns the number of path segments after the
+// "documents" marker in a Firestore resource name (e.g.
+// "databases/(default)/documents/cities/SF" → 2). An even (positive) count is a
+// document; an odd count is a collection.
+func segmentsAfterDocuments(name string) int {
+	parts := strings.Split(name, "/")
+	for i, p := range parts {
+		if p == "documents" {
+			return len(parts) - i - 1
+		}
+	}
+	return 0
 }

--- a/internal/gcp/adapter/router.go
+++ b/internal/gcp/adapter/router.go
@@ -71,7 +71,17 @@ func detectV1Service(path string) string {
 	if pi < 0 || pi+2 >= len(seg) {
 		return ""
 	}
-	switch detectResourceType(seg[pi+2:]) {
+	rest := seg[pi+2:]
+	// Strip a trailing custom-method suffix (":commit", ":runQuery", ...) from
+	// the last segment so "documents:commit" detects as "documents" (mirrors the
+	// JSONCodec.Decode custom-method handling).
+	if len(rest) > 0 {
+		last := rest[len(rest)-1]
+		if i := strings.IndexByte(last, ':'); i >= 0 {
+			rest[len(rest)-1] = last[:i]
+		}
+	}
+	switch detectResourceType(rest) {
 	case "topics", "subscriptions":
 		return "pubsub"
 	case "secrets":
@@ -80,6 +90,8 @@ func detectV1Service(path string) string {
 		return "kms"
 	case "serviceAccounts", "keys":
 		return "iam"
+	case "documents", "indexes":
+		return "firestore"
 	}
 	return ""
 }

--- a/internal/gcp/adapter/services.go
+++ b/internal/gcp/adapter/services.go
@@ -54,6 +54,11 @@ var gcpServices = []ServiceDescriptor{
 		ProviderPrefix: "IAM",
 		Codec:          func() adapter.Codec { return &JSONCodec{Service: "iam"} },
 	},
+	{
+		ServiceName:    "firestore",
+		ProviderPrefix: "Firestore",
+		Codec:          func() adapter.Codec { return &JSONCodec{Service: "firestore"} },
+	},
 }
 
 // serviceProviderMap maps wire service name → provider registry prefix.

--- a/internal/gcp/provider/firestore/commit.go
+++ b/internal/gcp/provider/firestore/commit.go
@@ -1,0 +1,670 @@
+package firestore
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+
+	"jaiscloud/internal/clock"
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+	"jaiscloud/internal/gcp/wire"
+	"jaiscloud/internal/model"
+	"jaiscloud/internal/provider"
+)
+
+// ─── wire request types (decoded from the JSON body) ──────────────────────────
+
+type documentMaskWire struct {
+	FieldPaths []string `json:"fieldPaths,omitempty"`
+}
+
+type preconditionWire struct {
+	Exists     *bool  `json:"exists"`
+	UpdateTime string `json:"updateTime,omitempty"`
+}
+
+type documentWire struct {
+	Name       string                           `json:"name,omitempty"`
+	Fields     map[string]*firestorestore.Value `json:"fields,omitempty"`
+	CreateTime string                           `json:"createTime,omitempty"`
+	UpdateTime string                           `json:"updateTime,omitempty"`
+}
+
+type fieldTransformWire struct {
+	FieldPath             string                     `json:"fieldPath,omitempty"`
+	Increment             *firestorestore.Value      `json:"increment,omitempty"`
+	Maximum               *firestorestore.Value      `json:"maximum,omitempty"`
+	Minimum               *firestorestore.Value      `json:"minimum,omitempty"`
+	SetToServerValue      string                     `json:"setToServerValue,omitempty"`
+	AppendMissingElements *firestorestore.ArrayValue `json:"appendMissingElements,omitempty"`
+	RemoveAllFromArray    *firestorestore.ArrayValue `json:"removeAllFromArray,omitempty"`
+}
+
+type documentTransformWire struct {
+	Document        string               `json:"document,omitempty"`
+	FieldTransforms []fieldTransformWire `json:"fieldTransforms,omitempty"`
+}
+
+type writeWire struct {
+	Update           *documentWire          `json:"update,omitempty"`
+	Delete           string                 `json:"delete,omitempty"`
+	Transform        *documentTransformWire `json:"transform,omitempty"`
+	UpdateMask       *documentMaskWire      `json:"updateMask,omitempty"`
+	UpdateTransforms []fieldTransformWire   `json:"updateTransforms,omitempty"`
+	CurrentDocument  *preconditionWire      `json:"currentDocument,omitempty"`
+}
+
+type commitRequestWire struct {
+	Transaction string       `json:"transaction,omitempty"`
+	Writes      []*writeWire `json:"writes,omitempty"`
+}
+
+type batchWriteRequestWire struct {
+	Writes []*writeWire `json:"writes,omitempty"`
+}
+
+type batchGetRequestWire struct {
+	Documents   []string `json:"documents,omitempty"`
+	Transaction string   `json:"transaction,omitempty"`
+}
+
+type rollbackRequestWire struct {
+	Transaction string `json:"transaction,omitempty"`
+}
+
+type runQueryRequestWire struct {
+	StructuredQuery *structuredQuery `json:"structuredQuery,omitempty"`
+	Transaction     string           `json:"transaction,omitempty"`
+}
+
+// ─── transaction state (provider-scoped) ─────────────────────────────────────
+
+// readSet records the documents read within a transaction for optimistic
+// concurrency re-validation at commit.
+type readSet struct {
+	reads map[string]firestorestore.ReadRef
+}
+
+// decodeBody round-trips nr.Params["body"] into a typed struct.
+func decodeBody(nr *model.NormalizedRequest, v any) error {
+	body, _ := nr.Params["body"]
+	if body == nil {
+		body = map[string]any{}
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		return model.NewProviderError("InvalidArgument", "malformed request body", 400)
+	}
+	if err := json.Unmarshal(b, v); err != nil {
+		return model.NewProviderError("InvalidArgument", "malformed request body", 400)
+	}
+	return nil
+}
+
+// recordRead registers a document read in a transaction's read-set. Missing
+// documents are recorded with Exists=false so a concurrent create aborts.
+func (p *Provider) recordRead(txnID, name string, doc firestorestore.Document, exists bool) {
+	if txnID == "" {
+		return
+	}
+	p.txnMu.Lock()
+	defer p.txnMu.Unlock()
+	rs := p.readSets[txnID]
+	if rs == nil {
+		return
+	}
+	if rs.reads == nil {
+		rs.reads = make(map[string]firestorestore.ReadRef)
+	}
+	rs.reads[name] = firestorestore.ReadRef{Name: name, Exists: exists, UpdateTime: doc.UpdateTime}
+}
+
+// readSetFor returns the read-set entries for a transaction, or nil.
+func (p *Provider) readSetFor(txnID string) []firestorestore.ReadRef {
+	if txnID == "" {
+		return nil
+	}
+	p.txnMu.Lock()
+	defer p.txnMu.Unlock()
+	rs := p.readSets[txnID]
+	if rs == nil || len(rs.reads) == 0 {
+		return nil
+	}
+	out := make([]firestorestore.ReadRef, 0, len(rs.reads))
+	for _, r := range rs.reads {
+		out = append(out, r)
+	}
+	return out
+}
+
+// clearReadSet removes a transaction's read-set (after commit/rollback).
+func (p *Provider) clearReadSet(txnID string) {
+	p.txnMu.Lock()
+	defer p.txnMu.Unlock()
+	delete(p.readSets, txnID)
+}
+
+// newTxnID returns an opaque base64 transaction ID.
+func newTxnID() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "txn-" + base64.RawURLEncoding.EncodeToString([]byte(time.Now().String()))
+	}
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// ─── error helpers ────────────────────────────────────────────────────────────
+
+// newPreconditionErr returns a FAILED_PRECONDITION error at HTTP 400 (missing
+// composite index / failed precondition).
+func newPreconditionErr(msg string) error {
+	return &model.ProviderError{Code: "FailedPrecondition", Message: msg, HTTPStatus: 400, Status: "FAILED_PRECONDITION"}
+}
+
+// newAbortedErr returns an ABORTED error at HTTP 409 (transaction contention).
+func newAbortedErr(msg string) error {
+	return &model.ProviderError{Code: "Aborted", Message: msg, HTTPStatus: 409, Status: "ABORTED"}
+}
+
+// mapCommitError maps store commit sentinels to Firestore RPC statuses.
+func mapCommitError(err error) error {
+	switch {
+	case errors.Is(err, firestorestore.ErrAborted):
+		return newAbortedErr("transaction was aborted due to concurrent modification")
+	case errors.Is(err, firestorestore.ErrPreconditionFailed):
+		return newPreconditionErr("precondition failed")
+	default:
+		return err
+	}
+}
+
+// ─── handlers ─────────────────────────────────────────────────────────────────
+
+// BeginTransaction implements documents.beginTransaction.
+func (p *Provider) BeginTransaction(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	txnID := newTxnID()
+	p.txnMu.Lock()
+	if p.readSets == nil {
+		p.readSets = make(map[string]*readSet)
+	}
+	p.readSets[txnID] = &readSet{reads: map[string]firestorestore.ReadRef{}}
+	p.txnMu.Unlock()
+	return provider.OK(map[string]any{"transaction": txnID}), nil
+}
+
+// Rollback implements documents.rollback.
+func (p *Provider) Rollback(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	var req rollbackRequestWire
+	if err := decodeBody(nr, &req); err != nil {
+		return nil, err
+	}
+	p.clearReadSet(req.Transaction)
+	return &model.ProviderResponse{HTTPStatus: 200, Data: map[string]any{}}, nil
+}
+
+// Commit implements documents.commit: an atomic batch of writes with optimistic
+// preconditions and transaction read-set validation.
+func (p *Provider) Commit(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	var req commitRequestWire
+	if err := decodeBody(nr, &req); err != nil {
+		return nil, err
+	}
+	if len(req.Writes) > maxWriteBatchSize {
+		return nil, model.NewProviderError("InvalidArgument",
+			"a commit may contain at most "+strconv.Itoa(maxWriteBatchSize)+" writes", 400)
+	}
+	if size, err := writeBatchSize(req.Writes); err != nil {
+		return nil, err
+	} else if size > maxTxnBytes {
+		return nil, model.NewProviderError("InvalidArgument", "transaction exceeds the maximum size of 10 MiB", 400)
+	}
+
+	commitTime := clock.Now()
+	writes, results, err := p.buildWrites(ctx, nr, req.Writes, commitTime)
+	if err != nil {
+		return nil, err
+	}
+	reads := p.readSetFor(req.Transaction)
+	if err := p.store.Commit(ctx, reads, writes); err != nil {
+		return nil, mapCommitError(err)
+	}
+	p.clearReadSet(req.Transaction)
+
+	wr := make([]any, 0, len(results))
+	for _, r := range results {
+		wr = append(wr, r)
+	}
+	return provider.OK(map[string]any{
+		"commitTime":   commitTime.Format(time.RFC3339Nano),
+		"writeResults": wr,
+	}), nil
+}
+
+// buildWrites translates wire writes into store writes + write-results,
+// resolving masks and transforms against the current document state.
+func (p *Provider) buildWrites(ctx context.Context, nr *model.NormalizedRequest, wire []*writeWire, now time.Time) ([]firestorestore.Write, []map[string]any, error) {
+	writes := make([]firestorestore.Write, 0, len(wire))
+	results := make([]map[string]any, 0, len(wire))
+	for _, w := range wire {
+		pre, err := toPrecondition(w.CurrentDocument)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		switch {
+		case w.Delete != "":
+			writes = append(writes, firestorestore.Write{Name: w.Delete, Precondition: pre})
+			results = append(results, map[string]any{}) // no updateTime after delete
+
+		case w.Transform != nil:
+			doc, res, err := p.buildTransform(ctx, w.Transform, pre, now)
+			if err != nil {
+				return nil, nil, err
+			}
+			writes = append(writes, firestorestore.Write{Name: doc.Name, Document: &doc, Precondition: pre})
+			results = append(results, res)
+
+		case w.Update != nil:
+			doc, res, err := p.buildUpdate(ctx, w.Update, w.UpdateMask, w.UpdateTransforms, pre, now)
+			if err != nil {
+				return nil, nil, err
+			}
+			writes = append(writes, firestorestore.Write{Name: doc.Name, Document: &doc, Precondition: pre})
+			results = append(results, res)
+
+		default:
+			return nil, nil, model.NewProviderError("InvalidArgument", "write must specify update, delete, or transform", 400)
+		}
+	}
+	return writes, results, nil
+}
+
+// toPrecondition converts a wire precondition into a store precondition.
+func toPrecondition(pw *preconditionWire) (*firestorestore.Precondition, error) {
+	if pw == nil {
+		return nil, nil
+	}
+	pre := &firestorestore.Precondition{}
+	if pw.Exists != nil {
+		pre.Exists = pw.Exists
+	}
+	if pw.UpdateTime != "" {
+		t, err := time.Parse(time.RFC3339Nano, pw.UpdateTime)
+		if err != nil {
+			return nil, model.NewProviderError("InvalidArgument", "invalid updateTime precondition", 400)
+		}
+		pre.UpdateTime = &t
+	}
+	return pre, nil
+}
+
+// buildUpdate resolves an update (with optional mask + transforms) against the
+// current document.
+func (p *Provider) buildUpdate(ctx context.Context, dw *documentWire, mask *documentMaskWire, transforms []fieldTransformWire, pre *firestorestore.Precondition, now time.Time) (firestorestore.Document, map[string]any, error) {
+	if dw.Name == "" {
+		return firestorestore.Document{}, nil, model.NewProviderError("InvalidArgument", "update document name is required", 400)
+	}
+	if err := validateFields(dw.Fields); err != nil {
+		return firestorestore.Document{}, nil, err
+	}
+	if err := checkSize(dw.Fields); err != nil {
+		return firestorestore.Document{}, nil, err
+	}
+
+	existing, err := p.store.GetDocument(ctx, dw.Name)
+	exists := err == nil
+	if err != nil && !errors.Is(err, firestorestore.ErrDocumentNotFound) {
+		return firestorestore.Document{}, nil, err
+	}
+
+	var maskPaths []string
+	if mask != nil {
+		maskPaths = mask.FieldPaths
+	}
+	base := map[string]*firestorestore.Value{}
+	if exists {
+		base = existing.Fields
+	}
+	merged := applyMask(dw.Fields, maskPaths, base)
+
+	// Apply post-update transforms to the merged fields.
+	var transformResults []*firestorestore.Value
+	if len(transforms) > 0 {
+		var res []*firestorestore.Value
+		merged, res, err = applyFieldTransforms(merged, transforms, now)
+		if err != nil {
+			return firestorestore.Document{}, nil, err
+		}
+		transformResults = res
+	}
+	if err := checkSize(merged); err != nil {
+		return firestorestore.Document{}, nil, err
+	}
+
+	createTime := now
+	if exists {
+		createTime = existing.CreateTime
+	}
+	doc := firestorestore.Document{Name: dw.Name, Fields: merged, CreateTime: createTime, UpdateTime: now}
+	res := map[string]any{"updateTime": now.Format(time.RFC3339Nano)}
+	if len(transformResults) > 0 {
+		tr := make([]any, 0, len(transformResults))
+		for _, r := range transformResults {
+			tr = append(tr, valueWire(r))
+		}
+		res["transformResults"] = tr
+	}
+	return doc, res, nil
+}
+
+// buildTransform resolves a document transform against the current document.
+func (p *Provider) buildTransform(ctx context.Context, tw *documentTransformWire, pre *firestorestore.Precondition, now time.Time) (firestorestore.Document, map[string]any, error) {
+	if tw.Document == "" {
+		return firestorestore.Document{}, nil, model.NewProviderError("InvalidArgument", "transform document name is required", 400)
+	}
+	existing, err := p.store.GetDocument(ctx, tw.Document)
+	exists := err == nil
+	if err != nil && !errors.Is(err, firestorestore.ErrDocumentNotFound) {
+		return firestorestore.Document{}, nil, err
+	}
+
+	base := map[string]*firestorestore.Value{}
+	createTime := now
+	if exists {
+		base = existing.Fields
+		createTime = existing.CreateTime
+	}
+	fields, transformResults, err := applyFieldTransforms(base, tw.FieldTransforms, now)
+	if err != nil {
+		return firestorestore.Document{}, nil, err
+	}
+	if err := checkSize(fields); err != nil {
+		return firestorestore.Document{}, nil, err
+	}
+
+	doc := firestorestore.Document{Name: tw.Document, Fields: fields, CreateTime: createTime, UpdateTime: now}
+	tr := make([]any, 0, len(transformResults))
+	for _, r := range transformResults {
+		tr = append(tr, valueWire(r))
+	}
+	return doc, map[string]any{"updateTime": now.Format(time.RFC3339Nano), "transformResults": tr}, nil
+}
+
+// BatchWrite implements documents.batchWrite: non-atomic, per-write results.
+func (p *Provider) BatchWrite(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	var req batchWriteRequestWire
+	if err := decodeBody(nr, &req); err != nil {
+		return nil, err
+	}
+	if len(req.Writes) > maxWriteBatchSize {
+		return nil, model.NewProviderError("InvalidArgument",
+			"a batchWrite may contain at most "+strconv.Itoa(maxWriteBatchSize)+" writes", 400)
+	}
+	now := clock.Now()
+	statuses := make([]any, 0, len(req.Writes))
+	writeResults := make([]any, 0, len(req.Writes))
+	for _, w := range req.Writes {
+		writes, results, err := p.buildWrites(ctx, nr, []*writeWire{w}, now)
+		if err != nil {
+			statuses = append(statuses, statusWire(3, errMsg(err)))
+			writeResults = append(writeResults, map[string]any{})
+			continue
+		}
+		if err := p.store.Commit(ctx, nil, writes); err != nil {
+			statuses = append(statuses, statusWireForError(err))
+			writeResults = append(writeResults, map[string]any{})
+			continue
+		}
+		statuses = append(statuses, statusWire(0, ""))
+		writeResults = append(writeResults, results[0])
+	}
+	return provider.OK(map[string]any{
+		"status":       statuses,
+		"writeResults": writeResults,
+	}), nil
+}
+
+// statusWire renders a google.rpc.Status-style object (code 0 = OK).
+func statusWire(code int64, msg string) map[string]any {
+	s := map[string]any{"code": code}
+	if msg != "" {
+		s["message"] = msg
+	}
+	return s
+}
+
+// statusWireForError maps a commit error to a per-write batchWrite status.
+func statusWireForError(err error) map[string]any {
+	switch {
+	case errors.Is(err, firestorestore.ErrAborted):
+		return statusWire(10, "transaction aborted")
+	case errors.Is(err, firestorestore.ErrPreconditionFailed):
+		return statusWire(9, "precondition failed")
+	default:
+		return statusWire(13, errMsg(err))
+	}
+}
+
+func errMsg(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// BatchGet implements documents.batchGet. The response body is newline-delimited
+// JSON (server-streaming): one BatchGetDocumentsResponse object per line, each
+// either {"found":{...},"readTime":"..."} or {"missing":"<name>","readTime":"..."},
+// with no trailing done line (BatchGetDocumentsResponse has no done field).
+func (p *Provider) BatchGet(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	var req batchGetRequestWire
+	if err := decodeBody(nr, &req); err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	readTime := clock.Now()
+	lines := make([]string, 0, len(req.Documents))
+	for _, name := range req.Documents {
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		var item map[string]any
+		doc, err := p.store.GetDocument(ctx, name)
+		if err != nil {
+			if errors.Is(err, firestorestore.ErrDocumentNotFound) {
+				p.recordRead(req.Transaction, name, firestorestore.Document{}, false)
+				item = map[string]any{"missing": name, "readTime": readTime.Format(time.RFC3339Nano)}
+			} else {
+				return nil, err
+			}
+		} else {
+			p.recordRead(req.Transaction, name, doc, true)
+			item = map[string]any{"found": documentMap(doc), "readTime": readTime.Format(time.RFC3339Nano)}
+		}
+		b, err := json.Marshal(item)
+		if err != nil {
+			return nil, err
+		}
+		lines = append(lines, string(b))
+	}
+	return provider.OK(map[string]any{wire.RawJSONKey: json.RawMessage(strings.Join(lines, "\n"))}), nil
+}
+
+// ─── field transforms ─────────────────────────────────────────────────────────
+
+// applyFieldTransforms applies each transform to a copy of fields, returning the
+// updated fields and the per-transform result values.
+func applyFieldTransforms(fields map[string]*firestorestore.Value, transforms []fieldTransformWire, serverTime time.Time) (map[string]*firestorestore.Value, []*firestorestore.Value, error) {
+	out := make(map[string]*firestorestore.Value, len(fields)+len(transforms))
+	for k, v := range fields {
+		out[k] = v
+	}
+	results := make([]*firestorestore.Value, 0, len(transforms))
+	for _, tf := range transforms {
+		if tf.FieldPath == "" {
+			return nil, nil, model.NewProviderError("InvalidArgument", "transform fieldPath is required", 400)
+		}
+		cur := fieldValue(&firestorestore.Document{Fields: out}, tf.FieldPath)
+		var result *firestorestore.Value
+		switch {
+		case tf.Increment != nil:
+			result = applyIncrement(cur, tf.Increment)
+			out = setFieldPathValue(out, tf.FieldPath, result)
+		case tf.Maximum != nil:
+			result = applyExtremum(cur, tf.Maximum, true)
+			out = setFieldPathValue(out, tf.FieldPath, result)
+		case tf.Minimum != nil:
+			result = applyExtremum(cur, tf.Minimum, false)
+			out = setFieldPathValue(out, tf.FieldPath, result)
+		case tf.SetToServerValue != "":
+			v := firestorestore.TimestampVal(serverTime)
+			out = setFieldPathValue(out, tf.FieldPath, v)
+			result = v
+		case tf.AppendMissingElements != nil:
+			v, err := appendMissing(cur, tf.AppendMissingElements)
+			if err != nil {
+				return nil, nil, err
+			}
+			out = setFieldPathValue(out, tf.FieldPath, v)
+			result = firestorestore.NullVal()
+		case tf.RemoveAllFromArray != nil:
+			v, err := removeAll(cur, tf.RemoveAllFromArray)
+			if err != nil {
+				return nil, nil, err
+			}
+			out = setFieldPathValue(out, tf.FieldPath, v)
+			result = firestorestore.NullVal()
+		default:
+			return nil, nil, model.NewProviderError("InvalidArgument", "transform must specify an operation", 400)
+		}
+		results = append(results, result)
+	}
+	return out, results, nil
+}
+
+// setFieldPathValue sets the value at a (possibly dotted) field path.
+func setFieldPathValue(fields map[string]*firestorestore.Value, path string, v *firestorestore.Value) map[string]*firestorestore.Value {
+	setFieldPath(fields, strings.Split(path, "."), v)
+	return fields
+}
+
+func applyIncrement(cur, inc *firestorestore.Value) *firestorestore.Value {
+	if !isNumeric(cur) {
+		return inc
+	}
+	ci, cint, cfloat := numberParts(cur)
+	ii, iint, ifloat := numberParts(inc)
+	if ci && ii {
+		return firestorestore.IntVal(clampAdd(cint, iint))
+	}
+	cf := cfloat
+	if ci {
+		cf = float64(cint)
+	}
+	inf := ifloat
+	if ii {
+		inf = float64(iint)
+	}
+	return firestorestore.DoubleVal(cf + inf)
+}
+
+func applyExtremum(cur, v *firestorestore.Value, isMax bool) *firestorestore.Value {
+	if !isNumeric(cur) {
+		return v
+	}
+	c := compareNumbers(cur, v)
+	if c == 0 {
+		return cur
+	}
+	if (isMax && c > 0) || (!isMax && c < 0) {
+		return cur
+	}
+	return v
+}
+
+func appendMissing(cur *firestorestore.Value, arr *firestorestore.ArrayValue) (*firestorestore.Value, error) {
+	existing := []*firestorestore.Value{}
+	if cur != nil && cur.ArrayValue != nil {
+		existing = append(existing, cur.ArrayValue.Values...)
+	}
+	toAppend := []*firestorestore.Value{}
+	if arr != nil {
+		toAppend = arr.Values
+	}
+	for _, v := range toAppend {
+		dup := false
+		for _, e := range existing {
+			if valuesEqual(e, v) {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			existing = append(existing, v)
+		}
+	}
+	return firestorestore.ArrayVal(existing...), nil
+}
+
+func removeAll(cur *firestorestore.Value, arr *firestorestore.ArrayValue) (*firestorestore.Value, error) {
+	var keep []*firestorestore.Value
+	if cur != nil && cur.ArrayValue != nil {
+		for _, e := range cur.ArrayValue.Values {
+			remove := false
+			if arr != nil {
+				for _, r := range arr.Values {
+					if valuesEqual(e, r) {
+						remove = true
+						break
+					}
+				}
+			}
+			if !remove {
+				keep = append(keep, e)
+			}
+		}
+	}
+	return firestorestore.ArrayVal(keep...), nil
+}
+
+func isNumeric(v *firestorestore.Value) bool {
+	return v != nil && (v.IntegerValue != nil || v.DoubleValue != nil)
+}
+
+func clampAdd(a, b int64) int64 {
+	sum := a + b
+	if (b > 0 && sum < a) || (b < 0 && sum > a) {
+		if b > 0 {
+			return 1<<63 - 1
+		}
+		return -1 << 63
+	}
+	return sum
+}
+
+// valueWire renders a Value as a wire-compatible map for writeResults.
+func valueWire(v *firestorestore.Value) map[string]any {
+	if v == nil {
+		return map[string]any{}
+	}
+	b, _ := json.Marshal(v)
+	var m map[string]any
+	json.Unmarshal(b, &m)
+	return m
+}
+
+// writeBatchSize returns the approximate wire size of the writes, enforcing the
+// per-document limit in the process.
+func writeBatchSize(writes []*writeWire) (int, error) {
+	b, err := json.Marshal(writes)
+	if err != nil {
+		return 0, model.NewProviderError("InvalidArgument", "malformed writes", 400)
+	}
+	return len(b), nil
+}

--- a/internal/gcp/provider/firestore/commit_test.go
+++ b/internal/gcp/provider/firestore/commit_test.go
@@ -1,0 +1,96 @@
+package firestore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+	"jaiscloud/internal/model"
+)
+
+func assertProviderError(t *testing.T, err error, httpStatus int, status string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error (HTTP %d, status %q), got nil", httpStatus, status)
+	}
+	var pe *model.ProviderError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *model.ProviderError, got %T: %v", err, err)
+	}
+	if pe.HTTPStatus != httpStatus {
+		t.Fatalf("expected HTTP %d, got %d", httpStatus, pe.HTTPStatus)
+	}
+	if status != "" && pe.Status != status {
+		t.Fatalf("expected status %q, got %q", status, pe.Status)
+	}
+}
+
+func TestTransactionMissingReadAbortsOnConcurrentCreate(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	name := "projects/proj/databases/(default)/documents/cities/SF"
+
+	resp, err := p.BeginTransaction(ctx, testNR())
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	txnID, _ := resp.Data["transaction"].(string)
+	if txnID == "" {
+		t.Fatal("expected a non-empty transaction id")
+	}
+
+	// Read a missing document inside the transaction → NOT_FOUND.
+	getNR := testNR()
+	getNR.Params["name"] = "databases/(default)/documents/cities/SF"
+	getNR.Params["transaction"] = txnID
+	if _, err := p.DocumentsGet(ctx, getNR); err == nil {
+		t.Fatal("expected NOT_FOUND for missing doc")
+	} else {
+		assertProviderError(t, err, 404, "")
+	}
+
+	// Create the document outside the transaction.
+	if err := p.store.CreateDocument(ctx, firestorestore.Document{
+		Name:   name,
+		Fields: map[string]*firestorestore.Value{"a": intField(1)},
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Commit a write in the transaction → ABORTED @409.
+	commitNR := testNR()
+	commitNR.Params["body"] = map[string]any{
+		"transaction": txnID,
+		"writes": []any{
+			map[string]any{
+				"update": map[string]any{
+					"name":   name,
+					"fields": map[string]any{"b": map[string]any{"integerValue": "2"}},
+				},
+			},
+		},
+	}
+	if _, err := p.Commit(ctx, commitNR); err == nil {
+		t.Fatal("expected ABORTED for concurrent create after missing read")
+	} else {
+		assertProviderError(t, err, 409, "ABORTED")
+	}
+}
+
+func TestDocumentsGetMissingWithoutTransaction(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+
+	nr := testNR()
+	nr.Params["name"] = "databases/(default)/documents/cities/MISSING"
+	if _, err := p.DocumentsGet(ctx, nr); err == nil {
+		t.Fatal("expected NOT_FOUND for missing doc")
+	} else {
+		assertProviderError(t, err, 404, "")
+	}
+
+	if len(p.readSets) != 0 {
+		t.Fatalf("expected no read-set entries, got %d", len(p.readSets))
+	}
+}

--- a/internal/gcp/provider/firestore/firestore.go
+++ b/internal/gcp/provider/firestore/firestore.go
@@ -1,0 +1,656 @@
+// Package firestore implements the Cloud Firestore provider (document CRUD) on
+// top of the dedicated FirestoreStore. This is the DynamoDB analogue: documents
+// are schemaless, and collections are implicit path segments (no CreateTable/DDL).
+//
+// Slice 1 implements documents.get / createDocument / patch / delete over the
+// REST/JSON surface. runQuery (StructuredQuery), commit/transactions, and
+// composite-index enforcement are TODO(slice-2).
+package firestore
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"jaiscloud/internal/clock"
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+	"jaiscloud/internal/model"
+	"jaiscloud/internal/provider"
+	"jaiscloud/internal/store"
+)
+
+const (
+	// maxDocumentSize is the Firestore per-document limit (1 MiB).
+	maxDocumentSize = 1 << 20 // 1,048,576 bytes
+	// maxFieldNameBytes is the per-field-name byte limit (document.proto).
+	maxFieldNameBytes = 1500
+	// maxStringBytes is the per-stringValue/bytesValue byte limit (1 MiB − 89).
+	maxStringBytes = (1 << 20) - 89 // 1,048,487 bytes
+	// autoIDLength is the length of a server-generated document ID.
+	autoIDLength = 20
+)
+
+// autoIDAlphabet is the alphabet Firestore uses for auto-generated document IDs.
+const autoIDAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+
+// reservedNameRe matches reserved field names / document IDs (^__.*__$).
+var reservedNameRe = regexp.MustCompile(`^__.*__$`)
+
+// Provider implements the Firestore documents REST surface.
+type Provider struct {
+	store firestorestore.FirestoreStore
+	// resources holds the composite-index registry (control plane), scoped by
+	// project (AccountID) and encoded as "firestore_index" ResourceEntries.
+	resources store.ResourceStore
+
+	// txnMu guards readSets: the in-memory transaction read-set registry
+	// (transactions are ephemeral and never persisted).
+	txnMu    sync.Mutex
+	readSets map[string]*readSet
+}
+
+// New returns a Firestore provider backed by the given document store and
+// control-plane resource store (for composite indexes).
+func New(s firestorestore.FirestoreStore, resources store.ResourceStore) *Provider {
+	return &Provider{
+		store:     s,
+		resources: resources,
+		readSets:  make(map[string]*readSet),
+	}
+}
+
+func (p *Provider) Routes() map[string]provider.HandlerFunc {
+	return map[string]provider.HandlerFunc{
+		"Firestore.GetDocument":       p.DocumentsGet,
+		"Firestore.CreateDocument":    p.CreateDocument,
+		"Firestore.PatchDocument":     p.DocumentsPatch,
+		"Firestore.DeleteDocument":    p.DocumentsDelete,
+		"Firestore.ListDocuments":     p.ListDocuments,
+		"Firestore.ListCollectionIds": p.ListCollectionIds,
+		"Firestore.RunQuery":          p.RunQuery,
+		"Firestore.Commit":            p.Commit,
+		"Firestore.BatchWrite":        p.BatchWrite,
+		"Firestore.BatchGet":          p.BatchGet,
+		"Firestore.BeginTransaction":  p.BeginTransaction,
+		"Firestore.Rollback":          p.Rollback,
+		"Firestore.CreateIndex":       p.CreateIndex,
+		"Firestore.ListIndexes":       p.ListIndexes,
+		"Firestore.GetIndex":          p.GetIndex,
+		"Firestore.DeleteIndex":       p.DeleteIndex,
+	}
+}
+
+// Reset clears transaction read-sets (document state is reset via the store's
+// own Resetter; index state via the resource store's).
+func (p *Provider) Reset(_ context.Context) {
+	p.txnMu.Lock()
+	p.readSets = make(map[string]*readSet)
+	p.txnMu.Unlock()
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+// relativeName returns the database id and relative document path encoded in
+// nr.Params["name"] ("databases/{db}/documents/{path}").
+func relativeName(nr *model.NormalizedRequest) (database, path string, err error) {
+	name, _ := nr.Params["name"].(string)
+	parts := strings.Split(name, "/")
+	if len(parts) < 3 || parts[0] != "databases" || parts[2] != "documents" {
+		return "", "", model.NewProviderError("InvalidArgument", "invalid document path", 400)
+	}
+	return parts[1], strings.Join(parts[3:], "/"), nil
+}
+
+// fullName builds the full document resource name from the request.
+func fullName(nr *model.NormalizedRequest, database, path string) string {
+	return nr.ResourceID("firestore-document", "databases/"+database+"/documents/"+path)
+}
+
+// mapStoreError maps store sentinel errors to Firestore GCP error envelopes.
+//
+// TODO(slice-2): surface precondition failures as HTTP 400 FAILED_PRECONDITION
+// and transaction contention as HTTP 409 ABORTED. Those require a per-error
+// RPC-status override on the shared JSONCodec envelope (the envelope currently
+// derives `status` from the HTTP code).
+func mapStoreError(err error) error {
+	switch {
+	case errors.Is(err, firestorestore.ErrDocumentNotFound):
+		return model.NewProviderError("NotFound", "document not found", 404)
+	case errors.Is(err, firestorestore.ErrDocumentExists):
+		return model.NewProviderError("AlreadyExists", "document already exists", 409)
+	case errors.Is(err, firestorestore.ErrInvalidArgument):
+		return model.NewProviderError("InvalidArgument", "invalid document", 400)
+	default:
+		return err
+	}
+}
+
+// extractFields extracts the document fields from a decoded request body.
+func extractFields(body map[string]any) (map[string]*firestorestore.Value, error) {
+	if body == nil {
+		return map[string]*firestorestore.Value{}, nil
+	}
+	raw, ok := body["fields"]
+	if !ok || raw == nil {
+		return map[string]*firestorestore.Value{}, nil
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil, model.NewProviderError("InvalidArgument", "malformed fields", 400)
+	}
+	var fields map[string]*firestorestore.Value
+	if err := json.Unmarshal(b, &fields); err != nil {
+		return nil, model.NewProviderError("InvalidArgument", "malformed field value", 400)
+	}
+	return fields, nil
+}
+
+// validatePath rejects reserved collection/document IDs (^__.*__$) in a
+// relative document path.
+func validatePath(path string) error {
+	if path == "" {
+		return nil
+	}
+	for _, seg := range strings.Split(path, "/") {
+		if reservedNameRe.MatchString(seg) {
+			return model.NewProviderError("InvalidArgument", "collection or document id "+seg+" is reserved", 400)
+		}
+	}
+	return nil
+}
+
+// validateDocumentID enforces Firestore document-id constraints: no '/' (the
+// hierarchy separator) and no reserved ^__.*__$ prefix/suffix.
+func validateDocumentID(id string) error {
+	if strings.Contains(id, "/") {
+		return model.NewProviderError("InvalidArgument", "document id must not contain '/'", 400)
+	}
+	if reservedNameRe.MatchString(id) {
+		return model.NewProviderError("InvalidArgument", "document id "+id+" is reserved", 400)
+	}
+	return nil
+}
+
+// validateFields rejects reserved field names (^__.*__$) anywhere in the field
+// tree.
+func validateFields(fields map[string]*firestorestore.Value) error {
+	for k, v := range fields {
+		if reservedNameRe.MatchString(k) {
+			return model.NewProviderError("InvalidArgument", "field name "+k+" is reserved", 400)
+		}
+		if err := validateValue(v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateValue(v *firestorestore.Value) error {
+	if v == nil {
+		return nil
+	}
+	if v.MapValue != nil {
+		for k, cv := range v.MapValue.Fields {
+			if reservedNameRe.MatchString(k) {
+				return model.NewProviderError("InvalidArgument", "field name "+k+" is reserved", 400)
+			}
+			if err := validateValue(cv); err != nil {
+				return err
+			}
+		}
+	}
+	if v.ArrayValue != nil {
+		for _, cv := range v.ArrayValue.Values {
+			if err := validateValue(cv); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// checkSize enforces the 1 MiB per-document size limit by serializing the fields,
+// and the per-field limits (field-name length, string/bytes value caps) via a
+// recursive value-tree walk.
+func checkSize(fields map[string]*firestorestore.Value) error {
+	if err := checkFieldLimits(fields); err != nil {
+		return err
+	}
+	b, err := json.Marshal(fields)
+	if err != nil {
+		return model.NewProviderError("InvalidArgument", "malformed document fields", 400)
+	}
+	if len(b) > maxDocumentSize {
+		return model.NewProviderError("InvalidArgument", "document exceeds maximum size of 1 MiB", 400)
+	}
+	return nil
+}
+
+// checkFieldLimits walks the Value tree (top-level fields, nested mapValue.fields,
+// arrayValue.values) enforcing the per-field limits: a field name must be
+// non-empty and ≤ 1,500 UTF-8 bytes; a stringValue/bytesValue must be
+// ≤ 1 MiB − 89 bytes.
+func checkFieldLimits(fields map[string]*firestorestore.Value) error {
+	for k, v := range fields {
+		if err := checkFieldName(k); err != nil {
+			return err
+		}
+		if err := checkValueLimits(v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkFieldName(k string) error {
+	if k == "" {
+		return model.NewProviderError("InvalidArgument", "field name must not be empty", 400)
+	}
+	if len(k) > maxFieldNameBytes {
+		return model.NewProviderError("InvalidArgument", "field name exceeds maximum size of 1500 bytes", 400)
+	}
+	return nil
+}
+
+func checkValueLimits(v *firestorestore.Value) error {
+	if v == nil {
+		return nil
+	}
+	if v.StringValue != nil && len(*v.StringValue) > maxStringBytes {
+		return model.NewProviderError("InvalidArgument", "string value exceeds maximum size of 1048487 bytes", 400)
+	}
+	if v.BytesValue != nil && len(v.BytesValue) > maxStringBytes {
+		return model.NewProviderError("InvalidArgument", "bytes value exceeds maximum size of 1048487 bytes", 400)
+	}
+	if v.MapValue != nil {
+		for k, cv := range v.MapValue.Fields {
+			if err := checkFieldName(k); err != nil {
+				return err
+			}
+			if err := checkValueLimits(cv); err != nil {
+				return err
+			}
+		}
+	}
+	if v.ArrayValue != nil {
+		for _, cv := range v.ArrayValue.Values {
+			if err := checkValueLimits(cv); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// randomID generates a Firestore-style auto-ID of n characters.
+func randomID(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return strings.Repeat("0", n)
+	}
+	for i := range b {
+		b[i] = autoIDAlphabet[int(b[i])%len(autoIDAlphabet)]
+	}
+	return string(b)
+}
+
+// queryFieldPaths returns the field paths for a repeated query parameter (e.g.
+// "mask.fieldPaths", "updateMask.fieldPaths"), honouring repeated and
+// comma-separated values.
+func queryFieldPaths(nr *model.NormalizedRequest, key string) []string {
+	var paths []string
+	add := func(v string) {
+		for _, part := range strings.Split(v, ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				paths = append(paths, part)
+			}
+		}
+	}
+	if nr.Raw != nil {
+		for _, v := range nr.Raw.URL.Query()[key] {
+			add(v)
+		}
+	}
+	if len(paths) == 0 {
+		if v, _ := nr.Params[key].(string); v != "" {
+			add(v)
+		}
+	}
+	return paths
+}
+
+// updateMaskPaths returns the updateMask field paths, honouring repeated and
+// comma-separated updateMask.fieldPaths query parameters.
+func updateMaskPaths(nr *model.NormalizedRequest) []string {
+	return queryFieldPaths(nr, "updateMask.fieldPaths")
+}
+
+// maskFieldPaths returns the mask field paths (mask.fieldPaths query parameter).
+func maskFieldPaths(nr *model.NormalizedRequest) []string {
+	return queryFieldPaths(nr, "mask.fieldPaths")
+}
+
+// preconditionFromQuery parses the currentDocument precondition query parameters
+// (currentDocument.exists / currentDocument.updateTime) used by patch/delete.
+// It returns nil when no precondition is set.
+func preconditionFromQuery(nr *model.NormalizedRequest) (*firestorestore.Precondition, error) {
+	pre := &firestorestore.Precondition{}
+	if s, _ := nr.Params["currentDocument.exists"].(string); s != "" {
+		v, err := strconv.ParseBool(s)
+		if err != nil {
+			return nil, model.NewProviderError("InvalidArgument", "invalid currentDocument.exists precondition", 400)
+		}
+		pre.Exists = &v
+	}
+	if s, _ := nr.Params["currentDocument.updateTime"].(string); s != "" {
+		t, err := time.Parse(time.RFC3339Nano, s)
+		if err != nil {
+			return nil, model.NewProviderError("InvalidArgument", "invalid currentDocument.updateTime precondition", 400)
+		}
+		pre.UpdateTime = &t
+	}
+	if pre.Exists == nil && pre.UpdateTime == nil {
+		return nil, nil
+	}
+	return pre, nil
+}
+
+// checkPrecondition validates a document precondition against the current state
+// (exists and updateTime). It returns a FAILED_PRECONDITION error on mismatch.
+func checkPrecondition(exists bool, updateTime time.Time, pre *firestorestore.Precondition) error {
+	if pre == nil {
+		return nil
+	}
+	if pre.Exists != nil {
+		if *pre.Exists != exists {
+			return newPreconditionErr("precondition failed: document existence does not match")
+		}
+		return nil
+	}
+	if pre.UpdateTime != nil {
+		if !exists || !updateTime.Equal(*pre.UpdateTime) {
+			return newPreconditionErr("precondition failed: updateTime does not match")
+		}
+	}
+	return nil
+}
+
+// maskFields projects a document's fields down to the given field paths. A path
+// not present in the document is omitted; "__name__" is always implicit and
+// skipped (the name is carried on the wire independently).
+func maskFields(doc firestorestore.Document, paths []string) map[string]*firestorestore.Value {
+	out := map[string]*firestorestore.Value{}
+	for _, fp := range paths {
+		if fp == "__name__" {
+			continue
+		}
+		if v := fieldValue(&doc, fp); v != nil {
+			setFieldPath(out, strings.Split(fp, "."), v)
+		}
+	}
+	return out
+}
+
+// applyMask merges body fields into a document's fields per Firestore patch
+// semantics:
+//   - no mask: the body fields fully replace the document's fields.
+//   - mask present: only the field paths in the mask are updated; a mask path
+//     not present in the body is deleted; fields outside the mask are unchanged.
+//
+// base is the existing fields (nil when the document is being created).
+func applyMask(fields map[string]*firestorestore.Value, mask []string, base map[string]*firestorestore.Value) map[string]*firestorestore.Value {
+	if len(mask) == 0 {
+		out := make(map[string]*firestorestore.Value, len(fields))
+		for k, v := range fields {
+			out[k] = v
+		}
+		return out
+	}
+	out := make(map[string]*firestorestore.Value, len(base)+len(mask))
+	for k, v := range base {
+		out[k] = v
+	}
+	for _, fp := range mask {
+		parts := strings.Split(fp, ".")
+		if len(parts) == 1 {
+			if v, ok := fields[parts[0]]; ok {
+				out[parts[0]] = v
+			} else {
+				delete(out, parts[0])
+			}
+			continue
+		}
+		// Nested path: extract the leaf value from the body subtree.
+		leaf := valueAt(fields[parts[0]], parts[1:])
+		setFieldPath(out, parts, leaf)
+	}
+	return out
+}
+
+// valueAt returns the value at the dotted field path within a mapValue, or nil.
+func valueAt(v *firestorestore.Value, path []string) *firestorestore.Value {
+	cur := v
+	for _, p := range path {
+		if cur == nil || cur.MapValue == nil {
+			return nil
+		}
+		cur = cur.MapValue.Fields[p]
+	}
+	return cur
+}
+
+// setFieldPath sets (or deletes, when val is nil) the field at the dotted path,
+// creating intermediate mapValues as needed.
+func setFieldPath(fields map[string]*firestorestore.Value, path []string, val *firestorestore.Value) {
+	if len(path) == 1 {
+		if val == nil {
+			delete(fields, path[0])
+		} else {
+			fields[path[0]] = val
+		}
+		return
+	}
+	cur, ok := fields[path[0]]
+	if !ok || cur == nil || cur.MapValue == nil {
+		if val == nil {
+			return // nothing to delete
+		}
+		cur = firestorestore.MapVal(map[string]*firestorestore.Value{})
+		fields[path[0]] = cur
+	}
+	setFieldPath(cur.MapValue.Fields, path[1:], val)
+}
+
+// documentMap serialises a store Document to its REST wire form.
+func documentMap(d firestorestore.Document) map[string]any {
+	b, _ := json.Marshal(d)
+	var m map[string]any
+	json.Unmarshal(b, &m)
+	return m
+}
+
+// ─── documents methods ────────────────────────────────────────────────────────
+
+// DocumentsGet implements documents.get.
+func (p *Provider) DocumentsGet(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	database, path, err := relativeName(nr)
+	if err != nil {
+		return nil, err
+	}
+	name := fullName(nr, database, path)
+	doc, err := p.store.GetDocument(ctx, name)
+	if err != nil {
+		if txnID, _ := nr.Params["transaction"].(string); txnID != "" && errors.Is(err, firestorestore.ErrDocumentNotFound) {
+			p.recordRead(txnID, name, firestorestore.Document{}, false)
+		}
+		return nil, mapStoreError(err)
+	}
+	if txnID, _ := nr.Params["transaction"].(string); txnID != "" {
+		p.recordRead(txnID, name, doc, true)
+	}
+	if mask := maskFieldPaths(nr); len(mask) > 0 {
+		doc.Fields = maskFields(doc, mask)
+	}
+	return provider.OK(documentMap(doc)), nil
+}
+
+// CreateDocument implements documents.createDocument. The document id comes
+// from ?documentId=; when omitted the server generates a 20-character auto-ID
+// and returns it in the response name.
+func (p *Provider) CreateDocument(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	database, path, err := relativeName(nr)
+	if err != nil {
+		return nil, err
+	}
+	if err := validatePath(path); err != nil {
+		return nil, err
+	}
+
+	docID, _ := nr.Params["documentId"].(string)
+	if docID == "" {
+		docID = randomID(autoIDLength)
+	} else if err := validateDocumentID(docID); err != nil {
+		return nil, err
+	}
+
+	name := fullName(nr, database, path+"/"+docID)
+
+	body, _ := nr.Params["body"].(map[string]any)
+	fields, err := extractFields(body)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateFields(fields); err != nil {
+		return nil, err
+	}
+	if err := checkSize(fields); err != nil {
+		return nil, err
+	}
+
+	now := clock.Now()
+	doc := firestorestore.Document{
+		Name:       name,
+		Fields:     fields,
+		CreateTime: now,
+		UpdateTime: now,
+	}
+	if err := p.store.CreateDocument(ctx, doc); err != nil {
+		return nil, mapStoreError(err)
+	}
+	return provider.OK(documentMap(doc)), nil
+}
+
+// DocumentsPatch implements documents.patch. Patch upserts: a missing document
+// is created. The updateMask (updateMask.fieldPaths) restricts which fields are
+// updated; without it the body fields fully replace the document's fields.
+func (p *Provider) DocumentsPatch(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	database, path, err := relativeName(nr)
+	if err != nil {
+		return nil, err
+	}
+	if err := validatePath(path); err != nil {
+		return nil, err
+	}
+	name := fullName(nr, database, path)
+
+	body, _ := nr.Params["body"].(map[string]any)
+	fields, err := extractFields(body)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateFields(fields); err != nil {
+		return nil, err
+	}
+
+	mask := maskFieldPaths(nr)
+	if len(mask) == 0 {
+		mask = updateMaskPaths(nr)
+	}
+	pre, err := preconditionFromQuery(nr)
+	if err != nil {
+		return nil, err
+	}
+	now := clock.Now()
+
+	existing, err := p.store.GetDocument(ctx, name)
+	exists := err == nil
+	if err != nil && !errors.Is(err, firestorestore.ErrDocumentNotFound) {
+		return nil, err
+	}
+
+	// Optimistic precondition check (currentDocument.exists / updateTime).
+	if exists {
+		if err := checkPrecondition(true, existing.UpdateTime, pre); err != nil {
+			return nil, err
+		}
+	} else if err := checkPrecondition(false, time.Time{}, pre); err != nil {
+		return nil, err
+	}
+
+	var base map[string]*firestorestore.Value
+	createTime := now
+	if exists {
+		base = existing.Fields
+		createTime = existing.CreateTime
+	}
+	merged := applyMask(fields, mask, base)
+	if err := checkSize(merged); err != nil {
+		return nil, err
+	}
+	doc := firestorestore.Document{
+		Name:       name,
+		Fields:     merged,
+		CreateTime: createTime,
+		UpdateTime: now,
+	}
+	if exists {
+		if err := p.store.UpdateDocument(ctx, doc); err != nil {
+			return nil, mapStoreError(err)
+		}
+	} else {
+		if err := p.store.CreateDocument(ctx, doc); err != nil {
+			return nil, mapStoreError(err)
+		}
+	}
+	return provider.OK(documentMap(doc)), nil
+}
+
+// DocumentsDelete implements documents.delete. Idempotent, unless a
+// currentDocument precondition is set (then it is validated first).
+func (p *Provider) DocumentsDelete(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	database, path, err := relativeName(nr)
+	if err != nil {
+		return nil, err
+	}
+	name := fullName(nr, database, path)
+
+	pre, err := preconditionFromQuery(nr)
+	if err != nil {
+		return nil, err
+	}
+	if pre != nil {
+		existing, err := p.store.GetDocument(ctx, name)
+		exists := err == nil
+		if err != nil && !errors.Is(err, firestorestore.ErrDocumentNotFound) {
+			return nil, err
+		}
+		var updateTime time.Time
+		if exists {
+			updateTime = existing.UpdateTime
+		}
+		if err := checkPrecondition(exists, updateTime, pre); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := p.store.DeleteDocument(ctx, name); err != nil {
+		return nil, mapStoreError(err)
+	}
+	return provider.OK(map[string]any{}), nil
+}

--- a/internal/gcp/provider/firestore/firestore_test.go
+++ b/internal/gcp/provider/firestore/firestore_test.go
@@ -1,0 +1,275 @@
+package firestore
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+	"jaiscloud/internal/model"
+)
+
+func newTestProvider() *Provider {
+	return New(firestorestore.NewMemoryStore(), nil)
+}
+
+func testNR() *model.NormalizedRequest {
+	return &model.NormalizedRequest{
+		AccountID: "proj",
+		Params:    map[string]any{},
+		ResourceID: func(rt, n string) string {
+			return "projects/proj/" + n
+		},
+	}
+}
+
+func patchNR() *model.NormalizedRequest {
+	nr := testNR()
+	nr.Params["name"] = "databases/(default)/documents/cities/SF"
+	nr.Params["body"] = map[string]any{
+		"fields": map[string]any{
+			"name": map[string]any{"stringValue": "SF"},
+		},
+	}
+	return nr
+}
+
+func assertPreconditionErr(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected FAILED_PRECONDITION error, got nil")
+	}
+	var pe *model.ProviderError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *model.ProviderError, got %T: %v", err, err)
+	}
+	if pe.HTTPStatus != 400 || pe.Status != "FAILED_PRECONDITION" {
+		t.Fatalf("expected FAILED_PRECONDITION@400, got HTTP=%d status=%q", pe.HTTPStatus, pe.Status)
+	}
+}
+
+func assertInvalidArgumentErr(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected INVALID_ARGUMENT error, got nil")
+	}
+	var pe *model.ProviderError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *model.ProviderError, got %T: %v", err, err)
+	}
+	if pe.HTTPStatus != 400 || pe.Code != "InvalidArgument" {
+		t.Fatalf("expected InvalidArgument@400, got HTTP=%d code=%q", pe.HTTPStatus, pe.Code)
+	}
+}
+
+func TestDocumentsPatchPrecondition(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	name := "projects/proj/databases/(default)/documents/cities/SF"
+
+	// Seed a document.
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	if err := p.store.CreateDocument(ctx, firestorestore.Document{
+		Name: name, Fields: map[string]*firestorestore.Value{"a": intField(1)}, CreateTime: now, UpdateTime: now,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// exists=false on a present doc → FAILED_PRECONDITION.
+	nr := patchNR()
+	nr.Params["currentDocument.exists"] = "false"
+	_, err := p.DocumentsPatch(ctx, nr)
+	assertPreconditionErr(t, err)
+
+	// stale updateTime → FAILED_PRECONDITION.
+	nr = patchNR()
+	nr.Params["currentDocument.updateTime"] = now.Add(-time.Hour).Format(time.RFC3339Nano)
+	_, err = p.DocumentsPatch(ctx, nr)
+	assertPreconditionErr(t, err)
+
+	// exists=true on a missing doc → FAILED_PRECONDITION.
+	nr = patchNR()
+	nr.Params["name"] = "databases/(default)/documents/cities/MISSING"
+	nr.Params["currentDocument.exists"] = "true"
+	_, err = p.DocumentsPatch(ctx, nr)
+	assertPreconditionErr(t, err)
+
+	// matching updateTime → succeeds.
+	nr = patchNR()
+	nr.Params["currentDocument.updateTime"] = now.Format(time.RFC3339Nano)
+	resp, err := p.DocumentsPatch(ctx, nr)
+	if err != nil {
+		t.Fatalf("patch with matching updateTime: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected a response")
+	}
+}
+
+func TestDocumentsPatchMask(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	name := "projects/proj/databases/(default)/documents/cities/SF"
+
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	if err := p.store.CreateDocument(ctx, firestorestore.Document{
+		Name: name,
+		Fields: map[string]*firestorestore.Value{
+			"a": intField(1),
+			"b": intField(2),
+		},
+		CreateTime: now, UpdateTime: now,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	nr := testNR()
+	nr.Params["name"] = "databases/(default)/documents/cities/SF"
+	nr.Params["body"] = map[string]any{
+		"fields": map[string]any{
+			"a": map[string]any{"integerValue": "99"},
+		},
+	}
+	nr.Params["mask.fieldPaths"] = "a"
+
+	resp, err := p.DocumentsPatch(ctx, nr)
+	if err != nil {
+		t.Fatalf("patch with mask: %v", err)
+	}
+	m, _ := resp.Data["fields"].(map[string]any)
+	if _, ok := m["a"]; !ok {
+		t.Errorf("expected field a to be present, got %+v", m)
+	}
+	if _, ok := m["b"]; !ok {
+		t.Errorf("field b should be untouched by mask, got %+v", m)
+	}
+}
+
+func TestDocumentsDeletePrecondition(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	name := "projects/proj/databases/(default)/documents/cities/SF"
+
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	if err := p.store.CreateDocument(ctx, firestorestore.Document{
+		Name: name, Fields: map[string]*firestorestore.Value{"a": intField(1)}, CreateTime: now, UpdateTime: now,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// exists=false on a present doc → FAILED_PRECONDITION.
+	nr := testNR()
+	nr.Params["name"] = "databases/(default)/documents/cities/SF"
+	nr.Params["currentDocument.exists"] = "false"
+	_, err := p.DocumentsDelete(ctx, nr)
+	assertPreconditionErr(t, err)
+
+	// stale updateTime → FAILED_PRECONDITION.
+	nr = testNR()
+	nr.Params["name"] = "databases/(default)/documents/cities/SF"
+	nr.Params["currentDocument.updateTime"] = now.Add(-time.Hour).Format(time.RFC3339Nano)
+	_, err = p.DocumentsDelete(ctx, nr)
+	assertPreconditionErr(t, err)
+
+	// exists=true on a missing doc → FAILED_PRECONDITION.
+	nr = testNR()
+	nr.Params["name"] = "databases/(default)/documents/cities/MISSING"
+	nr.Params["currentDocument.exists"] = "true"
+	_, err = p.DocumentsDelete(ctx, nr)
+	assertPreconditionErr(t, err)
+
+	// matching updateTime → succeeds.
+	nr = testNR()
+	nr.Params["name"] = "databases/(default)/documents/cities/SF"
+	nr.Params["currentDocument.updateTime"] = now.Format(time.RFC3339Nano)
+	if _, err := p.DocumentsDelete(ctx, nr); err != nil {
+		t.Fatalf("delete with matching updateTime: %v", err)
+	}
+}
+
+func TestDocumentsGetMask(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	name := "projects/proj/databases/(default)/documents/cities/SF"
+
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	if err := p.store.CreateDocument(ctx, firestorestore.Document{
+		Name: name,
+		Fields: map[string]*firestorestore.Value{
+			"a": intField(1),
+			"b": intField(2),
+		},
+		CreateTime: now, UpdateTime: now,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	nr := testNR()
+	nr.Params["name"] = "databases/(default)/documents/cities/SF"
+	nr.Params["mask.fieldPaths"] = "a"
+
+	resp, err := p.DocumentsGet(ctx, nr)
+	if err != nil {
+		t.Fatalf("get with mask: %v", err)
+	}
+	m, _ := resp.Data["fields"].(map[string]any)
+	if _, ok := m["a"]; !ok {
+		t.Errorf("expected field a to be present, got %+v", m)
+	}
+	if _, ok := m["b"]; ok {
+		t.Errorf("field b should be masked out, got %+v", m)
+	}
+}
+
+func TestStringValueSizeLimit(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+
+	// Over the per-field string limit → 400 INVALID_ARGUMENT.
+	tooBig := strings.Repeat("x", maxStringBytes+1)
+	nr := patchNR()
+	nr.Params["body"] = map[string]any{
+		"fields": map[string]any{"s": map[string]any{"stringValue": tooBig}},
+	}
+	if _, err := p.DocumentsPatch(ctx, nr); err == nil {
+		t.Fatal("expected INVALID_ARGUMENT for oversized stringValue")
+	} else {
+		assertInvalidArgumentErr(t, err)
+	}
+
+	// Exactly at the limit → accepted by the field-limit check.
+	atLimit := strings.Repeat("x", maxStringBytes)
+	if err := checkFieldLimits(map[string]*firestorestore.Value{"s": firestorestore.StringVal(atLimit)}); err != nil {
+		t.Fatalf("expected %d-byte stringValue to be accepted, got %v", maxStringBytes, err)
+	}
+}
+
+func TestFieldNameLimits(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+
+	// Empty field name → 400 INVALID_ARGUMENT.
+	nr := patchNR()
+	nr.Params["body"] = map[string]any{
+		"fields": map[string]any{"": map[string]any{"integerValue": "1"}},
+	}
+	if _, err := p.DocumentsPatch(ctx, nr); err == nil {
+		t.Fatal("expected INVALID_ARGUMENT for empty field name")
+	} else {
+		assertInvalidArgumentErr(t, err)
+	}
+
+	// 1,501-byte field name → 400 INVALID_ARGUMENT.
+	longName := strings.Repeat("f", maxFieldNameBytes+1)
+	nr = patchNR()
+	nr.Params["body"] = map[string]any{
+		"fields": map[string]any{longName: map[string]any{"integerValue": "1"}},
+	}
+	if _, err := p.DocumentsPatch(ctx, nr); err == nil {
+		t.Fatal("expected INVALID_ARGUMENT for oversized field name")
+	} else {
+		assertInvalidArgumentErr(t, err)
+	}
+}

--- a/internal/gcp/provider/firestore/indexes.go
+++ b/internal/gcp/provider/firestore/indexes.go
@@ -1,0 +1,266 @@
+package firestore
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"jaiscloud/internal/gcp/paging"
+	"jaiscloud/internal/model"
+	"jaiscloud/internal/provider"
+	"jaiscloud/internal/store"
+)
+
+const rtIndex = "firestore_index"
+
+// indexDef is the persisted GoogleFirestoreAdminV1Index shape (minimal: name,
+// queryScope, fields). Composite indexes only; single-field indexes are
+// implicit and never registered.
+type indexDef struct {
+	Name       string       `json:"name,omitempty"`
+	QueryScope string       `json:"queryScope,omitempty"`
+	Fields     []indexField `json:"fields,omitempty"`
+}
+
+type indexField struct {
+	FieldPath   string `json:"fieldPath,omitempty"`
+	Order       string `json:"order,omitempty"`
+	ArrayConfig string `json:"arrayConfig,omitempty"`
+}
+
+// indexPath parses an index resource name (relative, after the project):
+// "databases/{db}/collectionGroups/{cg}/indexes" (5 segments) or
+// "databases/{db}/collectionGroups/{cg}/indexes/{id}" (6 segments).
+func indexPath(name string) (database, cg, id string, ok bool) {
+	parts := strings.Split(name, "/")
+	if len(parts) < 5 || parts[0] != "databases" || parts[2] != "collectionGroups" || parts[4] != "indexes" {
+		return "", "", "", false
+	}
+	database, cg = parts[1], parts[3]
+	if len(parts) >= 6 {
+		id = parts[5]
+	}
+	return database, cg, id, true
+}
+
+// fullIndexName builds the full index resource name.
+func fullIndexName(nr *model.NormalizedRequest, database, cg, id string) string {
+	return "projects/" + nr.AccountID + "/databases/" + database + "/collectionGroups/" + cg + "/indexes/" + id
+}
+
+// indexRelName builds the resource-store ID (relative index name).
+func indexRelName(database, cg, id string) string {
+	return "databases/" + database + "/collectionGroups/" + cg + "/indexes/" + id
+}
+
+// hasIndex reports whether a composite index covering the ordered required
+// field paths exists for the database.
+func (p *Provider) hasIndex(ctx context.Context, project, database string, required []string) (bool, error) {
+	if p.resources == nil {
+		return false, nil
+	}
+	entries, err := p.resources.List(ctx, project, store.GlobalRegion, rtIndex, "databases/"+database+"/")
+	if err != nil {
+		return false, err
+	}
+	for _, e := range entries {
+		var idx indexDef
+		if json.Unmarshal(e.Data, &idx) != nil {
+			continue
+		}
+		var paths []string
+		for _, f := range idx.Fields {
+			if f.FieldPath != "__name__" {
+				paths = append(paths, f.FieldPath)
+			}
+		}
+		if len(paths) < len(required) {
+			continue
+		}
+		match := true
+		for i, r := range required {
+			if paths[i] != r {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// CreateIndex implements projects.databases.collectionGroups.indexes.create.
+func (p *Provider) CreateIndex(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	name, _ := nr.Params["name"].(string)
+	database, cg, _, ok := indexPath(name)
+	if !ok {
+		return nil, model.NewProviderError("InvalidArgument", "invalid index parent path", 400)
+	}
+
+	body, _ := nr.Params["body"].(map[string]any)
+	b, _ := json.Marshal(body)
+	var idx indexDef
+	if err := json.Unmarshal(b, &idx); err != nil {
+		return nil, model.NewProviderError("InvalidArgument", "malformed index definition", 400)
+	}
+	if len(idx.Fields) < 2 {
+		return nil, model.NewProviderError("InvalidArgument", "a composite index requires at least 2 fields", 400)
+	}
+
+	id := randomHex(12)
+	idx.Name = fullIndexName(nr, database, cg, id)
+	if idx.QueryScope == "" {
+		idx.QueryScope = "COLLECTION"
+	}
+	data, _ := json.Marshal(idx)
+
+	if p.resources != nil {
+		if err := p.resources.Create(ctx, nr.AccountID, store.GlobalRegion, store.ResourceEntry{Type: rtIndex, ID: indexRelName(database, cg, id), Data: data}); err != nil {
+			if errors.Is(err, store.ErrAlreadyExists) {
+				return nil, model.NewProviderError("AlreadyExists", "index already exists", 409)
+			}
+			return nil, err
+		}
+	}
+	// CreateIndex returns a google.longrunning.Operation wrapping the created
+	// index (done=true), not the bare index body.
+	opID := randomHex(12)
+	opName := "projects/" + nr.AccountID + "/databases/" + database + "/operations/" + opID
+	return provider.OK(map[string]any{
+		"name":     opName,
+		"done":     true,
+		"response": indexMap(idx),
+	}), nil
+}
+
+// ListIndexes implements projects.databases.collectionGroups.indexes.list.
+func (p *Provider) ListIndexes(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	name, _ := nr.Params["name"].(string)
+	database, cg, _, ok := indexPath(name)
+	if !ok {
+		return nil, model.NewProviderError("InvalidArgument", "invalid index parent path", 400)
+	}
+	prefix := "databases/" + database + "/collectionGroups/" + cg + "/indexes/"
+	var idxs []indexDef
+	if p.resources != nil {
+		entries, err := p.resources.List(ctx, nr.AccountID, store.GlobalRegion, rtIndex, prefix)
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range entries {
+			var idx indexDef
+			if json.Unmarshal(e.Data, &idx) == nil {
+				idxs = append(idxs, idx)
+			}
+		}
+	}
+	// Optional `filter` query parameter: basic substring match on fieldPath.
+	if f, _ := nr.Params["filter"].(string); f != "" {
+		kept := idxs[:0]
+		for _, idx := range idxs {
+			if indexMatchesFilter(idx, f) {
+				kept = append(kept, idx)
+			}
+		}
+		idxs = kept
+	}
+
+	page, nextToken := paging.Page(idxs, func(d indexDef) string { return d.Name }, nr.Params)
+	items := make([]any, 0, len(page))
+	for _, idx := range page {
+		items = append(items, indexMap(idx))
+	}
+	resp := map[string]any{"indexes": items}
+	if nextToken != "" {
+		resp["nextPageToken"] = nextToken
+	}
+	return provider.OK(resp), nil
+}
+
+// GetIndex implements projects.databases.collectionGroups.indexes.get.
+func (p *Provider) GetIndex(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	name, _ := nr.Params["name"].(string)
+	database, cg, id, ok := indexPath(name)
+	if !ok || id == "" {
+		return nil, model.NewProviderError("InvalidArgument", "invalid index path", 400)
+	}
+	rel := indexRelName(database, cg, id)
+	if p.resources == nil {
+		return nil, model.NewProviderError("NotFound", "index not found", 404)
+	}
+	e, err := p.resources.Get(ctx, nr.AccountID, store.GlobalRegion, rtIndex, rel)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, model.NewProviderError("NotFound", "index not found", 404)
+		}
+		return nil, err
+	}
+	var idx indexDef
+	_ = json.Unmarshal(e.Data, &idx)
+	return provider.OK(indexMap(idx)), nil
+}
+
+// DeleteIndex implements projects.databases.collectionGroups.indexes.delete.
+func (p *Provider) DeleteIndex(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	name, _ := nr.Params["name"].(string)
+	database, cg, id, ok := indexPath(name)
+	if !ok || id == "" {
+		return nil, model.NewProviderError("InvalidArgument", "invalid index path", 400)
+	}
+	if p.resources == nil {
+		return &model.ProviderResponse{HTTPStatus: 200, Data: map[string]any{}}, nil
+	}
+	if err := p.resources.Delete(ctx, nr.AccountID, store.GlobalRegion, rtIndex, indexRelName(database, cg, id)); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, model.NewProviderError("NotFound", "index not found", 404)
+		}
+		return nil, err
+	}
+	return &model.ProviderResponse{HTTPStatus: 200, Data: map[string]any{}}, nil
+}
+
+// indexMap renders an indexDef to its REST wire form.
+func indexMap(idx indexDef) map[string]any {
+	fields := make([]any, 0, len(idx.Fields))
+	for _, f := range idx.Fields {
+		m := map[string]any{"fieldPath": f.FieldPath}
+		if f.Order != "" {
+			m["order"] = f.Order
+		}
+		if f.ArrayConfig != "" {
+			m["arrayConfig"] = f.ArrayConfig
+		}
+		fields = append(fields, m)
+	}
+	return map[string]any{
+		"name":       idx.Name,
+		"queryScope": idx.QueryScope,
+		"state":      "READY",
+		"fields":     fields,
+	}
+}
+
+// indexMatchesFilter reports whether any index field path contains the filter
+// substring (the ListIndexes `filter` parameter).
+func indexMatchesFilter(idx indexDef, filter string) bool {
+	for _, f := range idx.Fields {
+		if strings.Contains(f.FieldPath, filter) {
+			return true
+		}
+	}
+	return false
+}
+
+// randomHex returns a random hex string of the given length.
+func randomHex(n int) string {
+	b := make([]byte, (n+1)/2)
+	if _, err := rand.Read(b); err != nil {
+		return strings.Repeat("0", n)
+	}
+	return hex.EncodeToString(b)[:n]
+}

--- a/internal/gcp/provider/firestore/indexes_test.go
+++ b/internal/gcp/provider/firestore/indexes_test.go
@@ -1,0 +1,145 @@
+package firestore
+
+import (
+	"context"
+	"testing"
+
+	"jaiscloud/internal/model"
+	"jaiscloud/internal/store"
+)
+
+func TestIndexPath(t *testing.T) {
+	cases := []struct {
+		name string
+		want struct {
+			db, cg, id string
+			ok         bool
+		}
+	}{
+		{
+			name: "databases/(default)/collectionGroups/cities/indexes",
+			want: struct {
+				db, cg, id string
+				ok         bool
+			}{"(default)", "cities", "", true},
+		},
+		{
+			name: "databases/(default)/collectionGroups/cities/indexes/abc123",
+			want: struct {
+				db, cg, id string
+				ok         bool
+			}{"(default)", "cities", "abc123", true},
+		},
+		{name: "databases/(default)/collectionGroups/cities", want: struct {
+			db, cg, id string
+			ok         bool
+		}{"", "", "", false}},
+	}
+	for _, tc := range cases {
+		db, cg, id, ok := indexPath(tc.name)
+		if ok != tc.want.ok || db != tc.want.db || cg != tc.want.cg || id != tc.want.id {
+			t.Errorf("indexPath(%q) = (%q,%q,%q,%v), want (%q,%q,%q,%v)",
+				tc.name, db, cg, id, ok, tc.want.db, tc.want.cg, tc.want.id, tc.want.ok)
+		}
+	}
+}
+
+func TestIndexMapState(t *testing.T) {
+	m := indexMap(indexDef{Name: "n", QueryScope: "COLLECTION", Fields: []indexField{{FieldPath: "a", Order: "ASCENDING"}}})
+	if m["state"] != "READY" {
+		t.Errorf("indexMap state = %v, want READY", m["state"])
+	}
+}
+
+func TestCreateIndexReturnsOperation(t *testing.T) {
+	ctx := context.Background()
+	p := New(nil, store.NewMemoryResourceStore())
+
+	nr := &model.NormalizedRequest{
+		AccountID:  "proj",
+		Params:     map[string]any{},
+		ResourceID: func(rt, n string) string { return "projects/proj/" + n },
+	}
+	nr.Params["name"] = "databases/(default)/collectionGroups/cities/indexes"
+	nr.Params["body"] = map[string]any{
+		"queryScope": "COLLECTION",
+		"fields": []any{
+			map[string]any{"fieldPath": "a", "order": "ASCENDING"},
+			map[string]any{"fieldPath": "b", "order": "ASCENDING"},
+		},
+	}
+
+	resp, err := p.CreateIndex(ctx, nr)
+	if err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	if resp.Data["done"] != true {
+		t.Errorf("CreateIndex should return done=true, got %v", resp.Data["done"])
+	}
+	name, _ := resp.Data["name"].(string)
+	if want := "projects/proj/databases/(default)/operations/"; len(name) < len(want) || name[:len(want)] != want {
+		t.Errorf("CreateIndex operation name = %q, want prefix %q", name, want)
+	}
+	respIdx, ok := resp.Data["response"].(map[string]any)
+	if !ok {
+		t.Fatalf("CreateIndex response should contain the created index, got %v", resp.Data["response"])
+	}
+	if respIdx["state"] != "READY" {
+		t.Errorf("created index state = %v, want READY", respIdx["state"])
+	}
+}
+
+func TestListIndexesPaginationAndFilter(t *testing.T) {
+	ctx := context.Background()
+	p := New(nil, store.NewMemoryResourceStore())
+
+	// Seed three indexes.
+	for i, fp := range []string{"a", "b", "c"} {
+		nr := &model.NormalizedRequest{
+			AccountID:  "proj",
+			Params:     map[string]any{},
+			ResourceID: func(rt, n string) string { return "projects/proj/" + n },
+		}
+		nr.Params["name"] = "databases/(default)/collectionGroups/cities/indexes"
+		nr.Params["body"] = map[string]any{
+			"queryScope": "COLLECTION",
+			"fields": []any{
+				map[string]any{"fieldPath": fp, "order": "ASCENDING"},
+				map[string]any{"fieldPath": "x", "order": "ASCENDING"},
+			},
+		}
+		if _, err := p.CreateIndex(ctx, nr); err != nil {
+			t.Fatalf("seed index %d: %v", i, err)
+		}
+	}
+
+	nr := &model.NormalizedRequest{
+		AccountID:  "proj",
+		Params:     map[string]any{"pageSize": "2"},
+		ResourceID: func(rt, n string) string { return "projects/proj/" + n },
+	}
+	nr.Params["name"] = "databases/(default)/collectionGroups/cities/indexes"
+
+	resp, err := p.ListIndexes(ctx, nr)
+	if err != nil {
+		t.Fatalf("ListIndexes: %v", err)
+	}
+	indexes, _ := resp.Data["indexes"].([]any)
+	if len(indexes) != 2 {
+		t.Errorf("expected 2 indexes (pageSize=2), got %d", len(indexes))
+	}
+	if resp.Data["nextPageToken"] == "" {
+		t.Errorf("expected nextPageToken with 3 indexes and pageSize=2")
+	}
+
+	// Filter: substring match on fieldPath.
+	nr.Params["filter"] = "c"
+	resp, err = p.ListIndexes(ctx, nr)
+	if err != nil {
+		t.Fatalf("ListIndexes with filter: %v", err)
+	}
+	indexes, _ = resp.Data["indexes"].([]any)
+	if len(indexes) != 1 {
+		t.Errorf("expected 1 index matching filter 'c', got %d", len(indexes))
+	}
+}

--- a/internal/gcp/provider/firestore/query.go
+++ b/internal/gcp/provider/firestore/query.go
@@ -1,0 +1,873 @@
+package firestore
+
+import (
+	"errors"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+	"jaiscloud/internal/model"
+)
+
+// ─── StructuredQuery wire types ───────────────────────────────────────────────
+//
+// These mirror the Firestore REST wire shapes (StructuredQuery, Filter,
+// FieldFilter, Order, Cursor, Projection, CollectionSelector). Values are the
+// store's Value type, which round-trips the Firestore wire encoding.
+
+type collectionSelector struct {
+	CollectionID   string `json:"collectionId,omitempty"`
+	AllDescendants bool   `json:"allDescendants,omitempty"`
+}
+
+type fieldReference struct {
+	FieldPath string `json:"fieldPath,omitempty"`
+}
+
+type fieldFilter struct {
+	Field fieldReference        `json:"field,omitempty"`
+	Op    string                `json:"op,omitempty"`
+	Value *firestorestore.Value `json:"value,omitempty"`
+}
+
+type compositeFilter struct {
+	Op      string    `json:"op,omitempty"`
+	Filters []*filter `json:"filters,omitempty"`
+}
+
+type filter struct {
+	CompositeFilter *compositeFilter `json:"compositeFilter,omitempty"`
+	FieldFilter     *fieldFilter     `json:"fieldFilter,omitempty"`
+	UnaryFilter     *unaryFilter     `json:"unaryFilter,omitempty"`
+}
+
+type unaryFilter struct {
+	Op    string         `json:"op,omitempty"`
+	Field fieldReference `json:"field,omitempty"`
+}
+
+type order struct {
+	Field     fieldReference `json:"field,omitempty"`
+	Direction string         `json:"direction,omitempty"`
+}
+
+type cursor struct {
+	Values []*firestorestore.Value `json:"values,omitempty"`
+	Before bool                    `json:"before,omitempty"`
+}
+
+type projection struct {
+	Fields []fieldReference `json:"fields,omitempty"`
+}
+
+type structuredQuery struct {
+	From    []collectionSelector `json:"from,omitempty"`
+	Where   *filter              `json:"where,omitempty"`
+	Select  *projection          `json:"select,omitempty"`
+	OrderBy []order              `json:"orderBy,omitempty"`
+	StartAt *cursor              `json:"startAt,omitempty"`
+	EndAt   *cursor              `json:"endAt,omitempty"`
+	Offset  int64                `json:"offset,omitempty"`
+	Limit   int64                `json:"limit,omitempty"`
+}
+
+// ─── query limits ─────────────────────────────────────────────────────────────
+
+const (
+	maxNotInValues    = 10
+	maxInValues       = 30 // IN and ARRAY_CONTAINS_ANY per-filter value limit
+	maxDisjunctions   = 30
+	maxOrderByFields  = 1000
+	maxWriteBatchSize = 500
+	maxTxnBytes       = 10 << 20 // 10 MiB
+)
+
+func isRangeOp(op string) bool {
+	switch op {
+	case "LESS_THAN", "LESS_THAN_OR_EQUAL", "GREATER_THAN", "GREATER_THAN_OR_EQUAL":
+		return true
+	}
+	return false
+}
+
+func isDisjunctiveOp(op string) bool {
+	return op == "IN" || op == "NOT_IN" || op == "ARRAY_CONTAINS_ANY"
+}
+
+// validateFilter walks the filter tree enforcing Firestore operator limits:
+// IN/NOT_IN/ARRAY_CONTAINS_ANY values must be a non-empty array of at most
+// maxInValues values, and the combined disjunction count must not exceed
+// maxDisjunctions.
+func validateFilter(f *filter) error {
+	disjunctions := 1
+	var walk func(f *filter) error
+	walk = func(f *filter) error {
+		if f == nil {
+			return nil
+		}
+		if f.CompositeFilter != nil {
+			if f.CompositeFilter.Op != "AND" && f.CompositeFilter.Op != "OR" {
+				return model.NewProviderError("InvalidArgument", "invalid composite filter operator "+f.CompositeFilter.Op, 400)
+			}
+			for _, c := range f.CompositeFilter.Filters {
+				if err := walk(c); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		if f.FieldFilter != nil {
+			ff := f.FieldFilter
+			if isDisjunctiveOp(ff.Op) {
+				arr, ok := ff.Value.AsArray()
+				if !ok || len(arr) == 0 {
+					return model.NewProviderError("InvalidArgument", ff.Op+" requires a non-empty array value", 400)
+				}
+				limit := maxNotInValues
+				if ff.Op == "IN" || ff.Op == "ARRAY_CONTAINS_ANY" {
+					limit = maxInValues
+				}
+				if len(arr) > limit {
+					return model.NewProviderError("InvalidArgument", ff.Op+" supports at most "+strconv.Itoa(limit)+" values", 400)
+				}
+				disjunctions *= len(arr)
+				if disjunctions > maxDisjunctions {
+					return model.NewProviderError("InvalidArgument", "query exceeds the maximum of "+strconv.Itoa(maxDisjunctions)+" disjunctions", 400)
+				}
+			}
+			return nil
+		}
+		if f.UnaryFilter != nil {
+			uf := f.UnaryFilter
+			switch uf.Op {
+			case "IS_NULL", "IS_NOT_NULL", "IS_NAN", "IS_NOT_NAN":
+			default:
+				return model.NewProviderError("InvalidArgument", "invalid unary filter operator "+uf.Op, 400)
+			}
+			if uf.Field.FieldPath == "__name__" {
+				return model.NewProviderError("InvalidArgument", "unary filter on __name__ is not supported", 400)
+			}
+			return nil
+		}
+		return nil
+	}
+	return walk(f)
+}
+
+// ─── index requirement analysis ───────────────────────────────────────────────
+
+// analyzeQuery determines whether a query requires a composite index and, if so,
+// the ordered list of field paths the index must cover. It also enforces the
+// "inequality field must be the first orderBy field" rule.
+func analyzeQuery(q *structuredQuery) (required []string, err error) {
+	var inequality []string
+	var equality []string
+	var orderFields []string
+
+	appendUnique := func(dst []string, v string) []string {
+		for _, e := range dst {
+			if e == v {
+				return dst
+			}
+		}
+		return append(dst, v)
+	}
+
+	var walk func(f *filter)
+	walk = func(f *filter) {
+		if f == nil {
+			return
+		}
+		if f.CompositeFilter != nil {
+			for _, c := range f.CompositeFilter.Filters {
+				walk(c)
+			}
+			return
+		}
+		if f.FieldFilter != nil {
+			fp := f.FieldFilter.Field.FieldPath
+			if isRangeOp(f.FieldFilter.Op) {
+				inequality = appendUnique(inequality, fp)
+			} else {
+				equality = appendUnique(equality, fp)
+			}
+		}
+	}
+	walk(q.Where)
+
+	for _, o := range q.OrderBy {
+		if o.Field.FieldPath != "__name__" {
+			orderFields = appendUnique(orderFields, o.Field.FieldPath)
+		}
+	}
+
+	// Rule: an inequality field must be the first orderBy field.
+	if len(inequality) > 0 && len(orderFields) > 0 && orderFields[0] != inequality[0] {
+		return nil, model.NewProviderError("InvalidArgument",
+			"the first order-by must be on the same field as the range filter "+inequality[0], 400)
+	}
+
+	// Build the required index as equality-filter leaf fields (in filter order),
+	// then inequality fields, then orderBy fields — deduplicated. Equality fields
+	// are folded into the head before appending orderBy fields so that
+	// `WHERE a==1 ORDER BY b` requires (a,b) and `WHERE a==1 ORDER BY b,c`
+	// requires (a,b,c).
+	for _, f := range equality {
+		required = appendUnique(required, f)
+	}
+	for _, f := range inequality {
+		required = appendUnique(required, f)
+	}
+	for _, f := range orderFields {
+		required = appendUnique(required, f)
+	}
+
+	// A single non-__name__ field never requires a composite index.
+	if len(required) < 2 {
+		required = nil
+	}
+	return required, nil
+}
+
+// ─── value comparison (Firestore type ordering) ───────────────────────────────
+
+// valueKind returns the Firestore type ordering rank. nil is treated as null.
+func valueKind(v *firestorestore.Value) int {
+	if v == nil {
+		return 0 // null
+	}
+	switch {
+	case v.NullValue != nil:
+		return 0
+	case v.BooleanValue != nil:
+		return 1
+	case v.IntegerValue != nil || v.DoubleValue != nil:
+		return 2
+	case v.TimestampValue != nil:
+		return 3
+	case v.StringValue != nil:
+		return 4
+	case v.BytesValue != nil:
+		return 5
+	case v.ReferenceValue != nil:
+		return 6
+	case v.GeoPointValue != nil:
+		return 7
+	case v.ArrayValue != nil:
+		return 8
+	case v.MapValue != nil:
+		return 9
+	}
+	return 0
+}
+
+// numberParts returns a numeric value as (isInt, intPart, floatPart).
+func numberParts(v *firestorestore.Value) (isInt bool, i int64, f float64) {
+	if v == nil {
+		return false, 0, 0
+	}
+	if v.IntegerValue != nil {
+		return true, *v.IntegerValue, 0
+	}
+	if v.DoubleValue != nil {
+		return false, 0, *v.DoubleValue
+	}
+	return false, 0, 0
+}
+
+// compareNumbers compares two numeric Values (integer/double, mixed promoted to
+// double per IEEE 754).
+func compareNumbers(a, b *firestorestore.Value) int {
+	ai, aint, afloat := numberParts(a)
+	bi, bint, bfloat := numberParts(b)
+	if ai && bi {
+		switch {
+		case aint < bint:
+			return -1
+		case aint > bint:
+			return 1
+		}
+		return 0
+	}
+	af := afloat
+	if ai {
+		af = float64(aint)
+	}
+	bf := bfloat
+	if bi {
+		bf = float64(bint)
+	}
+	switch {
+	case af < bf:
+		return -1
+	case af > bf:
+		return 1
+	}
+	return 0
+}
+
+// compareValues returns -1/0/1 per Firestore type ordering. nil is null.
+func compareValues(a, b *firestorestore.Value) int {
+	ka, kb := valueKind(a), valueKind(b)
+	if ka != kb {
+		if ka < kb {
+			return -1
+		}
+		return 1
+	}
+	switch ka {
+	case 0: // null
+		return 0
+	case 1: // bool: false < true
+		av, _ := a.AsBool()
+		bv, _ := b.AsBool()
+		if !av && bv {
+			return -1
+		}
+		if av && !bv {
+			return 1
+		}
+		return 0
+	case 2: // number
+		return compareNumbers(a, b)
+	case 3: // timestamp
+		at, _ := a.AsTimestamp()
+		bt, _ := b.AsTimestamp()
+		return cmpTime(at, bt)
+	case 4: // string
+		as, _ := a.AsString()
+		bs, _ := b.AsString()
+		return strings.Compare(as, bs)
+	case 5: // bytes
+		ab, _ := a.AsBytes()
+		bb, _ := b.AsBytes()
+		return compareBytes(ab, bb)
+	case 6: // reference
+		ar, _ := a.AsReference()
+		br, _ := b.AsReference()
+		return strings.Compare(ar, br)
+	case 7: // geo point (lat then lon)
+		ag, _ := a.AsGeoPoint()
+		bg, _ := b.AsGeoPoint()
+		if c := cmpFloat(ag.Latitude, bg.Latitude); c != 0 {
+			return c
+		}
+		return cmpFloat(ag.Longitude, bg.Longitude)
+	case 8: // array (lexicographic)
+		aa, _ := a.AsArray()
+		ba, _ := b.AsArray()
+		n := len(aa)
+		if len(ba) < n {
+			n = len(ba)
+		}
+		for i := 0; i < n; i++ {
+			if c := compareValues(aa[i], ba[i]); c != 0 {
+				return c
+			}
+		}
+		return cmpInt(len(aa), len(ba))
+	case 9: // map (sorted key lexicographic)
+		am, _ := a.AsMap()
+		bm, _ := b.AsMap()
+		akeys := sortedKeys(am)
+		bkeys := sortedKeys(bm)
+		n := len(akeys)
+		if len(bkeys) < n {
+			n = len(bkeys)
+		}
+		for i := 0; i < n; i++ {
+			if c := strings.Compare(akeys[i], bkeys[i]); c != 0 {
+				return c
+			}
+			if c := compareValues(am[akeys[i]], bm[bkeys[i]]); c != 0 {
+				return c
+			}
+		}
+		return cmpInt(len(akeys), len(bkeys))
+	}
+	return 0
+}
+
+// valuesEqual reports Firestore equality (numbers compare by value across
+// int/double; NaN == NaN; null == null). nil is null.
+func valuesEqual(a, b *firestorestore.Value) bool {
+	if valueKind(a) != valueKind(b) {
+		return false
+	}
+	switch valueKind(a) {
+	case 0:
+		return true
+	case 2:
+		return compareNumbers(a, b) == 0
+	case 8:
+		aa, _ := a.AsArray()
+		ba, _ := b.AsArray()
+		if len(aa) != len(ba) {
+			return false
+		}
+		for i := range aa {
+			if !valuesEqual(aa[i], ba[i]) {
+				return false
+			}
+		}
+		return true
+	case 9:
+		am, _ := a.AsMap()
+		bm, _ := b.AsMap()
+		if len(am) != len(bm) {
+			return false
+		}
+		for k, av := range am {
+			bv, ok := bm[k]
+			if !ok || !valuesEqual(av, bv) {
+				return false
+			}
+		}
+		return true
+	default:
+		return compareValues(a, b) == 0
+	}
+}
+
+func cmpTime(a, b time.Time) int {
+	switch {
+	case a.Before(b):
+		return -1
+	case a.After(b):
+		return 1
+	}
+	return 0
+}
+
+func cmpFloat(a, b float64) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	}
+	return 0
+}
+
+func cmpInt(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	}
+	return 0
+}
+
+func compareBytes(a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] < b[i] {
+			return -1
+		}
+		if a[i] > b[i] {
+			return 1
+		}
+	}
+	return cmpInt(len(a), len(b))
+}
+
+func sortedKeys(m map[string]*firestorestore.Value) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// ─── field access ─────────────────────────────────────────────────────────────
+
+// fieldValue returns the value at a dot-delimited field path, or nil when
+// absent. "__name__" resolves to the document's full name as a reference.
+func fieldValue(doc *firestorestore.Document, fieldPath string) *firestorestore.Value {
+	if fieldPath == "__name__" {
+		return firestorestore.ReferenceVal(doc.Name)
+	}
+	if doc.Fields == nil {
+		return nil
+	}
+	parts := strings.Split(fieldPath, ".")
+	cur, ok := doc.Fields[parts[0]]
+	if !ok {
+		return nil
+	}
+	for _, p := range parts[1:] {
+		if cur == nil || cur.MapValue == nil {
+			return nil
+		}
+		cur = cur.MapValue.Fields[p]
+	}
+	return cur
+}
+
+// ─── filter evaluation ────────────────────────────────────────────────────────
+
+// eval returns whether doc satisfies the Filter tree.
+func eval(doc *firestorestore.Document, f *filter) (bool, error) {
+	if f == nil {
+		return true, nil
+	}
+	if f.CompositeFilter != nil {
+		cf := f.CompositeFilter
+		switch cf.Op {
+		case "AND":
+			for _, c := range cf.Filters {
+				ok, err := eval(doc, c)
+				if err != nil || !ok {
+					return ok, err
+				}
+			}
+			return true, nil
+		case "OR":
+			for _, c := range cf.Filters {
+				ok, err := eval(doc, c)
+				if err != nil {
+					return false, err
+				}
+				if ok {
+					return true, nil
+				}
+			}
+			return false, nil
+		default:
+			return false, errors.New("unsupported composite operator " + cf.Op)
+		}
+	}
+	if f.FieldFilter != nil {
+		return evalFieldFilter(doc, f.FieldFilter)
+	}
+	if f.UnaryFilter != nil {
+		return evalUnaryFilter(doc, f.UnaryFilter), nil
+	}
+	return true, nil
+}
+
+// evalUnaryFilter evaluates a unary filter (IS_NULL/IS_NOT_NULL/IS_NAN/IS_NOT_NAN)
+// against a document. A nil value means the field is absent.
+func evalUnaryFilter(doc *firestorestore.Document, uf *unaryFilter) bool {
+	v := fieldValue(doc, uf.Field.FieldPath)
+	switch uf.Op {
+	case "IS_NULL":
+		return v == nil || v.NullValue != nil
+	case "IS_NOT_NULL":
+		return v != nil && v.NullValue == nil
+	case "IS_NAN":
+		return v != nil && v.DoubleValue != nil && math.IsNaN(*v.DoubleValue)
+	case "IS_NOT_NAN":
+		return !(v != nil && v.DoubleValue != nil && math.IsNaN(*v.DoubleValue))
+	}
+	return false
+}
+
+func evalFieldFilter(doc *firestorestore.Document, ff *fieldFilter) (bool, error) {
+	v := fieldValue(doc, ff.Field.FieldPath)
+	target := ff.Value
+	switch ff.Op {
+	case "EQUAL":
+		return valueMatchesEqual(v, target), nil
+	case "NOT_EQUAL":
+		return !valueMatchesEqual(v, target), nil
+	case "ARRAY_CONTAINS":
+		return arrayContains(v, target), nil
+	case "IN":
+		tv, _ := target.AsArray()
+		return inValues(v, tv), nil
+	case "ARRAY_CONTAINS_ANY":
+		tv, _ := target.AsArray()
+		return arrayContainsAny(v, tv), nil
+	case "NOT_IN":
+		tv, _ := target.AsArray()
+		return !inValues(v, tv), nil
+	case "LESS_THAN":
+		return v != nil && compareValues(v, target) < 0, nil
+	case "LESS_THAN_OR_EQUAL":
+		return v != nil && compareValues(v, target) <= 0, nil
+	case "GREATER_THAN":
+		return v != nil && compareValues(v, target) > 0, nil
+	case "GREATER_THAN_OR_EQUAL":
+		return v != nil && compareValues(v, target) >= 0, nil
+	default:
+		return false, errors.New("unsupported field filter operator " + ff.Op)
+	}
+}
+
+// valueMatchesEqual handles EQUAL semantics: an array document field matches if
+// any element equals the target.
+func valueMatchesEqual(v, target *firestorestore.Value) bool {
+	if v == nil {
+		return false
+	}
+	if v.ArrayValue != nil {
+		for _, e := range v.ArrayValue.Values {
+			if valuesEqual(e, target) {
+				return true
+			}
+		}
+		return false
+	}
+	return valuesEqual(v, target)
+}
+
+// arrayContains reports whether v (an array) contains target.
+func arrayContains(v, target *firestorestore.Value) bool {
+	if v == nil || v.ArrayValue == nil {
+		return false
+	}
+	for _, e := range v.ArrayValue.Values {
+		if valuesEqual(e, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// inValues reports whether v equals any of targets, or (array field) intersects.
+func inValues(v *firestorestore.Value, targets []*firestorestore.Value) bool {
+	if v == nil {
+		return false
+	}
+	if v.ArrayValue != nil {
+		for _, e := range v.ArrayValue.Values {
+			for _, t := range targets {
+				if valuesEqual(e, t) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	for _, t := range targets {
+		if valuesEqual(v, t) {
+			return true
+		}
+	}
+	return false
+}
+
+// arrayContainsAny reports whether array field v intersects targets.
+func arrayContainsAny(v *firestorestore.Value, targets []*firestorestore.Value) bool {
+	if v == nil || v.ArrayValue == nil {
+		return false
+	}
+	for _, e := range v.ArrayValue.Values {
+		for _, t := range targets {
+			if valuesEqual(e, t) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ─── ordering / cursor / projection ───────────────────────────────────────────
+
+// sortDesc encodes the per-field sort directions including the implicit
+// __name__ tie-breaker (same direction as the last order, or ASCENDING).
+func sortDesc(orders []order) []bool {
+	desc := make([]bool, len(orders)+1)
+	for i, o := range orders {
+		desc[i] = o.Direction == "DESCENDING"
+	}
+	desc[len(orders)] = len(orders) > 0 && orders[len(orders)-1].Direction == "DESCENDING"
+	return desc
+}
+
+// docSortKey builds the full sort key for a document: one value per orderBy
+// field (missing → nil/null), then the __name__ reference tie-breaker.
+func docSortKey(doc *firestorestore.Document, orders []order) []*firestorestore.Value {
+	key := make([]*firestorestore.Value, 0, len(orders)+1)
+	for _, o := range orders {
+		key = append(key, fieldValue(doc, o.Field.FieldPath))
+	}
+	key = append(key, firestorestore.ReferenceVal(doc.Name))
+	return key
+}
+
+// compareCursor compares a document's sort key against a cursor position (a
+// prefix of the order-by key), honouring per-field direction.
+func compareCursor(docKey []*firestorestore.Value, cursorVals []*firestorestore.Value, desc []bool) int {
+	for i := 0; i < len(cursorVals) && i < len(docKey); i++ {
+		c := compareValues(docKey[i], cursorVals[i])
+		if c != 0 {
+			if desc[i] {
+				return -c
+			}
+			return c
+		}
+	}
+	return 0
+}
+
+// lessSortKeys compares two full sort keys.
+func lessSortKeys(a, b []*firestorestore.Value, desc []bool) bool {
+	for i := 0; i < len(a) && i < len(b); i++ {
+		c := compareValues(a[i], b[i])
+		if c != 0 {
+			if desc[i] {
+				return c > 0
+			}
+			return c < 0
+		}
+	}
+	return false
+}
+
+// matchesCollection reports whether a document is selected by a collection
+// selector. parent is the runQuery parent resource prefix
+// ("projects/{p}/databases/{db}/documents[/{doc path}]"): collectionId is
+// resolved relative to it. When allDescendants is false the selector matches
+// only the collection that is an immediate child of parent; when true it
+// matches all descendant collections of parent with that ID (collection group).
+func matchesCollection(doc *firestorestore.Document, sel collectionSelector, parent string) bool {
+	if doc.CollectionID != sel.CollectionID {
+		return false
+	}
+	if sel.AllDescendants {
+		return strings.HasPrefix(doc.Name, parent+"/")
+	}
+	return doc.ParentPath == parent+"/"+sel.CollectionID
+}
+
+// executeQuery runs a StructuredQuery over the given documents and returns the
+// matching documents in query order, with projection applied.
+func executeQuery(docs []*firestorestore.Document, q *structuredQuery, parent string) ([]*firestorestore.Document, error) {
+	if err := validateFilter(q.Where); err != nil {
+		return nil, err
+	}
+
+	// from
+	if len(q.From) > 0 {
+		filtered := make([]*firestorestore.Document, 0, len(docs))
+		for _, d := range docs {
+			for _, sel := range q.From {
+				if matchesCollection(d, sel, parent) {
+					filtered = append(filtered, d)
+					break
+				}
+			}
+		}
+		docs = filtered
+	}
+
+	// where
+	if q.Where != nil {
+		filtered := make([]*firestorestore.Document, 0, len(docs))
+		for _, d := range docs {
+			ok, err := eval(d, q.Where)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				filtered = append(filtered, d)
+			}
+		}
+		docs = filtered
+	}
+
+	// orderBy (+ implicit __name__ tie-breaker)
+	desc := sortDesc(q.OrderBy)
+	keyed := make([]sortEntry, 0, len(docs))
+	for _, d := range docs {
+		keyed = append(keyed, sortEntry{doc: d, key: docSortKey(d, q.OrderBy)})
+	}
+	sort.SliceStable(keyed, func(i, j int) bool {
+		return lessSortKeys(keyed[i].key, keyed[j].key, desc)
+	})
+
+	// cursor filtering (startAt / endAt)
+	startIdx := 0
+	endIdx := len(keyed)
+	if q.StartAt != nil {
+		for _, e := range keyed {
+			c := compareCursor(e.key, q.StartAt.Values, desc)
+			before := c < 0
+			if q.StartAt.Before {
+				before = c <= 0
+			}
+			if before {
+				startIdx++
+			} else {
+				break
+			}
+		}
+	}
+	if q.EndAt != nil {
+		for endIdx > startIdx {
+			e := keyed[endIdx-1]
+			c := compareCursor(e.key, q.EndAt.Values, desc)
+			after := c > 0
+			if q.EndAt.Before {
+				after = c >= 0
+			}
+			if after {
+				endIdx--
+			} else {
+				break
+			}
+		}
+	}
+	keyed = keyed[startIdx:endIdx]
+
+	// offset
+	if q.Offset > 0 {
+		if int(q.Offset) >= len(keyed) {
+			keyed = nil
+		} else {
+			keyed = keyed[q.Offset:]
+		}
+	}
+
+	// limit
+	if q.Limit > 0 && int(q.Limit) < len(keyed) {
+		keyed = keyed[:q.Limit]
+	}
+
+	// project (a copy so the original store document is untouched)
+	result := make([]*firestorestore.Document, 0, len(keyed))
+	for _, e := range keyed {
+		d := *e.doc
+		if q.Select != nil && len(q.Select.Fields) > 0 {
+			d.Fields = projectFields(e.doc, q.Select)
+		}
+		result = append(result, &d)
+	}
+	return result, nil
+}
+
+type sortEntry struct {
+	doc *firestorestore.Document
+	key []*firestorestore.Value
+}
+
+// projectFields returns only the projected field paths (a "__name__"-only
+// projection yields an empty fields map; the name is always on the wire).
+func projectFields(doc *firestorestore.Document, proj *projection) map[string]*firestorestore.Value {
+	out := map[string]*firestorestore.Value{}
+	for _, fr := range proj.Fields {
+		if fr.FieldPath == "__name__" {
+			continue
+		}
+		if v := fieldValue(doc, fr.FieldPath); v != nil {
+			setFieldPath(out, strings.Split(fr.FieldPath, "."), v)
+		}
+	}
+	return out
+}
+
+// numericValuesEqual reports whether two Values are numerically equal, used by
+// transforms. Kept for symmetry with Firestore's "equivalent numbers".
+func numericValuesEqual(a, b *firestorestore.Value) bool {
+	return valueKind(a) == valueKind(b) && valueKind(a) == 2 && compareNumbers(a, b) == 0
+}

--- a/internal/gcp/provider/firestore/query_test.go
+++ b/internal/gcp/provider/firestore/query_test.go
@@ -1,0 +1,421 @@
+package firestore
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+)
+
+func doc(name string, fields map[string]*firestorestore.Value) *firestorestore.Document {
+	d := &firestorestore.Document{Name: name, Fields: fields}
+	project, db, path, ok := firestorestore.ParseDocumentName(name)
+	if ok {
+		segs := strings.Split(path, "/")
+		if len(segs) >= 2 {
+			d.CollectionID = segs[len(segs)-2]
+			d.ParentPath = "projects/" + project + "/databases/" + db + "/documents/" + strings.Join(segs[:len(segs)-1], "/")
+		}
+	}
+	return d
+}
+
+func intField(v int64) *firestorestore.Value  { return firestorestore.IntVal(v) }
+func strField(s string) *firestorestore.Value { return firestorestore.StringVal(s) }
+
+func TestEvalFieldFilters(t *testing.T) {
+	d := doc("projects/p/databases/(default)/documents/cities/SF", map[string]*firestorestore.Value{
+		"state": strField("CA"),
+		"pop":   intField(800000),
+		"tags":  firestorestore.ArrayVal(strField("a"), strField("b"), strField("c")),
+		"meta":  firestorestore.MapVal(map[string]*firestorestore.Value{"n": intField(5)}),
+	})
+
+	ff := func(op string, v *firestorestore.Value) *filter {
+		return &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "state"}, Op: op, Value: v}}
+	}
+
+	cases := []struct {
+		name string
+		f    *filter
+		want bool
+	}{
+		{"equal", ff("EQUAL", strField("CA")), true},
+		{"equal miss", ff("EQUAL", strField("NY")), false},
+		{"not_equal", ff("NOT_EQUAL", strField("NY")), true},
+		{"gt", &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "pop"}, Op: "GREATER_THAN", Value: intField(1)}}, true},
+		{"lt miss", &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "pop"}, Op: "LESS_THAN", Value: intField(1)}}, false},
+		{"array_contains", &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "tags"}, Op: "ARRAY_CONTAINS", Value: strField("b")}}, true},
+		{"array_contains miss", &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "tags"}, Op: "ARRAY_CONTAINS", Value: strField("z")}}, false},
+		{"in", &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "state"}, Op: "IN", Value: firestorestore.ArrayVal(strField("CA"), strField("TX"))}}, true},
+		{"not_in", &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "state"}, Op: "NOT_IN", Value: firestorestore.ArrayVal(strField("NY"))}}, true},
+		{"array_contains_any", &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "tags"}, Op: "ARRAY_CONTAINS_ANY", Value: firestorestore.ArrayVal(strField("x"), strField("b"))}}, true},
+		{"nested field", &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "meta.n"}, Op: "EQUAL", Value: intField(5)}}, true},
+		{"nested field miss", &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "meta.n"}, Op: "EQUAL", Value: intField(6)}}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := eval(d, tc.f)
+			if err != nil {
+				t.Fatalf("eval: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("eval = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvalCompositeFilters(t *testing.T) {
+	d := doc("n", map[string]*firestorestore.Value{"a": intField(1), "b": strField("x")})
+
+	andF := &filter{CompositeFilter: &compositeFilter{Op: "AND", Filters: []*filter{
+		{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "a"}, Op: "EQUAL", Value: intField(1)}},
+		{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "b"}, Op: "EQUAL", Value: strField("x")}},
+	}}}
+	if ok, _ := eval(d, andF); !ok {
+		t.Errorf("AND should match")
+	}
+
+	orF := &filter{CompositeFilter: &compositeFilter{Op: "OR", Filters: []*filter{
+		{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "a"}, Op: "EQUAL", Value: intField(99)}},
+		{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "b"}, Op: "EQUAL", Value: strField("x")}},
+	}}}
+	if ok, _ := eval(d, orF); !ok {
+		t.Errorf("OR should match")
+	}
+
+	orMiss := &filter{CompositeFilter: &compositeFilter{Op: "OR", Filters: []*filter{
+		{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "a"}, Op: "EQUAL", Value: intField(99)}},
+		{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "b"}, Op: "EQUAL", Value: strField("nope")}},
+	}}}
+	if ok, _ := eval(d, orMiss); ok {
+		t.Errorf("OR should not match")
+	}
+}
+
+func TestCompareValuesOrdering(t *testing.T) {
+	vals := []*firestorestore.Value{
+		firestorestore.NullVal(),
+		firestorestore.BoolVal(false),
+		firestorestore.BoolVal(true),
+		firestorestore.IntVal(1),
+		firestorestore.DoubleVal(1.5),
+		firestorestore.TimestampVal(mustTime("2026-01-01T00:00:00Z")),
+		firestorestore.StringVal("a"),
+		firestorestore.StringVal("b"),
+		firestorestore.BytesVal([]byte{1}),
+		firestorestore.ReferenceVal("projects/p/databases/(default)/documents/c/d"),
+		firestorestore.GeoPointVal(0, 0),
+		firestorestore.ArrayVal(intField(1)),
+		firestorestore.MapVal(map[string]*firestorestore.Value{"k": intField(1)}),
+	}
+	for i := 1; i < len(vals); i++ {
+		if compareValues(vals[i-1], vals[i]) >= 0 {
+			t.Errorf("expected vals[%d] < vals[%d]", i-1, i)
+		}
+	}
+	// int/double equality across representation.
+	if !valuesEqual(intField(3), firestorestore.DoubleVal(3.0)) {
+		t.Errorf("3 and 3.0 should be equal")
+	}
+}
+
+func TestExecuteQueryOrderingLimitCursor(t *testing.T) {
+	docs := []*firestorestore.Document{
+		doc("projects/p/databases/(default)/documents/cities/a", map[string]*firestorestore.Value{"pop": intField(10)}),
+		doc("projects/p/databases/(default)/documents/cities/b", map[string]*firestorestore.Value{"pop": intField(30)}),
+		doc("projects/p/databases/(default)/documents/cities/c", map[string]*firestorestore.Value{"pop": intField(20)}),
+	}
+	q := &structuredQuery{
+		From: []collectionSelector{{CollectionID: "cities"}},
+		OrderBy: []order{
+			{Field: fieldReference{FieldPath: "pop"}, Direction: "DESCENDING"},
+		},
+		Limit: 2,
+	}
+	res, err := executeQuery(docs, q, "projects/p/databases/(default)/documents")
+	if err != nil {
+		t.Fatalf("executeQuery: %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(res))
+	}
+	if res[0].Name != "projects/p/databases/(default)/documents/cities/b" || res[1].Name != "projects/p/databases/(default)/documents/cities/c" {
+		t.Errorf("unexpected descending order: %s, %s", res[0].Name, res[1].Name)
+	}
+
+	// Offset.
+	q2 := &structuredQuery{
+		From:    []collectionSelector{{CollectionID: "cities"}},
+		OrderBy: []order{{Field: fieldReference{FieldPath: "pop"}, Direction: "ASCENDING"}},
+		Offset:  1,
+	}
+	res2, err := executeQuery(docs, q2, "projects/p/databases/(default)/documents")
+	if err != nil {
+		t.Fatalf("executeQuery offset: %v", err)
+	}
+	if len(res2) != 2 || res2[0].Name != "projects/p/databases/(default)/documents/cities/c" {
+		t.Errorf("unexpected offset result: %+v", res2)
+	}
+}
+
+func TestExecuteQueryCursorInclusive(t *testing.T) {
+	docs := []*firestorestore.Document{
+		doc("projects/p/databases/(default)/documents/cities/a", map[string]*firestorestore.Value{"pop": intField(10)}),
+		doc("projects/p/databases/(default)/documents/cities/b", map[string]*firestorestore.Value{"pop": intField(20)}),
+		doc("projects/p/databases/(default)/documents/cities/c", map[string]*firestorestore.Value{"pop": intField(30)}),
+	}
+	base := &structuredQuery{
+		From:    []collectionSelector{{CollectionID: "cities"}},
+		OrderBy: []order{{Field: fieldReference{FieldPath: "pop"}, Direction: "ASCENDING"}},
+	}
+
+	// startAt inclusive (before=false) at 20 → b, c.
+	q := *base
+	q.StartAt = &cursor{Values: []*firestorestore.Value{intField(20)}, Before: false}
+	res, _ := executeQuery(docs, &q, "projects/p/databases/(default)/documents")
+	if len(res) != 2 || res[0].Name != "projects/p/databases/(default)/documents/cities/b" {
+		t.Errorf("inclusive startAt: got %d results", len(res))
+	}
+
+	// startAt exclusive (before=true) at 20 → c only.
+	q = *base
+	q.StartAt = &cursor{Values: []*firestorestore.Value{intField(20)}, Before: true}
+	res, _ = executeQuery(docs, &q, "projects/p/databases/(default)/documents")
+	if len(res) != 1 || res[0].Name != "projects/p/databases/(default)/documents/cities/c" {
+		t.Errorf("exclusive startAt: got %d results", len(res))
+	}
+
+	// endAt inclusive (before=false) at 20 → a, b.
+	q = *base
+	q.EndAt = &cursor{Values: []*firestorestore.Value{intField(20)}, Before: false}
+	res, _ = executeQuery(docs, &q, "projects/p/databases/(default)/documents")
+	if len(res) != 2 || res[1].Name != "projects/p/databases/(default)/documents/cities/b" {
+		t.Errorf("inclusive endAt: got %d results", len(res))
+	}
+
+	// endAt exclusive (before=true) at 20 → a only.
+	q = *base
+	q.EndAt = &cursor{Values: []*firestorestore.Value{intField(20)}, Before: true}
+	res, _ = executeQuery(docs, &q, "projects/p/databases/(default)/documents")
+	if len(res) != 1 || res[0].Name != "projects/p/databases/(default)/documents/cities/a" {
+		t.Errorf("exclusive endAt: got %d results", len(res))
+	}
+}
+
+func TestExecuteQueryProjection(t *testing.T) {
+	docs := []*firestorestore.Document{
+		doc("projects/p/databases/(default)/documents/cities/a", map[string]*firestorestore.Value{
+			"name": strField("A"), "pop": intField(10),
+		}),
+	}
+	q := &structuredQuery{
+		From:   []collectionSelector{{CollectionID: "cities"}},
+		Select: &projection{Fields: []fieldReference{{FieldPath: "name"}}},
+	}
+	res, err := executeQuery(docs, q, "projects/p/databases/(default)/documents")
+	if err != nil {
+		t.Fatalf("executeQuery: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(res))
+	}
+	if _, ok := res[0].Fields["name"]; !ok {
+		t.Errorf("expected projected field name, got %+v", res[0].Fields)
+	}
+	if _, ok := res[0].Fields["pop"]; ok {
+		t.Errorf("pop should not be projected")
+	}
+}
+
+func TestValidateFilterLimits(t *testing.T) {
+	// NOT_IN with 11 values → rejected (max 10).
+	big := make([]*firestorestore.Value, 11)
+	for i := range big {
+		big[i] = intField(int64(i))
+	}
+	f := &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "x"}, Op: "NOT_IN", Value: firestorestore.ArrayVal(big...)}}
+	if err := validateFilter(f); err == nil {
+		t.Errorf("expected NOT_IN with 11 values to be rejected")
+	}
+
+	// IN with 11-30 values → accepted.
+	for _, n := range []int{11, 30} {
+		vals := make([]*firestorestore.Value, n)
+		for i := range vals {
+			vals[i] = intField(int64(i))
+		}
+		f := &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "x"}, Op: "IN", Value: firestorestore.ArrayVal(vals...)}}
+		if err := validateFilter(f); err != nil {
+			t.Errorf("expected IN with %d values to be accepted, got %v", n, err)
+		}
+	}
+
+	// IN with 31 values → rejected (max 30).
+	vals31 := make([]*firestorestore.Value, 31)
+	for i := range vals31 {
+		vals31[i] = intField(int64(i))
+	}
+	f = &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "x"}, Op: "IN", Value: firestorestore.ArrayVal(vals31...)}}
+	if err := validateFilter(f); err == nil {
+		t.Errorf("expected IN with 31 values to be rejected")
+	}
+
+	// 31 disjunctions via 3 IN filters of sizes 3,4,3 = 36.
+	f = &filter{CompositeFilter: &compositeFilter{Op: "AND", Filters: []*filter{
+		{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "a"}, Op: "IN", Value: firestorestore.ArrayVal(intField(1), intField(2), intField(3))}},
+		{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "b"}, Op: "IN", Value: firestorestore.ArrayVal(intField(1), intField(2), intField(3), intField(4))}},
+		{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "c"}, Op: "IN", Value: firestorestore.ArrayVal(intField(1), intField(2), intField(3))}},
+	}}}
+	if err := validateFilter(f); err == nil {
+		t.Errorf("expected 36 disjunctions to be rejected")
+	}
+}
+
+func TestAnalyzeQuery(t *testing.T) {
+	// Single field: no index required.
+	q := &structuredQuery{OrderBy: []order{{Field: fieldReference{FieldPath: "pop"}, Direction: "ASCENDING"}}}
+	req, err := analyzeQuery(q)
+	if err != nil || len(req) != 0 {
+		t.Errorf("single orderBy should not require index: req=%v err=%v", req, err)
+	}
+
+	// Multiple orderBy fields: composite required.
+	q = &structuredQuery{OrderBy: []order{
+		{Field: fieldReference{FieldPath: "a"}, Direction: "ASCENDING"},
+		{Field: fieldReference{FieldPath: "b"}, Direction: "ASCENDING"},
+	}}
+	req, err = analyzeQuery(q)
+	if err != nil || len(req) != 2 {
+		t.Errorf("multi orderBy should require index: req=%v err=%v", req, err)
+	}
+
+	// Inequality field not first orderBy → error.
+	q = &structuredQuery{
+		Where:   &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "a"}, Op: "GREATER_THAN", Value: intField(1)}},
+		OrderBy: []order{{Field: fieldReference{FieldPath: "b"}, Direction: "ASCENDING"}},
+	}
+	if _, err := analyzeQuery(q); err == nil {
+		t.Errorf("inequality not first orderBy should error")
+	}
+
+	// Inequality first + extra orderBy → composite required.
+	q = &structuredQuery{
+		Where: &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "a"}, Op: "GREATER_THAN", Value: intField(1)}},
+		OrderBy: []order{
+			{Field: fieldReference{FieldPath: "a"}, Direction: "ASCENDING"},
+			{Field: fieldReference{FieldPath: "b"}, Direction: "ASCENDING"},
+		},
+	}
+	req, err = analyzeQuery(q)
+	if err != nil || len(req) != 2 {
+		t.Errorf("inequality + extra orderBy should require index: req=%v err=%v", req, err)
+	}
+
+	// Composite filter over two fields → index required.
+	q = &structuredQuery{Where: &filter{CompositeFilter: &compositeFilter{Op: "AND", Filters: []*filter{
+		{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "a"}, Op: "EQUAL", Value: intField(1)}},
+		{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "b"}, Op: "EQUAL", Value: intField(2)}},
+	}}}}
+	req, err = analyzeQuery(q)
+	if err != nil || len(req) != 2 {
+		t.Errorf("composite filter should require index: req=%v err=%v", req, err)
+	}
+
+	// Equality filter + orderBy on another field → (a,b) required.
+	q = &structuredQuery{
+		Where:   &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "a"}, Op: "EQUAL", Value: intField(1)}},
+		OrderBy: []order{{Field: fieldReference{FieldPath: "b"}, Direction: "ASCENDING"}},
+	}
+	req, err = analyzeQuery(q)
+	if err != nil || len(req) != 2 || req[0] != "a" || req[1] != "b" {
+		t.Errorf("equality + orderBy should require (a,b): req=%v err=%v", req, err)
+	}
+
+	// Equality + multi orderBy → (a,b,c) required.
+	q = &structuredQuery{
+		Where: &filter{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "a"}, Op: "EQUAL", Value: intField(1)}},
+		OrderBy: []order{
+			{Field: fieldReference{FieldPath: "b"}, Direction: "ASCENDING"},
+			{Field: fieldReference{FieldPath: "c"}, Direction: "ASCENDING"},
+		},
+	}
+	req, err = analyzeQuery(q)
+	if err != nil || len(req) != 3 || req[0] != "a" || req[1] != "b" || req[2] != "c" {
+		t.Errorf("equality + multi orderBy should require (a,b,c): req=%v err=%v", req, err)
+	}
+
+	// Two equality filters + orderBy on another field → (a,b,c) required.
+	q = &structuredQuery{
+		Where: &filter{CompositeFilter: &compositeFilter{Op: "AND", Filters: []*filter{
+			{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "a"}, Op: "EQUAL", Value: intField(1)}},
+			{FieldFilter: &fieldFilter{Field: fieldReference{FieldPath: "b"}, Op: "EQUAL", Value: intField(2)}},
+		}}},
+		OrderBy: []order{{Field: fieldReference{FieldPath: "c"}, Direction: "ASCENDING"}},
+	}
+	req, err = analyzeQuery(q)
+	if err != nil || len(req) != 3 || req[0] != "a" || req[1] != "b" || req[2] != "c" {
+		t.Errorf("two equality + orderBy should require (a,b,c): req=%v err=%v", req, err)
+	}
+}
+
+func TestEvalUnaryFilters(t *testing.T) {
+	nan := math.NaN()
+	d := doc("n", map[string]*firestorestore.Value{
+		"a":   strField("x"),
+		"n":   firestorestore.NullVal(),
+		"d":   firestorestore.DoubleVal(1.5),
+		"nan": firestorestore.DoubleVal(nan),
+	})
+
+	uf := func(fp, op string) *filter {
+		return &filter{UnaryFilter: &unaryFilter{Field: fieldReference{FieldPath: fp}, Op: op}}
+	}
+
+	cases := []struct {
+		name string
+		f    *filter
+		want bool
+	}{
+		{"is_null present null", uf("n", "IS_NULL"), true},
+		{"is_null absent", uf("missing", "IS_NULL"), true},
+		{"is_null non-null", uf("a", "IS_NULL"), false},
+		{"is_not_null present", uf("a", "IS_NOT_NULL"), true},
+		{"is_not_null null", uf("n", "IS_NOT_NULL"), false},
+		{"is_not_null absent", uf("missing", "IS_NOT_NULL"), false},
+		{"is_nan nan", uf("nan", "IS_NAN"), true},
+		{"is_nan non-nan double", uf("d", "IS_NAN"), false},
+		{"is_nan absent", uf("missing", "IS_NAN"), false},
+		{"is_not_nan non-nan double", uf("d", "IS_NOT_NAN"), true},
+		{"is_not_nan nan", uf("nan", "IS_NOT_NAN"), false},
+		{"is_not_nan absent", uf("missing", "IS_NOT_NAN"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := eval(d, tc.f)
+			if err != nil {
+				t.Fatalf("eval: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("eval = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// A unary filter on __name__ is invalid.
+	if err := validateFilter(uf("__name__", "IS_NULL")); err == nil {
+		t.Errorf("expected unary filter on __name__ to be rejected")
+	}
+}
+
+func mustTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/internal/gcp/provider/firestore/reads.go
+++ b/internal/gcp/provider/firestore/reads.go
@@ -1,0 +1,190 @@
+package firestore
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+
+	"jaiscloud/internal/clock"
+	"jaiscloud/internal/gcp/paging"
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+	"jaiscloud/internal/gcp/wire"
+	"jaiscloud/internal/model"
+	"jaiscloud/internal/provider"
+)
+
+// ListDocuments implements documents.list / documents.listDocuments (they share
+// one wire path: GET on a collection). Returns the direct children of the
+// collection, paginated by pageToken/pageSize.
+func (p *Provider) ListDocuments(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	database, path, err := relativeName(nr)
+	if err != nil {
+		return nil, err
+	}
+	project := nr.AccountID
+	docs, err := p.store.ListDocuments(ctx, project, database)
+	if err != nil {
+		return nil, err
+	}
+	coll := fullName(nr, database, path)
+	children := make([]firestorestore.Document, 0)
+	for _, d := range docs {
+		if d.ParentPath == coll {
+			children = append(children, d)
+		}
+	}
+	sort.Slice(children, func(i, j int) bool { return children[i].Name < children[j].Name })
+
+	page, nextToken := paging.Page(children, func(d firestorestore.Document) string { return d.Name }, nr.Params)
+
+	if txnID, _ := nr.Params["transaction"].(string); txnID != "" {
+		for _, d := range page {
+			p.recordRead(txnID, d.Name, d, true)
+		}
+	}
+
+	mask := maskFieldPaths(nr)
+	items := make([]any, 0, len(page))
+	for _, d := range page {
+		if len(mask) > 0 {
+			d.Fields = maskFields(d, mask)
+		}
+		items = append(items, documentMap(d))
+	}
+	resp := map[string]any{"documents": items}
+	if nextToken != "" {
+		resp["nextPageToken"] = nextToken
+	}
+	return provider.OK(resp), nil
+}
+
+// ListCollectionIds implements documents.listCollectionIds: returns the distinct
+// subcollection IDs of a document.
+func (p *Provider) ListCollectionIds(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	database, path, err := relativeName(nr)
+	if err != nil {
+		return nil, err
+	}
+	project := nr.AccountID
+	parent := fullName(nr, database, path)
+
+	docs, err := p.store.ListDocuments(ctx, project, database)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	var ids []string
+	for _, d := range docs {
+		if parentDocOfCollection(d.ParentPath) != parent {
+			continue
+		}
+		if d.CollectionID == "" || seen[d.CollectionID] {
+			continue
+		}
+		seen[d.CollectionID] = true
+		ids = append(ids, d.CollectionID)
+	}
+	sort.Strings(ids)
+
+	page, nextToken := paging.Page(ids, func(s string) string { return s }, nr.Params)
+	resp := map[string]any{"collectionIds": page}
+	if nextToken != "" {
+		resp["nextPageToken"] = nextToken
+	}
+	return provider.OK(resp), nil
+}
+
+// parentDocOfCollection returns the document path that owns a collection path
+// (strip the trailing collection-id segment).
+func parentDocOfCollection(collPath string) string {
+	i := strings.LastIndex(collPath, "/")
+	if i < 0 {
+		return ""
+	}
+	return collPath[:i]
+}
+
+// RunQuery implements documents.runQuery over a StructuredQuery.
+func (p *Provider) RunQuery(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	var req runQueryRequestWire
+	if err := decodeBody(nr, &req); err != nil {
+		return nil, err
+	}
+	if req.StructuredQuery == nil {
+		return nil, model.NewProviderError("InvalidArgument", "runQuery requires a structuredQuery", 400)
+	}
+
+	database, path, err := relativeName(nr)
+	if err != nil {
+		return nil, err
+	}
+	project := nr.AccountID
+	// The runQuery parent is the resource path before :runQuery
+	// (".../documents" or ".../documents/{doc path}"); from[].collectionId is
+	// relative to it.
+	parent := "projects/" + project + "/databases/" + database + "/documents"
+	if path != "" {
+		parent += "/" + path
+	}
+
+	// Composite-index enforcement (strict): reject queries that require a
+	// missing composite index before executing.
+	required, err := analyzeQuery(req.StructuredQuery)
+	if err != nil {
+		return nil, err
+	}
+	if len(required) > 0 {
+		ok, err := p.hasIndex(ctx, project, database, required)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, newPreconditionErr("the query requires a composite index on " +
+				strings.Join(required, ", ") + " which is not defined")
+		}
+	}
+
+	docs, err := p.store.ListDocuments(ctx, project, database)
+	if err != nil {
+		return nil, err
+	}
+	docPtrs := make([]*firestorestore.Document, len(docs))
+	for i := range docs {
+		docPtrs[i] = &docs[i]
+	}
+	results, err := executeQuery(docPtrs, req.StructuredQuery, parent)
+	if err != nil {
+		return nil, err
+	}
+
+	// Server-streaming responses are newline-delimited JSON: one RunQueryResponse
+	// object per line, terminated by a {"done":true} line.
+	readTime := clock.Now()
+	lines := make([]string, 0, len(results)+1)
+	for _, d := range results {
+		if req.Transaction != "" {
+			p.recordRead(req.Transaction, d.Name, *d, true)
+		}
+		item := map[string]any{
+			"document": documentMap(*d),
+			"readTime": readTime.Format(time.RFC3339Nano),
+		}
+		b, err := json.Marshal(item)
+		if err != nil {
+			return nil, err
+		}
+		lines = append(lines, string(b))
+	}
+	final := map[string]any{"done": true}
+	if req.StructuredQuery.Offset > 0 {
+		final["skippedResults"] = req.StructuredQuery.Offset
+	}
+	b, err := json.Marshal(final)
+	if err != nil {
+		return nil, err
+	}
+	lines = append(lines, string(b))
+	return provider.OK(map[string]any{wire.RawJSONKey: json.RawMessage(strings.Join(lines, "\n"))}), nil
+}

--- a/internal/gcp/provider/firestore/runquery_test.go
+++ b/internal/gcp/provider/firestore/runquery_test.go
@@ -1,0 +1,88 @@
+package firestore
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+	"jaiscloud/internal/gcp/wire"
+)
+
+// ndjsonLines extracts the newline-delimited JSON response lines carried under
+// wire.RawJSONKey.
+func ndjsonLines(t *testing.T, data map[string]any) []string {
+	t.Helper()
+	raw, ok := data[wire.RawJSONKey].(json.RawMessage)
+	if !ok {
+		t.Fatalf("expected raw JSON in response data, got %T", data[wire.RawJSONKey])
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+	return strings.Split(string(raw), "\n")
+}
+
+func TestRunQuerySubcollectionScoping(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+
+	sub := "projects/proj/databases/(default)/documents/cities/SF/landmarks/a"
+	root := "projects/proj/databases/(default)/documents/cities/SF"
+	for _, name := range []string{sub, root} {
+		if err := p.store.CreateDocument(ctx, firestorestore.Document{
+			Name:   name,
+			Fields: map[string]*firestorestore.Value{"x": intField(1)},
+		}); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	runQuery := func(parent string, from []any) ([]string, error) {
+		nr := testNR()
+		nr.Params["name"] = parent
+		nr.Params["body"] = map[string]any{"structuredQuery": map[string]any{"from": from}}
+		resp, err := p.RunQuery(ctx, nr)
+		if err != nil {
+			return nil, err
+		}
+		return ndjsonLines(t, resp.Data), nil
+	}
+
+	// A subcollection query scoped to a document matches its subcollection doc.
+	lines, err := runQuery("databases/(default)/documents/cities/SF",
+		[]any{map[string]any{"collectionId": "landmarks"}})
+	if err != nil {
+		t.Fatalf("runQuery subcollection: %v", err)
+	}
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 NDJSON lines (doc + done), got %d: %v", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "landmarks/a") {
+		t.Errorf("expected subcollection doc in first line, got %q", lines[0])
+	}
+	if !strings.Contains(lines[1], `"done":true`) {
+		t.Errorf("expected final done line, got %q", lines[1])
+	}
+
+	// A root-level collection is NOT matched by a subcollection-scoped query.
+	lines, err = runQuery("databases/(default)/documents/cities/SF",
+		[]any{map[string]any{"collectionId": "cities"}})
+	if err != nil {
+		t.Fatalf("runQuery root collection from subcollection scope: %v", err)
+	}
+	if len(lines) != 1 || !strings.Contains(lines[0], `"done":true`) {
+		t.Errorf("expected only a done line (no match), got %v", lines)
+	}
+
+	// Collection-group query (allDescendants) scoped under the same parent.
+	lines, err = runQuery("databases/(default)/documents/cities/SF",
+		[]any{map[string]any{"collectionId": "landmarks", "allDescendants": true}})
+	if err != nil {
+		t.Fatalf("runQuery collection group: %v", err)
+	}
+	if len(lines) != 2 || !strings.Contains(lines[0], "landmarks/a") {
+		t.Errorf("expected collection-group match, got %v", lines)
+	}
+}

--- a/internal/gcp/provider/firestore/transform_test.go
+++ b/internal/gcp/provider/firestore/transform_test.go
@@ -1,0 +1,65 @@
+package firestore
+
+import (
+	"testing"
+	"time"
+
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+)
+
+func TestApplyFieldTransforms(t *testing.T) {
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	base := map[string]*firestorestore.Value{
+		"count":  firestorestore.IntVal(5),
+		"score":  firestorestore.DoubleVal(1.5),
+		"arr":    firestorestore.ArrayVal(firestorestore.IntVal(1), firestorestore.IntVal(2)),
+		"exists": firestorestore.StringVal("keep"),
+	}
+
+	fields, results, err := applyFieldTransforms(base, []fieldTransformWire{
+		{FieldPath: "count", Increment: firestorestore.IntVal(3)},
+		{FieldPath: "score", Maximum: firestorestore.DoubleVal(2.0)},
+		{FieldPath: "min", Minimum: firestorestore.IntVal(10)},
+		{FieldPath: "created", SetToServerValue: "REQUEST_TIME"},
+		{FieldPath: "arr", AppendMissingElements: &firestorestore.ArrayValue{Values: []*firestorestore.Value{firestorestore.IntVal(2), firestorestore.IntVal(3)}}},
+		{FieldPath: "arr", RemoveAllFromArray: &firestorestore.ArrayValue{Values: []*firestorestore.Value{firestorestore.IntVal(1)}}},
+	}, now)
+	if err != nil {
+		t.Fatalf("applyFieldTransforms: %v", err)
+	}
+	if len(results) != 6 {
+		t.Fatalf("expected 6 transform results, got %d", len(results))
+	}
+	if v, _ := fields["count"].AsInt64(); v != 8 {
+		t.Errorf("increment: got %v, want 8", v)
+	}
+	if v, _ := fields["score"].AsFloat64(); v != 2.0 {
+		t.Errorf("maximum: got %v, want 2.0", v)
+	}
+	if v, _ := fields["min"].AsInt64(); v != 10 {
+		t.Errorf("minimum on missing: got %v, want 10", v)
+	}
+	if v, _ := fields["created"].AsTimestamp(); !v.Equal(now) {
+		t.Errorf("setToServerValue: got %v, want %v", v, now)
+	}
+	// setToServerValue transform result is the written Timestamp, not null.
+	if v, _ := results[3].AsTimestamp(); !v.Equal(now) {
+		t.Errorf("setToServerValue transform result: got %+v, want timestamp %v", results[3], now)
+	}
+	// appendMissingElements and removeAllFromArray still produce null results.
+	if results[4].NullValue == nil || results[5].NullValue == nil {
+		t.Errorf("appendMissing/removeAll transform results should be null, got %+v, %+v", results[4], results[5])
+	}
+	arr, _ := fields["arr"].AsArray()
+	if len(arr) != 2 || !valuesEqual(arr[0], firestorestore.IntVal(2)) || !valuesEqual(arr[1], firestorestore.IntVal(3)) {
+		t.Errorf("append+remove array: got %+v", arr)
+	}
+}
+
+func TestApplyIncrementOverflow(t *testing.T) {
+	cur := firestorestore.IntVal(1<<63 - 1)
+	got := applyIncrement(cur, firestorestore.IntVal(1))
+	if v, _ := got.AsInt64(); v != 1<<63-1 {
+		t.Errorf("overflow should clamp, got %v", v)
+	}
+}

--- a/internal/gcp/resource/resource.go
+++ b/internal/gcp/resource/resource.go
@@ -41,6 +41,10 @@ var formatters = map[string]func(project, name string) string{
 	},
 	// IAM — service accounts are identified by their email in the full name.
 	"service-account": func(p, n string) string { return fmt.Sprintf("projects/%s/serviceAccounts/%s", p, n) },
+	// Firestore — document names: projects/{p}/databases/{db}/documents/{path}.
+	// The name argument is the relative path after the project, i.e.
+	// "databases/{db}/documents/{path}".
+	"firestore-document": func(p, n string) string { return fmt.Sprintf("projects/%s/%s", p, n) },
 	// Cloud Functions
 	"cloud-function": func(p, n string) string { return fmt.Sprintf("projects/%s/locations/-/functions/%s", p, n) },
 }

--- a/internal/gcp/store/firestore/commit_test.go
+++ b/internal/gcp/store/firestore/commit_test.go
@@ -1,0 +1,96 @@
+package firestore
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func testDoc(name string, t time.Time) Document {
+	return Document{Name: name, Fields: map[string]*Value{"n": IntVal(1)}, CreateTime: t, UpdateTime: t}
+}
+
+func TestMemoryCommitAtomicAndPrecondition(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	name := "projects/p/databases/(default)/documents/cities/SF"
+
+	if err := s.CreateDocument(ctx, testDoc(name, now)); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Precondition exists=true on a present doc → ok.
+	existsTrue := true
+	err := s.Commit(ctx, nil, []Write{{
+		Name:         name,
+		Document:     &Document{Name: name, Fields: map[string]*Value{"n": IntVal(2)}, CreateTime: now, UpdateTime: now.Add(time.Minute)},
+		Precondition: &Precondition{Exists: &existsTrue},
+	}})
+	if err != nil {
+		t.Fatalf("commit with exists precondition: %v", err)
+	}
+
+	// Precondition exists=false on a present doc → ErrPreconditionFailed.
+	existsFalse := false
+	err = s.Commit(ctx, nil, []Write{{
+		Name:         name,
+		Document:     &Document{Name: name, Fields: map[string]*Value{}, CreateTime: now, UpdateTime: now.Add(2 * time.Minute)},
+		Precondition: &Precondition{Exists: &existsFalse},
+	}})
+	if !errors.Is(err, ErrPreconditionFailed) {
+		t.Fatalf("expected ErrPreconditionFailed, got %v", err)
+	}
+
+	// Precondition updateTime mismatch → ErrPreconditionFailed.
+	stale := now.Add(-time.Hour)
+	err = s.Commit(ctx, nil, []Write{{
+		Name:         name,
+		Document:     &Document{Name: name, Fields: map[string]*Value{}, CreateTime: now, UpdateTime: now.Add(2 * time.Minute)},
+		Precondition: &Precondition{UpdateTime: &stale},
+	}})
+	if !errors.Is(err, ErrPreconditionFailed) {
+		t.Fatalf("expected ErrPreconditionFailed on stale updateTime, got %v", err)
+	}
+
+	// Batch atomicity: a failing write aborts the whole batch.
+	before, _ := s.GetDocument(ctx, name)
+	bad := "projects/p/databases/(default)/documents/cities/MISSING"
+	err = s.Commit(ctx, nil, []Write{
+		{Name: name, Document: &Document{Name: name, Fields: map[string]*Value{"n": IntVal(99)}, CreateTime: now, UpdateTime: now.Add(3 * time.Minute)}},
+		{Name: bad, Precondition: &Precondition{Exists: &existsTrue}}, // fails: missing
+	})
+	if !errors.Is(err, ErrPreconditionFailed) {
+		t.Fatalf("expected ErrPreconditionFailed, got %v", err)
+	}
+	after, _ := s.GetDocument(ctx, name)
+	if !after.UpdateTime.Equal(before.UpdateTime) {
+		t.Errorf("atomicity violated: first write applied despite batch failure")
+	}
+}
+
+func TestMemoryCommitReadSetAbort(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	name := "projects/p/databases/(default)/documents/cities/SF"
+	s.CreateDocument(ctx, testDoc(name, now))
+
+	// Read-set records the doc at time now, then it is mutated.
+	reads := []ReadRef{{Name: name, Exists: true, UpdateTime: now}}
+	s.UpdateDocument(ctx, Document{Name: name, Fields: map[string]*Value{"n": IntVal(5)}, CreateTime: now, UpdateTime: now.Add(time.Minute)})
+
+	err := s.Commit(ctx, reads, []Write{{Name: name, Document: &Document{Name: name, Fields: map[string]*Value{}, CreateTime: now, UpdateTime: now.Add(2 * time.Minute)}}})
+	if !errors.Is(err, ErrAborted) {
+		t.Fatalf("expected ErrAborted, got %v", err)
+	}
+
+	// Read-set records missing doc, then it is created → abort.
+	s2 := NewMemoryStore()
+	reads2 := []ReadRef{{Name: name, Exists: false}}
+	s2.CreateDocument(ctx, testDoc(name, now))
+	if err := s2.Commit(ctx, reads2, nil); !errors.Is(err, ErrAborted) {
+		t.Fatalf("expected ErrAborted on missing→created, got %v", err)
+	}
+}

--- a/internal/gcp/store/firestore/memory.go
+++ b/internal/gcp/store/firestore/memory.go
@@ -1,0 +1,143 @@
+package firestore
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// MemoryStore is an in-memory FirestoreStore. Documents are keyed by their full
+// resource name.
+type MemoryStore struct {
+	mu   sync.RWMutex
+	docs map[string]Document // full name → document
+}
+
+// NewMemoryStore returns an empty in-memory store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{docs: make(map[string]Document)}
+}
+
+func (s *MemoryStore) GetDocument(_ context.Context, name string) (Document, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	d, ok := s.docs[name]
+	if !ok {
+		return Document{}, ErrDocumentNotFound
+	}
+	return d, nil
+}
+
+func (s *MemoryStore) CreateDocument(_ context.Context, doc Document) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.docs[doc.Name]; ok {
+		return ErrDocumentExists
+	}
+	normalizeDocument(&doc)
+	s.docs[doc.Name] = doc
+	return nil
+}
+
+func (s *MemoryStore) UpdateDocument(_ context.Context, doc Document) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.docs[doc.Name]; !ok {
+		return ErrDocumentNotFound
+	}
+	normalizeDocument(&doc)
+	s.docs[doc.Name] = doc
+	return nil
+}
+
+// DeleteDocument is idempotent: deleting a non-existent document succeeds (real
+// Firestore DeleteDocument does not error without a precondition).
+func (s *MemoryStore) DeleteDocument(_ context.Context, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.docs, name)
+	return nil
+}
+
+func (s *MemoryStore) ListDocuments(_ context.Context, project, database string) ([]Document, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	prefix := "projects/" + project + "/databases/" + database + "/documents/"
+	result := make([]Document, 0)
+	for name, d := range s.docs {
+		if strings.HasPrefix(name, prefix) {
+			result = append(result, d)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result, nil
+}
+
+// Commit applies a batch of writes atomically. Read-set entries and write
+// preconditions are validated against the current state under the store lock;
+// a mismatch aborts the whole batch without applying any write.
+func (s *MemoryStore) Commit(_ context.Context, reads []ReadRef, writes []Write) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// 1. Re-validate the transaction read-set.
+	for _, r := range reads {
+		d, ok := s.docs[r.Name]
+		if r.Exists != ok {
+			return ErrAborted
+		}
+		if ok && !d.UpdateTime.Equal(r.UpdateTime) {
+			return ErrAborted
+		}
+	}
+
+	// 2. Validate per-write preconditions.
+	for _, w := range writes {
+		if err := checkPrecondition(s.docs, w); err != nil {
+			return err
+		}
+	}
+
+	// 3. Apply all writes.
+	for _, w := range writes {
+		if w.Document == nil {
+			delete(s.docs, w.Name)
+			continue
+		}
+		doc := *w.Document
+		normalizeDocument(&doc)
+		s.docs[w.Name] = doc
+	}
+	return nil
+}
+
+// checkPrecondition validates a single write's precondition against the current
+// document map (the store lock is held by the caller).
+func checkPrecondition(docs map[string]Document, w Write) error {
+	cur, exists := docs[w.Name]
+	if w.Precondition == nil {
+		return nil
+	}
+	if w.Precondition.Exists != nil {
+		if *w.Precondition.Exists != exists {
+			return ErrPreconditionFailed
+		}
+		return nil
+	}
+	if w.Precondition.UpdateTime != nil {
+		if !exists {
+			return ErrPreconditionFailed
+		}
+		if !cur.UpdateTime.Equal(*w.Precondition.UpdateTime) {
+			return ErrPreconditionFailed
+		}
+	}
+	return nil
+}
+
+func (s *MemoryStore) Reset(_ context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.docs = make(map[string]Document)
+}

--- a/internal/gcp/store/firestore/memory_test.go
+++ b/internal/gcp/store/firestore/memory_test.go
@@ -1,0 +1,232 @@
+package firestore
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"jaiscloud/internal/clock"
+)
+
+func TestValueJSONRoundTrip(t *testing.T) {
+	ts := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name  string
+		val   *Value
+		check func(*Value) bool
+	}{
+		{"null", NullVal(), func(v *Value) bool { return v.NullValue != nil && *v.NullValue == NullEnumValue }},
+		{"bool", BoolVal(true), func(v *Value) bool { b, ok := v.AsBool(); return ok && b }},
+		{"int", IntVal(-42), func(v *Value) bool { n, ok := v.AsInt64(); return ok && n == -42 }},
+		{"double", DoubleVal(3.5), func(v *Value) bool { f, ok := v.AsFloat64(); return ok && f == 3.5 }},
+		{"timestamp", TimestampVal(ts), func(v *Value) bool { t, ok := v.AsTimestamp(); return ok && t.Equal(ts) }},
+		{"string", StringVal("hello"), func(v *Value) bool { s, ok := v.AsString(); return ok && s == "hello" }},
+		{"bytes", BytesVal([]byte{0x01, 0x02}), func(v *Value) bool { b, ok := v.AsBytes(); return ok && bytes.Equal(b, []byte{0x01, 0x02}) }},
+		{"reference", ReferenceVal("projects/p/databases/(default)/documents/c/d"), func(v *Value) bool {
+			s, ok := v.AsReference()
+			return ok && s == "projects/p/databases/(default)/documents/c/d"
+		}},
+		{"geopoint", GeoPointVal(37.77, -122.41), func(v *Value) bool {
+			g, ok := v.AsGeoPoint()
+			return ok && g.Latitude == 37.77 && g.Longitude == -122.41
+		}},
+		{"array", ArrayVal(StringVal("a"), IntVal(1)), func(v *Value) bool {
+			a, ok := v.AsArray()
+			return ok && len(a) == 2
+		}},
+		{"map", MapVal(map[string]*Value{"k": StringVal("v")}), func(v *Value) bool {
+			m, ok := v.AsMap()
+			return ok && m["k"] != nil
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.val)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var got Value
+			if err := json.Unmarshal(b, &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !tc.check(&got) {
+				t.Fatalf("round-trip mismatch: %s", b)
+			}
+		})
+	}
+}
+
+// TestValueIntegerWireEncoding asserts integerValue is a decimal string on the
+// wire (split int/double, unlike DynamoDB's arbitrary-precision number).
+func TestValueIntegerWireEncoding(t *testing.T) {
+	b, err := json.Marshal(IntVal(9007199254740993))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := raw["integerValue"]; got != "9007199254740993" {
+		t.Fatalf("expected integerValue as string, got %T %v", got, got)
+	}
+}
+
+func TestMemoryStoreCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+
+	name := "projects/p/databases/(default)/documents/cities/SF"
+	doc := Document{
+		Name:       name,
+		Fields:     map[string]*Value{"name": StringVal("San Francisco")},
+		CreateTime: now,
+		UpdateTime: now,
+	}
+
+	if err := s.CreateDocument(ctx, doc); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Duplicate → ErrDocumentExists.
+	if err := s.CreateDocument(ctx, doc); !errors.Is(err, ErrDocumentExists) {
+		t.Fatalf("expected ErrDocumentExists, got %v", err)
+	}
+
+	got, err := s.GetDocument(ctx, name)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.CollectionID != "cities" {
+		t.Errorf("expected CollectionID cities, got %q", got.CollectionID)
+	}
+	if got.ParentPath != "projects/p/databases/(default)/documents/cities" {
+		t.Errorf("unexpected ParentPath %q", got.ParentPath)
+	}
+	if v, ok := got.Fields["name"].AsString(); !ok || v != "San Francisco" {
+		t.Errorf("unexpected fields: %+v", got.Fields)
+	}
+
+	// Get missing → ErrDocumentNotFound.
+	if _, err := s.GetDocument(ctx, "projects/p/databases/(default)/documents/cities/NOPE"); !errors.Is(err, ErrDocumentNotFound) {
+		t.Fatalf("expected ErrDocumentNotFound, got %v", err)
+	}
+
+	// Update.
+	updated := Document{
+		Name:       name,
+		Fields:     map[string]*Value{"name": StringVal("SF"), "state": StringVal("CA")},
+		CreateTime: now,
+		UpdateTime: now.Add(time.Minute),
+	}
+	if err := s.UpdateDocument(ctx, updated); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got, _ = s.GetDocument(ctx, name)
+	if v, _ := got.Fields["name"].AsString(); v != "SF" {
+		t.Errorf("expected updated name SF, got %q", v)
+	}
+	if !got.UpdateTime.Equal(now.Add(time.Minute)) {
+		t.Errorf("unexpected UpdateTime %v", got.UpdateTime)
+	}
+
+	// Update missing → ErrDocumentNotFound.
+	if err := s.UpdateDocument(ctx, Document{Name: "projects/p/databases/(default)/documents/cities/NOPE"}); !errors.Is(err, ErrDocumentNotFound) {
+		t.Fatalf("expected ErrDocumentNotFound on update, got %v", err)
+	}
+
+	// ListDocuments scoped by project+database.
+	s.CreateDocument(ctx, Document{Name: "projects/p/databases/(default)/documents/cities/LA", CreateTime: now, UpdateTime: now})
+	s.CreateDocument(ctx, Document{Name: "projects/q/databases/(default)/documents/cities/NY", CreateTime: now, UpdateTime: now})
+	list, err := s.ListDocuments(ctx, "p", "(default)")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 docs in project p, got %d", len(list))
+	}
+	if list[0].Name != "projects/p/databases/(default)/documents/cities/LA" ||
+		list[1].Name != "projects/p/databases/(default)/documents/cities/SF" {
+		t.Errorf("unexpected list order: %+v", list)
+	}
+
+	// Delete is idempotent.
+	if err := s.DeleteDocument(ctx, name); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if err := s.DeleteDocument(ctx, name); err != nil {
+		t.Fatalf("delete should be idempotent, got %v", err)
+	}
+	if _, err := s.GetDocument(ctx, name); !errors.Is(err, ErrDocumentNotFound) {
+		t.Fatalf("expected ErrDocumentNotFound after delete, got %v", err)
+	}
+}
+
+func TestMemoryStoreSnapshotRestore(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+
+	s := NewMemoryStore()
+	s.CreateDocument(ctx, Document{
+		Name:       "projects/p/databases/(default)/documents/cities/SF",
+		Fields:     map[string]*Value{"name": StringVal("San Francisco"), "n": IntVal(7)},
+		CreateTime: now,
+		UpdateTime: now,
+	})
+	s.CreateDocument(ctx, Document{
+		Name:       "projects/p/databases/(default)/documents/cities/LA",
+		Fields:     map[string]*Value{"name": StringVal("Los Angeles")},
+		CreateTime: now,
+		UpdateTime: now,
+	})
+
+	var buf bytes.Buffer
+	if err := s.Snapshot(ctx, &buf); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	// Wipe, then restore.
+	s.Reset(ctx)
+	if empty, err := s.IsEmpty(ctx); err != nil || !empty {
+		t.Fatalf("expected empty after reset, got empty=%v err=%v", empty, err)
+	}
+
+	restored := NewMemoryStore()
+	if err := restored.Restore(ctx, &buf); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	doc, err := restored.GetDocument(ctx, "projects/p/databases/(default)/documents/cities/SF")
+	if err != nil {
+		t.Fatalf("get after restore: %v", err)
+	}
+	if v, ok := doc.Fields["n"].AsInt64(); !ok || v != 7 {
+		t.Errorf("unexpected restored field: %+v", doc.Fields)
+	}
+	// CollectionID/ParentPath are re-derived on restore.
+	if doc.CollectionID != "cities" || doc.ParentPath != "projects/p/databases/(default)/documents/cities" {
+		t.Errorf("derived fields not restored: collectionID=%q parentPath=%q", doc.CollectionID, doc.ParentPath)
+	}
+}
+
+// TestNormalizeDocumentDefaultsTimestamp asserts normalizeDocument fills
+// timestamps from the (frozen) global clock when unset.
+func TestNormalizeDocumentDefaultsTimestamp(t *testing.T) {
+	frozen := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	clock.SetGlobalClock(clock.FixedClock{T: frozen})
+	defer clock.SetGlobalClock(clock.RealClock{})
+
+	doc := &Document{Name: "projects/p/databases/(default)/documents/cities/SF"}
+	normalizeDocument(doc)
+
+	if !doc.CreateTime.Equal(frozen) || !doc.UpdateTime.Equal(frozen) {
+		t.Errorf("expected frozen timestamp, got create=%v update=%v", doc.CreateTime, doc.UpdateTime)
+	}
+	if doc.Fields == nil {
+		t.Errorf("expected non-nil Fields after normalize")
+	}
+}

--- a/internal/gcp/store/firestore/postgres.go
+++ b/internal/gcp/store/firestore/postgres.go
@@ -1,0 +1,228 @@
+package firestore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgresStore implements FirestoreStore against the jc_firestore_documents
+// table. The Firestore migrations (gcpstore.MigrationFS, migration 017) must
+// have run before use.
+type PostgresStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresStore returns a Postgres-backed FirestoreStore.
+func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore {
+	return &PostgresStore{pool: pool}
+}
+
+const firestoreDocCols = "project, database, collection_id, parent_path, name, fields, create_time, update_time"
+
+// scanDocument scans the firestoreDocCols columns into a Document. project and
+// database are scanned but discarded (they are re-derivable from Name).
+func scanDocument(scan func(...any) error) (Document, error) {
+	var d Document
+	var project, database string
+	var fields []byte
+	err := scan(&project, &database, &d.CollectionID, &d.ParentPath, &d.Name, &fields, &d.CreateTime, &d.UpdateTime)
+	if err != nil {
+		return Document{}, err
+	}
+	_ = json.Unmarshal(fields, &d.Fields)
+	if d.Fields == nil {
+		d.Fields = map[string]*Value{}
+	}
+	return d, nil
+}
+
+func (s *PostgresStore) GetDocument(ctx context.Context, name string) (Document, error) {
+	row := s.pool.QueryRow(ctx, `SELECT `+firestoreDocCols+` FROM jc_firestore_documents WHERE name=$1`, name)
+	d, err := scanDocument(row.Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Document{}, ErrDocumentNotFound
+	}
+	return d, err
+}
+
+func (s *PostgresStore) CreateDocument(ctx context.Context, doc Document) error {
+	normalizeDocument(&doc)
+	project, database, _, ok := ParseDocumentName(doc.Name)
+	if !ok {
+		return ErrInvalidArgument
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO jc_firestore_documents (project, database, collection_id, parent_path, name, fields, create_time, update_time)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+	`, project, database, doc.CollectionID, doc.ParentPath, doc.Name, fieldsJSON(doc.Fields), doc.CreateTime, doc.UpdateTime)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrDocumentExists
+		}
+		return fmt.Errorf("firestore CreateDocument: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) UpdateDocument(ctx context.Context, doc Document) error {
+	normalizeDocument(&doc)
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE jc_firestore_documents
+		SET fields=$2, update_time=$3, create_time=$4, collection_id=$5, parent_path=$6
+		WHERE name=$1
+	`, doc.Name, fieldsJSON(doc.Fields), doc.UpdateTime, doc.CreateTime, doc.CollectionID, doc.ParentPath)
+	if err != nil {
+		return fmt.Errorf("firestore UpdateDocument: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrDocumentNotFound
+	}
+	return nil
+}
+
+// DeleteDocument is idempotent.
+func (s *PostgresStore) DeleteDocument(ctx context.Context, name string) error {
+	_, err := s.pool.Exec(ctx, `DELETE FROM jc_firestore_documents WHERE name=$1`, name)
+	return err
+}
+
+func (s *PostgresStore) ListDocuments(ctx context.Context, project, database string) ([]Document, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT `+firestoreDocCols+` FROM jc_firestore_documents
+		WHERE project=$1 AND database=$2 ORDER BY name
+	`, project, database)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []Document
+	for rows.Next() {
+		d, err := scanDocument(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, d)
+	}
+	return result, rows.Err()
+}
+
+// Commit applies a batch of writes atomically inside a serializable transaction
+// with row locking, mirroring the memory store's read-set + precondition
+// semantics.
+func (s *PostgresStore) Commit(ctx context.Context, reads []ReadRef, writes []Write) error {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	// 1. Re-validate the read-set under row locks.
+	for _, r := range reads {
+		var updateTime time.Time
+		err := tx.QueryRow(ctx, `SELECT update_time FROM jc_firestore_documents WHERE name=$1 FOR UPDATE`, r.Name).Scan(&updateTime)
+		exists := err == nil
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			exists = false
+		case err != nil:
+			return err
+		}
+		if r.Exists != exists {
+			return ErrAborted
+		}
+		if exists && !updateTime.Equal(r.UpdateTime) {
+			return ErrAborted
+		}
+	}
+
+	// 2. Validate per-write preconditions (locking each touched row).
+	for _, w := range writes {
+		var cur *Document
+		var project, database, collectionID, parentPath, name string
+		var fields []byte
+		var createTime, updateTime time.Time
+		err := tx.QueryRow(ctx, `SELECT `+firestoreDocCols+` FROM jc_firestore_documents WHERE name=$1 FOR UPDATE`, w.Name).
+			Scan(&project, &database, &collectionID, &parentPath, &name, &fields, &createTime, &updateTime)
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			cur = nil
+		case err != nil:
+			return err
+		default:
+			d := Document{Name: name, CollectionID: collectionID, ParentPath: parentPath, CreateTime: createTime, UpdateTime: updateTime}
+			cur = &d
+		}
+		if err := checkPreconditionDoc(cur, w.Precondition); err != nil {
+			return err
+		}
+	}
+
+	// 3. Apply writes.
+	for _, w := range writes {
+		if w.Document == nil {
+			if _, err := tx.Exec(ctx, `DELETE FROM jc_firestore_documents WHERE name=$1`, w.Name); err != nil {
+				return err
+			}
+			continue
+		}
+		doc := *w.Document
+		normalizeDocument(&doc)
+		project, database, _, ok := ParseDocumentName(doc.Name)
+		if !ok {
+			return ErrInvalidArgument
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO jc_firestore_documents (project, database, collection_id, parent_path, name, fields, create_time, update_time)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+			ON CONFLICT (name) DO UPDATE SET fields=$6, create_time=$7, update_time=$8, collection_id=$3, parent_path=$4
+		`, project, database, doc.CollectionID, doc.ParentPath, doc.Name, fieldsJSON(doc.Fields), doc.CreateTime, doc.UpdateTime); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+// checkPreconditionDoc validates a precondition against an optional current
+// document (nil when the document does not exist).
+func checkPreconditionDoc(cur *Document, pre *Precondition) error {
+	if pre == nil {
+		return nil
+	}
+	exists := cur != nil
+	if pre.Exists != nil {
+		if *pre.Exists != exists {
+			return ErrPreconditionFailed
+		}
+		return nil
+	}
+	if pre.UpdateTime != nil {
+		if !exists || !cur.UpdateTime.Equal(*pre.UpdateTime) {
+			return ErrPreconditionFailed
+		}
+	}
+	return nil
+}
+
+// fieldsJSON marshals a document's fields map to JSONB-ready bytes.
+func fieldsJSON(fields map[string]*Value) []byte {
+	b, err := json.Marshal(fields)
+	if err != nil {
+		return []byte("{}")
+	}
+	return b
+}
+
+func (s *PostgresStore) Reset(ctx context.Context) {
+	if _, err := s.pool.Exec(ctx, `DELETE FROM jc_firestore_documents`); err != nil {
+		slog.Warn("firestore reset: exec failed", "err", err)
+	}
+}

--- a/internal/gcp/store/firestore/snapshot.go
+++ b/internal/gcp/store/firestore/snapshot.go
@@ -1,0 +1,108 @@
+package firestore
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"sort"
+)
+
+// firestoreSnap is the JSON snapshot shape for both memory and postgres
+// backends (mirrors the gcs snapshot envelope).
+type firestoreSnap struct {
+	Documents []Document `json:"documents"`
+}
+
+// MemoryStore Snapshot/Restore/IsEmpty.
+
+func (s *MemoryStore) IsEmpty(_ context.Context) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.docs) == 0, nil
+}
+
+func (s *MemoryStore) Snapshot(_ context.Context, w io.Writer) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	docs := make([]Document, 0, len(s.docs))
+	for _, d := range s.docs {
+		docs = append(docs, d)
+	}
+	sort.Slice(docs, func(i, j int) bool { return docs[i].Name < docs[j].Name })
+	return json.NewEncoder(w).Encode(firestoreSnap{Documents: docs})
+}
+
+func (s *MemoryStore) Restore(_ context.Context, r io.Reader) error {
+	var snap firestoreSnap
+	if err := json.NewDecoder(r).Decode(&snap); err != nil {
+		return err
+	}
+	docs := make(map[string]Document, len(snap.Documents))
+	for _, d := range snap.Documents {
+		normalizeDocument(&d)
+		docs[d.Name] = d
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.docs = docs
+	return nil
+}
+
+// PostgresStore Snapshot/Restore/IsEmpty.
+
+func (s *PostgresStore) IsEmpty(ctx context.Context) (bool, error) {
+	var n int
+	if err := s.pool.QueryRow(ctx, `SELECT count(*) FROM jc_firestore_documents`).Scan(&n); err != nil {
+		return false, err
+	}
+	return n == 0, nil
+}
+
+func (s *PostgresStore) Snapshot(ctx context.Context, w io.Writer) error {
+	rows, err := s.pool.Query(ctx, `SELECT `+firestoreDocCols+` FROM jc_firestore_documents ORDER BY name`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	var snap firestoreSnap
+	for rows.Next() {
+		d, err := scanDocument(rows.Scan)
+		if err != nil {
+			return err
+		}
+		snap.Documents = append(snap.Documents, d)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	return json.NewEncoder(w).Encode(snap)
+}
+
+func (s *PostgresStore) Restore(ctx context.Context, r io.Reader) error {
+	var snap firestoreSnap
+	if err := json.NewDecoder(r).Decode(&snap); err != nil {
+		return err
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `DELETE FROM jc_firestore_documents`); err != nil {
+		return err
+	}
+	for _, d := range snap.Documents {
+		normalizeDocument(&d)
+		project, database, _, ok := ParseDocumentName(d.Name)
+		if !ok {
+			return ErrInvalidArgument
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO jc_firestore_documents (project, database, collection_id, parent_path, name, fields, create_time, update_time)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+		`, project, database, d.CollectionID, d.ParentPath, d.Name, fieldsJSON(d.Fields), d.CreateTime, d.UpdateTime); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}

--- a/internal/gcp/store/firestore/store.go
+++ b/internal/gcp/store/firestore/store.go
@@ -1,0 +1,127 @@
+// Package firestore provides the Firestore document data-plane store. Documents
+// live in the dedicated jc_firestore_documents table (Postgres, slice 2) or in
+// memory; unlike DynamoDB there are no materialized index side-tables —
+// collections are implicit path segments and single-field indexes are implicit.
+package firestore
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"jaiscloud/internal/clock"
+)
+
+// Sentinel errors returned by the store, mapped to Firestore HTTP responses by
+// the provider (errors.Is-compatible, matching the gcs store conventions).
+var (
+	ErrDocumentNotFound   = errors.New("DocumentNotFound")
+	ErrDocumentExists     = errors.New("DocumentExists")
+	ErrInvalidArgument    = errors.New("InvalidArgument")
+	ErrPreconditionFailed = errors.New("PreconditionFailed")
+	ErrAborted            = errors.New("Aborted")
+)
+
+// Document is a single Firestore document. Name is the full resource name
+// ("projects/{p}/databases/{db}/documents/{path}"). CollectionID and ParentPath
+// are derived from Name and persisted only for efficient collectionGroup and
+// hierarchical queries; they are not part of the REST wire Document.
+type Document struct {
+	CollectionID string            `json:"-"`
+	ParentPath   string            `json:"-"`
+	Name         string            `json:"name,omitempty"`
+	Fields       map[string]*Value `json:"fields,omitempty"`
+	CreateTime   time.Time         `json:"createTime,omitempty"`
+	UpdateTime   time.Time         `json:"updateTime,omitempty"`
+}
+
+// Precondition is an optimistic per-write guard on a document's current state.
+// Exactly one of Exists / UpdateTime is meaningful: Exists is a *bool so the
+// wire can distinguish "exists must be false" from "not set".
+type Precondition struct {
+	Exists     *bool
+	UpdateTime *time.Time
+}
+
+// Write is a single document write applied atomically within a Commit. Document
+// is nil for a delete.
+type Write struct {
+	Name         string
+	Document     *Document
+	Precondition *Precondition
+}
+
+// ReadRef records a document read within a transaction, for optimistic
+// concurrency re-validation at commit time.
+type ReadRef struct {
+	Name       string
+	Exists     bool
+	UpdateTime time.Time
+}
+
+// FirestoreStore is the Firestore document data-plane store. Documents are keyed
+// by their full resource name, which is globally unique (it embeds the owning
+// project and database).
+//
+// TODO(slice-2): composite-index registry persistence. Commit (atomic batch
+// with preconditions + read-set validation) is implemented on both backends.
+type FirestoreStore interface {
+	// GetDocument returns the document with the given full name, or
+	// ErrDocumentNotFound.
+	GetDocument(ctx context.Context, name string) (Document, error)
+	// CreateDocument stores a new document, or ErrDocumentExists.
+	CreateDocument(ctx context.Context, doc Document) error
+	// UpdateDocument replaces an existing document, or ErrDocumentNotFound.
+	UpdateDocument(ctx context.Context, doc Document) error
+	// DeleteDocument removes a document. Idempotent: deleting a non-existent
+	// document succeeds (real Firestore DeleteDocument does not error without a
+	// precondition).
+	DeleteDocument(ctx context.Context, name string) error
+	// ListDocuments returns every document under the given project+database,
+	// sorted by name. Used by listDocuments/runQuery (slice 2).
+	ListDocuments(ctx context.Context, project, database string) ([]Document, error)
+	// Commit applies a batch of writes atomically after (1) re-validating the
+	// transaction read-set and (2) validating each write's precondition. It
+	// returns ErrAborted when a read-set entry no longer matches, and
+	// ErrPreconditionFailed when a write precondition fails; in both cases no
+	// writes are applied.
+	Commit(ctx context.Context, reads []ReadRef, writes []Write) error
+	Reset(ctx context.Context)
+}
+
+// ParseDocumentName splits a full document name
+// "projects/{p}/databases/{db}/documents/{path}" into its project, database,
+// and relative document path components. ok is false when name is malformed.
+func ParseDocumentName(name string) (project, database, path string, ok bool) {
+	segs := strings.Split(name, "/")
+	if len(segs) < 5 || segs[0] != "projects" || segs[2] != "databases" || segs[4] != "documents" {
+		return "", "", "", false
+	}
+	return segs[1], segs[3], strings.Join(segs[5:], "/"), true
+}
+
+// normalizeDocument fills default timestamps and derives CollectionID/ParentPath
+// from Name before persistence (both backends).
+func normalizeDocument(doc *Document) {
+	if doc.Fields == nil {
+		doc.Fields = map[string]*Value{}
+	}
+	if doc.CreateTime.IsZero() {
+		doc.CreateTime = clock.Now()
+	}
+	if doc.UpdateTime.IsZero() {
+		doc.UpdateTime = doc.CreateTime
+	}
+	project, database, path, ok := ParseDocumentName(doc.Name)
+	if !ok {
+		return
+	}
+	segs := strings.Split(path, "/")
+	if len(segs) < 2 {
+		return
+	}
+	doc.CollectionID = segs[len(segs)-2]
+	prefix := "projects/" + project + "/databases/" + database + "/documents/"
+	doc.ParentPath = prefix + strings.Join(segs[:len(segs)-1], "/")
+}

--- a/internal/gcp/store/firestore/value.go
+++ b/internal/gcp/store/firestore/value.go
@@ -1,0 +1,362 @@
+package firestore
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+)
+
+// NullEnumValue is the wire value of the Firestore nullValue enum.
+const NullEnumValue = "NULL_VALUE"
+
+// GeoPoint is a Firestore geoPointValue ({latitude, longitude}).
+type GeoPoint struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
+// ArrayValue is the Firestore arrayValue container.
+type ArrayValue struct {
+	Values []*Value `json:"values,omitempty"`
+}
+
+// MapValue is the Firestore mapValue container.
+type MapValue struct {
+	Fields map[string]*Value `json:"fields,omitempty"`
+}
+
+// Value is a Firestore value: exactly one variant field is set. It mirrors the
+// Firestore REST wire encoding, where integerValue is a decimal string,
+// bytesValue is base64, timestampValue is an RFC 3339 string, and nullValue is
+// the enum string "NULL_VALUE". Integers and doubles are split (unlike
+// DynamoDB's arbitrary-precision {"N": "42"}), and timestamp is first-class.
+type Value struct {
+	NullValue      *string     `json:"nullValue,omitempty"`
+	BooleanValue   *bool       `json:"booleanValue,omitempty"`
+	IntegerValue   *int64      `json:"integerValue,omitempty"`
+	DoubleValue    *float64    `json:"doubleValue,omitempty"`
+	TimestampValue *time.Time  `json:"timestampValue,omitempty"`
+	StringValue    *string     `json:"stringValue,omitempty"`
+	BytesValue     []byte      `json:"bytesValue,omitempty"`
+	ReferenceValue *string     `json:"referenceValue,omitempty"`
+	GeoPointValue  *GeoPoint   `json:"geoPointValue,omitempty"`
+	ArrayValue     *ArrayValue `json:"arrayValue,omitempty"`
+	MapValue       *MapValue   `json:"mapValue,omitempty"`
+}
+
+// MarshalJSON encodes the value with exactly one variant field, using the
+// Firestore wire shapes (integerValue as a decimal string, bytesValue as
+// base64, timestampValue as RFC 3339).
+func (v *Value) MarshalJSON() ([]byte, error) {
+	m := make(map[string]any, 1)
+	switch {
+	case v.NullValue != nil:
+		m["nullValue"] = *v.NullValue
+	case v.BooleanValue != nil:
+		m["booleanValue"] = *v.BooleanValue
+	case v.IntegerValue != nil:
+		m["integerValue"] = strconv.FormatInt(*v.IntegerValue, 10)
+	case v.DoubleValue != nil:
+		m["doubleValue"] = encodeDouble(*v.DoubleValue)
+	case v.TimestampValue != nil:
+		m["timestampValue"] = v.TimestampValue.Format(time.RFC3339Nano)
+	case v.StringValue != nil:
+		m["stringValue"] = *v.StringValue
+	case v.BytesValue != nil:
+		m["bytesValue"] = base64.StdEncoding.EncodeToString(v.BytesValue)
+	case v.ReferenceValue != nil:
+		m["referenceValue"] = *v.ReferenceValue
+	case v.GeoPointValue != nil:
+		m["geoPointValue"] = v.GeoPointValue
+	case v.ArrayValue != nil:
+		m["arrayValue"] = v.ArrayValue
+	case v.MapValue != nil:
+		m["mapValue"] = v.MapValue
+	}
+	return json.Marshal(m)
+}
+
+// encodeDouble renders a doubleValue for the wire: NaN/±Infinity are encoded as
+// the strings "NaN"/"Infinity"/"-Infinity" (protobuf JSON mapping) since
+// encoding/json cannot emit them as JSON numbers.
+func encodeDouble(f float64) any {
+	switch {
+	case math.IsNaN(f):
+		return "NaN"
+	case math.IsInf(f, 1):
+		return "Infinity"
+	case math.IsInf(f, -1):
+		return "-Infinity"
+	default:
+		return f
+	}
+}
+
+// UnmarshalJSON decodes a Firestore value from its REST wire form. A value with
+// more than one variant field is rejected; an empty value object yields the
+// zero Value (which is only valid transiently, never persisted).
+func (v *Value) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if len(raw) > 1 {
+		return fmt.Errorf("Firestore value must have exactly one variant, found %d", len(raw))
+	}
+	for key, rv := range raw {
+		switch key {
+		case "nullValue":
+			var s string
+			if err := json.Unmarshal(rv, &s); err != nil {
+				return err
+			}
+			v.NullValue = &s
+		case "booleanValue":
+			var b bool
+			if err := json.Unmarshal(rv, &b); err != nil {
+				return err
+			}
+			v.BooleanValue = &b
+		case "integerValue":
+			var s string
+			if err := json.Unmarshal(rv, &s); err != nil {
+				return err
+			}
+			n, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return err
+			}
+			v.IntegerValue = &n
+		case "doubleValue":
+			var f float64
+			if err := json.Unmarshal(rv, &f); err != nil {
+				// Not a plain JSON number: the special double strings
+				// ("NaN"/"Infinity"/"-Infinity") per the protobuf JSON mapping.
+				var s string
+				if serr := json.Unmarshal(rv, &s); serr != nil {
+					return err
+				}
+				switch s {
+				case "NaN":
+					f = math.NaN()
+				case "Infinity":
+					f = math.Inf(1)
+				case "-Infinity":
+					f = math.Inf(-1)
+				default:
+					return fmt.Errorf("invalid doubleValue %q", s)
+				}
+			}
+			v.DoubleValue = &f
+		case "timestampValue":
+			var s string
+			if err := json.Unmarshal(rv, &s); err != nil {
+				return err
+			}
+			t, err := time.Parse(time.RFC3339Nano, s)
+			if err != nil {
+				return err
+			}
+			v.TimestampValue = &t
+		case "stringValue":
+			var s string
+			if err := json.Unmarshal(rv, &s); err != nil {
+				return err
+			}
+			v.StringValue = &s
+		case "bytesValue":
+			var s string
+			if err := json.Unmarshal(rv, &s); err != nil {
+				return err
+			}
+			b, err := base64.StdEncoding.DecodeString(s)
+			if err != nil {
+				return err
+			}
+			v.BytesValue = b
+		case "referenceValue":
+			var s string
+			if err := json.Unmarshal(rv, &s); err != nil {
+				return err
+			}
+			v.ReferenceValue = &s
+		case "geoPointValue":
+			var g GeoPoint
+			if err := json.Unmarshal(rv, &g); err != nil {
+				return err
+			}
+			v.GeoPointValue = &g
+		case "arrayValue":
+			var a ArrayValue
+			if err := json.Unmarshal(rv, &a); err != nil {
+				return err
+			}
+			v.ArrayValue = &a
+		case "mapValue":
+			var m MapValue
+			if err := json.Unmarshal(rv, &m); err != nil {
+				return err
+			}
+			v.MapValue = &m
+		default:
+			return fmt.Errorf("unknown Firestore value variant %q", key)
+		}
+	}
+	return nil
+}
+
+// ─── constructors ─────────────────────────────────────────────────────────────
+
+// StringVal returns a stringValue.
+func StringVal(s string) *Value { return &Value{StringValue: &s} }
+
+// BoolVal returns a booleanValue.
+func BoolVal(b bool) *Value { return &Value{BooleanValue: &b} }
+
+// IntVal returns an integerValue.
+func IntVal(n int64) *Value { return &Value{IntegerValue: &n} }
+
+// DoubleVal returns a doubleValue.
+func DoubleVal(f float64) *Value { return &Value{DoubleValue: &f} }
+
+// TimestampVal returns a timestampValue.
+func TimestampVal(t time.Time) *Value { return &Value{TimestampValue: &t} }
+
+// NullVal returns a nullValue.
+func NullVal() *Value { return &Value{NullValue: strPtr(NullEnumValue)} }
+
+// BytesVal returns a bytesValue.
+func BytesVal(b []byte) *Value { return &Value{BytesValue: b} }
+
+// ReferenceVal returns a referenceValue (a document resource name).
+func ReferenceVal(r string) *Value { return &Value{ReferenceValue: &r} }
+
+// GeoPointVal returns a geoPointValue.
+func GeoPointVal(lat, lon float64) *Value {
+	return &Value{GeoPointValue: &GeoPoint{Latitude: lat, Longitude: lon}}
+}
+
+// ArrayVal returns an arrayValue.
+func ArrayVal(vals ...*Value) *Value { return &Value{ArrayValue: &ArrayValue{Values: vals}} }
+
+// MapVal returns a mapValue.
+func MapVal(fields map[string]*Value) *Value { return &Value{MapValue: &MapValue{Fields: fields}} }
+
+func strPtr(s string) *string { return &s }
+
+// ─── accessors ────────────────────────────────────────────────────────────────
+
+// Type returns the variant kind ("stringValue", "integerValue", ...), or ""
+// when no variant is set.
+func (v *Value) Type() string {
+	switch {
+	case v == nil:
+		return ""
+	case v.NullValue != nil:
+		return "nullValue"
+	case v.BooleanValue != nil:
+		return "booleanValue"
+	case v.IntegerValue != nil:
+		return "integerValue"
+	case v.DoubleValue != nil:
+		return "doubleValue"
+	case v.TimestampValue != nil:
+		return "timestampValue"
+	case v.StringValue != nil:
+		return "stringValue"
+	case v.BytesValue != nil:
+		return "bytesValue"
+	case v.ReferenceValue != nil:
+		return "referenceValue"
+	case v.GeoPointValue != nil:
+		return "geoPointValue"
+	case v.ArrayValue != nil:
+		return "arrayValue"
+	case v.MapValue != nil:
+		return "mapValue"
+	}
+	return ""
+}
+
+// AsString returns the stringValue variant.
+func (v *Value) AsString() (string, bool) {
+	if v == nil || v.StringValue == nil {
+		return "", false
+	}
+	return *v.StringValue, true
+}
+
+// AsBool returns the booleanValue variant.
+func (v *Value) AsBool() (bool, bool) {
+	if v == nil || v.BooleanValue == nil {
+		return false, false
+	}
+	return *v.BooleanValue, true
+}
+
+// AsInt64 returns the integerValue variant.
+func (v *Value) AsInt64() (int64, bool) {
+	if v == nil || v.IntegerValue == nil {
+		return 0, false
+	}
+	return *v.IntegerValue, true
+}
+
+// AsFloat64 returns the doubleValue variant.
+func (v *Value) AsFloat64() (float64, bool) {
+	if v == nil || v.DoubleValue == nil {
+		return 0, false
+	}
+	return *v.DoubleValue, true
+}
+
+// AsTimestamp returns the timestampValue variant.
+func (v *Value) AsTimestamp() (time.Time, bool) {
+	if v == nil || v.TimestampValue == nil {
+		return time.Time{}, false
+	}
+	return *v.TimestampValue, true
+}
+
+// AsBytes returns the bytesValue variant.
+func (v *Value) AsBytes() ([]byte, bool) {
+	if v == nil || v.BytesValue == nil {
+		return nil, false
+	}
+	return v.BytesValue, true
+}
+
+// AsReference returns the referenceValue variant.
+func (v *Value) AsReference() (string, bool) {
+	if v == nil || v.ReferenceValue == nil {
+		return "", false
+	}
+	return *v.ReferenceValue, true
+}
+
+// AsGeoPoint returns the geoPointValue variant.
+func (v *Value) AsGeoPoint() (GeoPoint, bool) {
+	if v == nil || v.GeoPointValue == nil {
+		return GeoPoint{}, false
+	}
+	return *v.GeoPointValue, true
+}
+
+// AsArray returns the arrayValue variant.
+func (v *Value) AsArray() ([]*Value, bool) {
+	if v == nil || v.ArrayValue == nil {
+		return nil, false
+	}
+	return v.ArrayValue.Values, true
+}
+
+// AsMap returns the mapValue variant.
+func (v *Value) AsMap() (map[string]*Value, bool) {
+	if v == nil || v.MapValue == nil {
+		return nil, false
+	}
+	return v.MapValue.Fields, true
+}

--- a/internal/gcp/store/firestore/value_test.go
+++ b/internal/gcp/store/firestore/value_test.go
@@ -1,0 +1,52 @@
+package firestore
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+)
+
+// TestValueSpecialDoubleJSONRoundTrip asserts NaN/±Infinity doubles round-trip
+// through the Firestore wire encoding: they are emitted as the strings
+// "NaN"/"Infinity"/"-Infinity" (protobuf JSON mapping), then decoded back to
+// the matching special float values.
+func TestValueSpecialDoubleJSONRoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		val   float64
+		wire  string
+		check func(float64) bool
+	}{
+		{"nan", math.NaN(), "NaN", math.IsNaN},
+		{"pos_inf", math.Inf(1), "Infinity", func(f float64) bool { return math.IsInf(f, 1) }},
+		{"neg_inf", math.Inf(-1), "-Infinity", func(f float64) bool { return math.IsInf(f, -1) }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(DoubleVal(tc.val))
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var raw map[string]any
+			if err := json.Unmarshal(b, &raw); err != nil {
+				t.Fatalf("unmarshal raw: %v", err)
+			}
+			if got, ok := raw["doubleValue"].(string); !ok || got != tc.wire {
+				t.Fatalf("expected doubleValue %q, got %v", tc.wire, raw["doubleValue"])
+			}
+
+			var got Value
+			if err := json.Unmarshal(b, &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			f, ok := got.AsFloat64()
+			if !ok {
+				t.Fatalf("expected doubleValue, got %+v", got)
+			}
+			if !tc.check(f) {
+				t.Fatalf("round-trip mismatch: got %v", f)
+			}
+		})
+	}
+}

--- a/internal/gcp/store/migrations/017_firestore.sql
+++ b/internal/gcp/store/migrations/017_firestore.sql
@@ -1,0 +1,21 @@
+-- Firestore document data plane. Documents are keyed by their full resource
+-- name (globally unique, embeds owning project + database). collection_id and
+-- parent_path are derived from name and persisted for efficient collectionGroup
+-- and hierarchical queries without full-table scans. fields is the raw
+-- map[string]Value JSON (Firestore wire Value shapes).
+CREATE TABLE IF NOT EXISTS jc_firestore_documents (
+    project       TEXT        NOT NULL,
+    database      TEXT        NOT NULL,
+    collection_id TEXT        NOT NULL,
+    parent_path   TEXT        NOT NULL,
+    name          TEXT        PRIMARY KEY,
+    fields        JSONB       NOT NULL DEFAULT '{}',
+    create_time   TIMESTAMPTZ NOT NULL,
+    update_time   TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_jc_firestore_documents_collection
+    ON jc_firestore_documents (project, database, collection_id);
+
+CREATE INDEX IF NOT EXISTS idx_jc_firestore_documents_parent
+    ON jc_firestore_documents (project, database, parent_path);

--- a/internal/gcp/wire/wire.go
+++ b/internal/gcp/wire/wire.go
@@ -41,4 +41,9 @@ const (
 	// CSEKKeySHA256 carries the base64 "x-goog-encryption-key-sha256" header
 	// value as a string in NormalizedRequest.Params (codec → provider).
 	CSEKKeySHA256 = "x-goog-encryption-key-sha256"
+	// RawJSONKey carries a json.RawMessage in ProviderResponse.Data that the codec
+	// emits verbatim (used by server-streaming REST methods — Firestore runQuery
+	// and batchGet — whose response body is newline-delimited JSON, one JSON
+	// object per line, not a JSON array or a single object).
+	RawJSONKey = "jaiscloud:rawJSON"
 )

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -120,6 +120,10 @@ type ProviderError struct {
 	Code       string // canonical code, e.g. "NotFound", "InvalidParameter"
 	Message    string
 	HTTPStatus int
+	// Status, when non-empty, overrides the codec-derived google.rpc status
+	// string in the error envelope (e.g. "FAILED_PRECONDITION" on HTTP 400,
+	// "ABORTED" on HTTP 409). GCP codecs honor it; AWS/Azure ignore it.
+	Status string
 	// Data carries additional structured fields merged into the error body by
 	// codecs (e.g. Reason, Type, LimitType for throttle errors). nil is safe.
 	Data map[string]any

--- a/tests/integration/gcp/sdkv1/firestore_test.go
+++ b/tests/integration/gcp/sdkv1/firestore_test.go
@@ -1,0 +1,195 @@
+// Package sdkv1_test exercises the Firestore documents REST surface through the
+// official apiary client (google.golang.org/api/firestore/v1).
+package sdkv1_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	firestore "google.golang.org/api/firestore/v1"
+
+	"github.com/stretchr/testify/require"
+)
+
+const fsParent = "projects/proj/databases/(default)/documents"
+
+func fsStr(v string) *firestore.Value { return &firestore.Value{StringValue: v} }
+func fsInt(v int64) *firestore.Value  { return &firestore.Value{IntegerValue: v} }
+
+func TestSDKFirestoreCRUD(t *testing.T) {
+	ctx := context.Background()
+	svc, err := firestore.NewService(ctx, opts()...)
+	require.NoError(t, err)
+
+	coll := unique("cities")
+
+	// createDocument with an explicit documentId.
+	doc, err := svc.Projects.Databases.Documents.CreateDocument(fsParent, coll, &firestore.Document{
+		Fields: map[string]firestore.Value{
+			"name":       *fsStr("San Francisco"),
+			"population": *fsInt(800000),
+		},
+	}).DocumentId("SF").Do()
+	require.NoError(t, err)
+	require.NotEmpty(t, doc.Name)
+	require.Equal(t, "San Francisco", doc.Fields["name"].StringValue)
+
+	// get.
+	got, err := svc.Projects.Databases.Documents.Get(doc.Name).Do()
+	require.NoError(t, err)
+	require.Equal(t, "San Francisco", got.Fields["name"].StringValue)
+	require.EqualValues(t, 800000, got.Fields["population"].IntegerValue)
+
+	// patch with updateMask.
+	patched, err := svc.Projects.Databases.Documents.Patch(doc.Name, &firestore.Document{
+		Fields: map[string]firestore.Value{"population": *fsInt(900000)},
+	}).UpdateMaskFieldPaths("population").Do()
+	require.NoError(t, err)
+	require.EqualValues(t, 900000, patched.Fields["population"].IntegerValue)
+
+	// list.
+	list, err := svc.Projects.Databases.Documents.List(fsParent, coll).Do()
+	require.NoError(t, err)
+	require.Len(t, list.Documents, 1)
+
+	// delete.
+	_, err = svc.Projects.Databases.Documents.Delete(doc.Name).Do()
+	require.NoError(t, err)
+
+	// get after delete → 404.
+	_, err = svc.Projects.Databases.Documents.Get(doc.Name).Do()
+	require.Error(t, err)
+}
+
+func TestSDKFirestoreCommitBatchWrite(t *testing.T) {
+	ctx := context.Background()
+	svc, err := firestore.NewService(ctx, opts()...)
+	require.NoError(t, err)
+
+	coll := unique("cities")
+
+	// commit: two creates.
+	db := "projects/proj/databases/(default)"
+	commit, err := svc.Projects.Databases.Documents.Commit(db, &firestore.CommitRequest{
+		Writes: []*firestore.Write{
+			{Update: &firestore.Document{Name: fsParent + "/" + coll + "/a", Fields: map[string]firestore.Value{"n": *fsInt(1)}}},
+			{Update: &firestore.Document{Name: fsParent + "/" + coll + "/b", Fields: map[string]firestore.Value{"n": *fsInt(2)}}},
+		},
+	}).Do()
+	require.NoError(t, err)
+	require.Len(t, commit.WriteResults, 2)
+	require.NotEmpty(t, commit.CommitTime)
+
+	// batchWrite: one valid update, one delete.
+	bw, err := svc.Projects.Databases.Documents.BatchWrite(db, &firestore.BatchWriteRequest{
+		Writes: []*firestore.Write{
+			{Update: &firestore.Document{Name: fsParent + "/" + coll + "/c", Fields: map[string]firestore.Value{"n": *fsInt(3)}}},
+			{Delete: fsParent + "/" + coll + "/a"},
+		},
+	}).Do()
+	require.NoError(t, err)
+	require.Len(t, bw.Status, 2)
+	require.EqualValues(t, 0, bw.Status[0].Code)
+	require.EqualValues(t, 0, bw.Status[1].Code)
+}
+
+func TestSDKFirestoreTransaction(t *testing.T) {
+	ctx := context.Background()
+	svc, err := firestore.NewService(ctx, opts()...)
+	require.NoError(t, err)
+
+	db := "projects/proj/databases/(default)"
+	begin, err := svc.Projects.Databases.Documents.BeginTransaction(db, &firestore.BeginTransactionRequest{}).Do()
+	require.NoError(t, err)
+	require.NotEmpty(t, begin.Transaction)
+
+	_, err = svc.Projects.Databases.Documents.Rollback(db, &firestore.RollbackRequest{Transaction: begin.Transaction}).Do()
+	require.NoError(t, err)
+}
+
+// TestSDKFirestoreRunQuery exercises runQuery via a raw HTTP call, because the
+// apiary RunQuery.Do decodes a single object while Firestore's server-streaming
+// REST response is newline-delimited JSON (one object per line).
+func TestSDKFirestoreRunQuery(t *testing.T) {
+	ctx := context.Background()
+	svc, err := firestore.NewService(ctx, opts()...)
+	require.NoError(t, err)
+
+	coll := unique("cities")
+	for _, id := range []string{"a", "b", "c"} {
+		_, err := svc.Projects.Databases.Documents.CreateDocument(fsParent, coll, &firestore.Document{
+			Fields: map[string]firestore.Value{"pop": *fsInt(int64(len(id) * 100))},
+		}).DocumentId(id).Do()
+		require.NoError(t, err)
+	}
+
+	reqBody, _ := json.Marshal(map[string]any{
+		"structuredQuery": map[string]any{
+			"from": []map[string]any{{"collectionId": coll}},
+			"where": map[string]any{
+				"fieldFilter": map[string]any{
+					"field": map[string]any{"fieldPath": "pop"},
+					"op":    "GREATER_THAN",
+					"value": map[string]any{"integerValue": "50"},
+				},
+			},
+			"orderBy": []map[string]any{
+				{"field": map[string]any{"fieldPath": "pop"}, "direction": "ASCENDING"},
+			},
+		},
+	})
+
+	url := strings.TrimRight(endpoint(), "/") + "/v1/" + fsParent + ":runQuery"
+	resp, err := http.Post(url, "application/json", strings.NewReader(string(reqBody)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	var docs []map[string]any
+	var done bool
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var msg map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &msg))
+		if _, ok := msg["document"]; ok {
+			docs = append(docs, msg)
+		}
+		if d, ok := msg["done"].(bool); ok && d {
+			done = true
+		}
+	}
+	require.Len(t, docs, 3)
+	require.True(t, done)
+}
+
+// TestSDKFirestoreCompositeIndexRejected verifies strict composite-index
+// enforcement: a multi-field orderBy without a registered index is rejected
+// with FAILED_PRECONDITION (HTTP 400).
+func TestSDKFirestoreCompositeIndexRejected(t *testing.T) {
+	coll := unique("cities")
+	reqBody, _ := json.Marshal(map[string]any{
+		"structuredQuery": map[string]any{
+			"from": []map[string]any{{"collectionId": coll}},
+			"orderBy": []map[string]any{
+				{"field": map[string]any{"fieldPath": "a"}, "direction": "ASCENDING"},
+				{"field": map[string]any{"fieldPath": "b"}, "direction": "ASCENDING"},
+			},
+		},
+	})
+	url := strings.TrimRight(endpoint(), "/") + "/v1/" + fsParent + ":runQuery"
+	resp, err := http.Post(url, "application/json", strings.NewReader(string(reqBody)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	require.Contains(t, string(body), "FAILED_PRECONDITION")
+}


### PR DESCRIPTION
## Summary

Implements **Firestore** (the DynamoDB analogue) over the REST/JSON track, with AWS-parity Postgres persistence, built on the Phase 0/1/1.5 store/identity/policy/crypto infrastructure.

## Scope

- **Value model** — typed `Value` one-of (`integerValue` as decimal string, `bytesValue` base64, `timestampValue` RFC 3339, `nullValue` enum, NaN/±Inf doubles, exactly-one-variant enforcement).
- **Document CRUD** — `get`, `createDocument` (client `?documentId=` or 20-char auto-ID), `patch` (`updateMask` + `mask.fieldPaths` + `currentDocument.*` preconditions), `delete` (preconditions), `list`, `listDocuments`, `listCollectionIds`, `batchGet`, `batchWrite` (non-atomic per-write statuses).
- **StructuredQuery engine** — all 10 `FieldFilter` operators, AND/OR composite + unary filters (`IS_NULL`/`IS_NOT_NULL`/`IS_NAN`/`IS_NOT_NAN`), `__name__` mapping, implicit `__name__` tie-breaker, `Cursor.before` inclusivity, projection, operator limits (`IN`/`ARRAY_CONTAINS_ANY` ≤30, `NOT_IN` ≤10, ≤30 disjunctions), subcollection/collection-group scoping.
- **Transactions** — `beginTransaction`/`rollback`/`commit` with read-set OCC (incl. missing-read tracking) → `ABORTED`@409; per-write `Precondition` → `FAILED_PRECONDITION`@400; 500-write + 10 MiB limits; `FieldTransform` ops.
- **Composite indexes** — `GoogleFirestoreAdminV1Index` admin CRUD + strict enforcement (missing composite index → `FAILED_PRECONDITION`@400).
- **Persistence** — `jc_firestore_documents` table + migration `017`; memory + Postgres, Snapshotter parity.

## Wire fidelity

- Newline-delimited JSON for server-streaming `runQuery`/`batchGet`.
- Per-error RPC-status override (`ProviderError.Status`) distinguishing `FAILED_PRECONDITION`@400 / `ABORTED`@409 from `INVALID_ARGUMENT`/`ALREADY_EXISTS`.
- 1 MiB document cap, `^__.*__$` reserved-name rejection, per-field size limits.

## Tests

- Store unit tests (Value round-trip incl. NaN/Inf, memory CRUD, snapshot/restore, commit OCC).
- Provider unit tests (query engine, transforms, preconditions, index enforcement, NDJSON framing).
- SDK apiary test `tests/integration/gcp/sdkv1/firestore_test.go` (`google.golang.org/api/firestore/v1`).

## Deferred (follow-ups)

- gRPC transport (streaming `write`/`listen`; official Firestore SDKs) — separate PR.
- `runAggregationQuery`, `partitionQuery`, `readTime`/`orderBy`/`recursive` on `list`.
