### PR TITLE
feat(gcp): SDK compatibility — gRPC transports (PubSub/SecretManager/KMS) + GCS/Firestore parity

### DIFF
--- a/cmd/jaiscloud-gcp/main.go
+++ b/cmd/jaiscloud-gcp/main.go
@@ -23,6 +23,9 @@ import (
 	"jaiscloud/internal/gcp/crypto"
 	grpcserver "jaiscloud/internal/gcp/grpc"
 	grpcfirestore "jaiscloud/internal/gcp/grpc/firestore"
+	grpckms "jaiscloud/internal/gcp/grpc/kms"
+	grpcpubsub "jaiscloud/internal/gcp/grpc/pubsub"
+	grpcsecretmanager "jaiscloud/internal/gcp/grpc/secretmanager"
 	firestoreprovider "jaiscloud/internal/gcp/provider/firestore"
 	iamprovider "jaiscloud/internal/gcp/provider/iam"
 	kmsprovider "jaiscloud/internal/gcp/provider/kms"
@@ -43,6 +46,10 @@ import (
 	"jaiscloud/internal/store"
 
 	firestorepb "cloud.google.com/go/firestore/apiv1/firestorepb"
+	iampb "cloud.google.com/go/iam/apiv1/iampb"
+	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
+	pubsubpb "cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/spf13/cobra"
@@ -138,8 +145,22 @@ func startCmd() *cobra.Command {
 			// registry.
 			grpcPort, _ := cmd.Flags().GetInt("grpc-port")
 			firestoreGRPC := grpcfirestore.NewService(firestoreP.Service, cfg.ProjectID)
+			pubsubGRPC := grpcpubsub.NewService(stores.resources, stores.messages, crypto.NewEnvelopeEncryptor(stores.keys), cfg.ProjectID)
+			secretGRPC := grpcsecretmanager.NewService(stores.secrets, stores.resources, crypto.NewEnvelopeEncryptor(stores.keys), cfg.ProjectID)
+			kmsGRPC := grpckms.NewService(stores.keys, stores.resources, crypto.NewEnvelopeEncryptor(stores.keys), cfg.ProjectID)
 			gserv := grpcserver.NewServer(fmt.Sprintf(":%d", grpcPort))
 			firestorepb.RegisterFirestoreServer(gserv.GRPC(), firestoreGRPC)
+			pubsubpb.RegisterPublisherServer(gserv.GRPC(), pubsubGRPC)
+			pubsubpb.RegisterSubscriberServer(gserv.GRPC(), pubsubGRPC)
+			kmspb.RegisterKeyManagementServiceServer(gserv.GRPC(), kmsGRPC)
+			// Secret Manager's IAM surface (GetIamPolicy/SetIamPolicy/
+			// TestIamPermissions) is served by the SecretManagerService itself
+			// (its proto embeds the methods), so it does not re-register the
+			// standalone google.iam.v1.IAMPolicy service that Pub/Sub and KMS own.
+			// Pub/Sub and KMS share the single IAMPolicy service, so their IAM
+			// surfaces are dispatched through one router.
+			secretmanagerpb.RegisterSecretManagerServiceServer(gserv.GRPC(), secretGRPC)
+			iampb.RegisterIAMPolicyServer(gserv.GRPC(), grpcserver.NewIAMRouter(pubsubGRPC, kmsGRPC))
 
 			adminHandler := admin.NewHandler()
 			adminHandler.RegisterResetter(stores.objects)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,10 @@ go 1.26.3
 
 require (
 	cloud.google.com/go/firestore v1.25.0
+	cloud.google.com/go/iam v1.13.0
+	cloud.google.com/go/kms v1.33.0
+	cloud.google.com/go/pubsub/v2 v2.7.0
+	cloud.google.com/go/secretmanager v1.21.0
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
@@ -69,6 +73,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/longrunning v1.2.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,15 @@
 cloud.google.com/go/firestore v1.25.0 h1:yY3rQKyQXNhnhETdseNayF6W1p4x0bdg9ZYS4hKJfOw=
 cloud.google.com/go/firestore v1.25.0/go.mod h1:0PU6hj+r/QlhB6BLsRX+Kt/SYefTXrpYrBeHbYaSis8=
+cloud.google.com/go/iam v1.13.0 h1:ufT3FPT5rFFXu6UtLkNoxaOaV5EuA1dsSkmemCSTo6U=
+cloud.google.com/go/iam v1.13.0/go.mod h1:gHXdDEiPDvqd1q1KwBDGQlgZY/BwY760zU2LhOZS5w0=
+cloud.google.com/go/kms v1.33.0 h1:pG0X78m212b2pv9N4fdMoUO69LuZGQ9kSvn8sHBOFAo=
+cloud.google.com/go/kms v1.33.0/go.mod h1:CSGvW6GnMQbY+1nOHcIzhMtHSbExXlOmCKjWtYVjcpA=
+cloud.google.com/go/longrunning v1.2.0 h1:WjYH3YHBGCxGJP9M4dWGHBfXr/cFIjMkNgWcJj7/iMM=
+cloud.google.com/go/longrunning v1.2.0/go.mod h1:5KMQALFGOCtFoi2xSOA1u3H7WKlhmckgiyFw7+LGQp0=
+cloud.google.com/go/pubsub/v2 v2.7.0 h1:MFrBTZZa6PDWZzCi4NJRsHKMm2w0a4oAaYNqwjgbQTE=
+cloud.google.com/go/pubsub/v2 v2.7.0/go.mod h1:JaFvWNVRk3Knoil/4M1ECeLOaI9D8drbmJWypQlK5aM=
+cloud.google.com/go/secretmanager v1.21.0 h1:e56QQaKWRyzBdUz40AeZaio/ZHAl268cFx3QFAAw9CY=
+cloud.google.com/go/secretmanager v1.21.0/go.mod h1:+nlV+GYqTD8DM+x7Kk3UF7ZPYgdYMowrkZxAmMXORQ8=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=

--- a/internal/gcp/adapter/gcs.go
+++ b/internal/gcp/adapter/gcs.go
@@ -47,6 +47,7 @@ func (c *GCSCodec) decodeRawMedia(r *http.Request, body []byte) (*model.Normaliz
 	nr := &model.NormalizedRequest{Service: "storage", Params: map[string]any{}}
 	queryToParams(r, nr.Params)
 	csekFromHeaders(r, nr.Params)
+	metadataFromHeaders(r, nr.Params)
 	nr.Params["bucket"] = seg[0]
 	nr.Params["object"] = strings.Join(seg[1:], "/")
 	if r.Method == http.MethodGet || r.Method == http.MethodHead {
@@ -76,6 +77,7 @@ func (c *GCSCodec) decodeStorage(r *http.Request, body []byte, rest string) (*mo
 	nr := &model.NormalizedRequest{Service: "storage", Params: map[string]any{}}
 	queryToParams(r, nr.Params)
 	csekFromHeaders(r, nr.Params)
+	metadataFromHeaders(r, nr.Params)
 
 	switch {
 	case len(seg) == 1 && seg[0] == "b":
@@ -160,6 +162,33 @@ func (c *GCSCodec) decodeStorage(r *http.Request, body []byte, rest string) (*mo
 		} else {
 			nr.Action = "ObjectsGetIamPolicy"
 		}
+	case len(seg) >= 3 && seg[0] == "b" && seg[2] == "o" && segmentIndex(seg, "rewriteTo") >= 0:
+		// /b/{srcBucket}/o/{srcObject...}/rewriteTo/b/{dstBucket}/o/{dstObject...}
+		ri := segmentIndex(seg, "rewriteTo")
+		nr.Params["sourceBucket"] = seg[1]
+		nr.Params["sourceObject"] = strings.Join(seg[3:ri], "/")
+		if ri+3 < len(seg) && seg[ri+1] == "b" && seg[ri+3] == "o" {
+			nr.Params["destinationBucket"] = seg[ri+2]
+			nr.Params["destinationObject"] = strings.Join(seg[ri+4:], "/")
+		}
+		nr.Action = "ObjectsRewrite"
+		if r.Method == http.MethodPost {
+			m, err := parseJSON(body)
+			if err != nil {
+				return nil, model.NewProviderError("InvalidRequest", "malformed JSON body", 400)
+			}
+			nr.Params["body"] = m
+		}
+	case len(seg) >= 4 && seg[0] == "b" && seg[2] == "o" && seg[len(seg)-1] == "compose":
+		// /b/{bucket}/o/{destination...}/compose
+		nr.Params["bucket"] = seg[1]
+		nr.Params["object"] = strings.Join(seg[3:len(seg)-1], "/")
+		nr.Action = "ObjectsCompose"
+		m, err := parseJSON(body)
+		if err != nil {
+			return nil, model.NewProviderError("InvalidRequest", "malformed JSON body", 400)
+		}
+		nr.Params["body"] = m
 	case len(seg) >= 3 && seg[0] == "b" && seg[2] == "o":
 		// /b/{bucket}/o[/{object}]
 		nr.Params["bucket"] = seg[1]
@@ -231,6 +260,7 @@ func (c *GCSCodec) decodeUpload(r *http.Request, body []byte, rest string) (*mod
 	nr := &model.NormalizedRequest{Service: "storage", Params: map[string]any{}}
 	queryToParams(r, nr.Params)
 	csekFromHeaders(r, nr.Params)
+	metadataFromHeaders(r, nr.Params)
 	nr.Params["bucket"] = seg[1]
 
 	if len(seg) > 3 {
@@ -310,6 +340,15 @@ func (c *GCSCodec) Encode(nr *model.NormalizedRequest, resp *model.ProviderRespo
 	}
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json; charset=UTF-8")
+
+	// Forward any extra response headers the provider surfaced (media-download
+	// x-goog-* headers, etc.). Applied before every branch below so they are
+	// emitted for streaming and buffered responses alike.
+	if extra, ok := resp.Data[wire.HeadersKey].(map[string]string); ok {
+		for k, v := range extra {
+			headers.Set(k, v)
+		}
+	}
 
 	if loc, ok := resp.Data[wire.LocationKey].(string); ok && loc != "" {
 		headers.Set("Location", loc)
@@ -473,6 +512,35 @@ func csekFromHeaders(r *http.Request, params map[string]any) {
 	if v := r.Header.Get("x-goog-encryption-key-sha256"); v != "" {
 		params[wire.CSEKKeySHA256] = v
 	}
+}
+
+// metadataFromHeaders copies x-goog-meta-* request headers into params as
+// wire.MetaHeadersKey (map[string]string). Custom object metadata is carried in
+// these headers by the simple-upload path (uploadType=media); the multipart and
+// resumable paths carry it in the JSON body's "metadata" map instead, and the
+// provider merges both sources.
+func metadataFromHeaders(r *http.Request, params map[string]any) {
+	md := map[string]string{}
+	for k, vs := range r.Header {
+		if len(vs) == 0 || !strings.HasPrefix(strings.ToLower(k), "x-goog-meta-") {
+			continue
+		}
+		key := k[len("x-goog-meta-"):]
+		md[strings.ToLower(key)] = vs[0]
+	}
+	if len(md) > 0 {
+		params[wire.MetaHeadersKey] = md
+	}
+}
+
+// segmentIndex returns the index of the first path segment equal to s, or -1.
+func segmentIndex(seg []string, s string) int {
+	for i, v := range seg {
+		if v == s {
+			return i
+		}
+	}
+	return -1
 }
 
 // parseJSON decodes a JSON body into a map, or returns nil for empty/JSON bodies

--- a/internal/gcp/adapter/gcs_test.go
+++ b/internal/gcp/adapter/gcs_test.go
@@ -1,7 +1,9 @@
 package gcp
 
 import (
+	"io"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"encoding/json"
@@ -197,5 +199,88 @@ func TestGCSCodecEncodeError(t *testing.T) {
 	}
 	if _, ok := errObj["status"]; ok {
 		t.Error("GCS error envelope must not contain a 'status' field")
+	}
+}
+
+func TestGCSCodecRewriteRouting(t *testing.T) {
+	c := &GCSCodec{}
+	r := httptest.NewRequest("POST", "/storage/v1/b/srcbkt/o/dir/src.txt/rewriteTo/b/dstbkt/o/dir/dst.txt", nil)
+	nr, err := c.Decode(r, []byte(`{"contentType":"text/plain"}`))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if nr.Action != "ObjectsRewrite" {
+		t.Fatalf("expected ObjectsRewrite, got %q", nr.Action)
+	}
+	if b, _ := nr.Params["sourceBucket"].(string); b != "srcbkt" {
+		t.Errorf("expected sourceBucket srcbkt, got %q", b)
+	}
+	if o, _ := nr.Params["sourceObject"].(string); o != "dir/src.txt" {
+		t.Errorf("expected sourceObject dir/src.txt, got %q", o)
+	}
+	if b, _ := nr.Params["destinationBucket"].(string); b != "dstbkt" {
+		t.Errorf("expected destinationBucket dstbkt, got %q", b)
+	}
+	if o, _ := nr.Params["destinationObject"].(string); o != "dir/dst.txt" {
+		t.Errorf("expected destinationObject dir/dst.txt, got %q", o)
+	}
+	if _, ok := nr.Params["body"].(map[string]any); !ok {
+		t.Error("expected rewrite request body to be parsed")
+	}
+}
+
+func TestGCSCodecComposeRouting(t *testing.T) {
+	c := &GCSCodec{}
+	r := httptest.NewRequest("POST", "/storage/v1/b/bkt/o/dir/dst.txt/compose", nil)
+	nr, err := c.Decode(r, []byte(`{"sourceObjects":[{"name":"a.txt"}]}`))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if nr.Action != "ObjectsCompose" {
+		t.Fatalf("expected ObjectsCompose, got %q", nr.Action)
+	}
+	if b, _ := nr.Params["bucket"].(string); b != "bkt" {
+		t.Errorf("expected bucket bkt, got %q", b)
+	}
+	if o, _ := nr.Params["object"].(string); o != "dir/dst.txt" {
+		t.Errorf("expected object dir/dst.txt, got %q", o)
+	}
+}
+
+func TestGCSCodecMetadataHeaders(t *testing.T) {
+	c := &GCSCodec{}
+	r := httptest.NewRequest("POST", "/upload/storage/v1/b/bkt/o?uploadType=media&name=obj", nil)
+	r.Header.Set("x-goog-meta-originalname", "file.dat")
+	r.Header.Set("x-goog-meta-env", "test")
+	nr, err := c.Decode(r, []byte("bytes"))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	md, _ := nr.Params[wire.MetaHeadersKey].(map[string]string)
+	if md["originalname"] != "file.dat" || md["env"] != "test" {
+		t.Fatalf("expected metadata headers captured, got %v", md)
+	}
+}
+
+func TestGCSCodecEncodeForwardsHeaders(t *testing.T) {
+	c := &GCSCodec{}
+	nr := &model.NormalizedRequest{}
+	resp := &model.ProviderResponse{
+		HTTPStatus: 200,
+		Data: map[string]any{
+			"_stream":           io.NopCloser(strings.NewReader("x")),
+			wire.HeadersKey:     map[string]string{"x-goog-generation": "123", "x-goog-meta-Foo": "bar"},
+			wire.ContentTypeKey: "text/plain",
+		},
+	}
+	status, hdr, _ := c.Encode(nr, resp)
+	if status != 200 {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if hdr.Get("x-goog-generation") != "123" {
+		t.Errorf("expected x-goog-generation header, got %q", hdr.Get("x-goog-generation"))
+	}
+	if hdr.Get("x-goog-meta-Foo") != "bar" {
+		t.Errorf("expected x-goog-meta-Foo header, got %q", hdr.Get("x-goog-meta-Foo"))
 	}
 }

--- a/internal/gcp/grpc/firestore/listen.go
+++ b/internal/gcp/grpc/firestore/listen.go
@@ -1,0 +1,376 @@
+package firestore
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"strings"
+	"time"
+
+	firestorepb "cloud.google.com/go/firestore/apiv1/firestorepb"
+	"jaiscloud/internal/clock"
+	firestoreprovider "jaiscloud/internal/gcp/provider/firestore"
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+	"jaiscloud/internal/model"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// EncodeResumeToken encodes a monotonic sequence number into an 8-byte resume
+// token (big-endian uint64).
+func EncodeResumeToken(seq uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, seq)
+	return b
+}
+
+// DecodeResumeToken decodes an 8-byte resume token back into a sequence number.
+// ok is false for any token that is not exactly 8 bytes.
+func DecodeResumeToken(b []byte) (uint64, bool) {
+	if len(b) != 8 {
+		return 0, false
+	}
+	return binary.BigEndian.Uint64(b), true
+}
+
+// listenTarget is a resolved watch target on a single Listen stream. Exactly
+// one of query / documents is set.
+type listenTarget struct {
+	query     *firestoreprovider.StructuredQuery
+	parent    string
+	documents []string
+}
+
+func (t listenTarget) isQuery() bool { return t.query != nil }
+
+// listenSession carries the per-stream target registry plus a helper to send
+// responses. All sends happen from the single Listen loop goroutine, so the
+// stream is never written concurrently.
+type listenSession struct {
+	srv     *Service
+	stream  firestorepb.Firestore_ListenServer
+	targets map[int32]listenTarget
+	nextID  int32
+
+	// lastReadTime is the most recent read_time handed out on this stream.
+	// read_time must be non-decreasing across the stream (the Go Firestore SDK
+	// requires each snapshot's read_time to be valid and consistent), so it is
+	// advanced monotonically rather than read directly from the wall clock,
+	// which can jump backwards on NTP adjustment.
+	lastReadTime time.Time
+}
+
+// nextReadTime returns a read_time strictly greater than every read_time
+// previously returned on this stream. It reads the shared clock and bumps it
+// past lastReadTime when the clock has not advanced (or has moved backwards),
+// guaranteeing monotonicity.
+func (ls *listenSession) nextReadTime() time.Time {
+	now := clock.Now()
+	if !now.After(ls.lastReadTime) {
+		now = ls.lastReadTime.Add(time.Nanosecond)
+	}
+	ls.lastReadTime = now
+	return now
+}
+
+// Listen implements the bidirectional streaming Firestore.Listen RPC. For each
+// added target it streams an initial snapshot (or incremental deltas when a
+// valid resume token is supplied), then real-time DocumentChange/DocumentDelete
+// events as writes are published by the shared provider Service's change-feed.
+func (s *Service) Listen(stream firestorepb.Firestore_ListenServer) error {
+	ctx := stream.Context()
+	ls := &listenSession{
+		srv:     s,
+		stream:  stream,
+		targets: make(map[int32]listenTarget),
+	}
+
+	sub := s.svc.SubscribeChange()
+	defer sub.Cancel()
+
+	reqCh := make(chan *firestorepb.ListenRequest, 8)
+	recvErr := make(chan error, 1)
+	go func() {
+		for {
+			req, err := stream.Recv()
+			if err != nil {
+				recvErr <- err
+				return
+			}
+			select {
+			case reqCh <- req:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-recvErr:
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		case req := <-reqCh:
+			if err := ls.handleRequest(req); err != nil {
+				return err
+			}
+		case ev := <-sub.C:
+			ls.handleChange(ev)
+		}
+	}
+}
+
+func (ls *listenSession) send(resp *firestorepb.ListenResponse) error {
+	return ls.stream.Send(resp)
+}
+
+func (ls *listenSession) handleRequest(req *firestorepb.ListenRequest) error {
+	switch tc := req.GetTargetChange().(type) {
+	case *firestorepb.ListenRequest_AddTarget:
+		return ls.handleAddTarget(tc.AddTarget)
+	case *firestorepb.ListenRequest_RemoveTarget:
+		return ls.handleRemoveTarget(tc.RemoveTarget)
+	}
+	return nil
+}
+
+func (ls *listenSession) handleAddTarget(t *firestorepb.Target) error {
+	if t == nil {
+		return status.Error(codes.InvalidArgument, "add_target requires a target")
+	}
+	id := t.GetTargetId()
+	if id == 0 {
+		id = ls.assignTargetID()
+	}
+
+	target, err := resolveTarget(t)
+	if err != nil {
+		return err
+	}
+	ls.targets[id] = target
+
+	if err := ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_TargetChange{
+		TargetChange: &firestorepb.TargetChange{
+			TargetChangeType: firestorepb.TargetChange_ADD,
+			TargetIds:        []int32{id},
+		},
+	}}); err != nil {
+		return err
+	}
+
+	// A valid resume token replays only the deltas after it; an absent or
+	// invalid token falls back to the full initial snapshot.
+	incremental := false
+	if rt, ok := t.GetResumeType().(*firestorepb.Target_ResumeToken); ok {
+		if seq, valid := DecodeResumeToken(rt.ResumeToken); valid {
+			incremental = true
+			for _, ev := range ls.srv.svc.ChangesSince(seq) {
+				if ls.targetMatches(target, ev) {
+					if err := ls.sendChange(id, ev); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	if !incremental {
+		if err := ls.sendSnapshot(id, target); err != nil {
+			return err
+		}
+	}
+
+	if err := ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_TargetChange{
+		TargetChange: &firestorepb.TargetChange{
+			TargetChangeType: firestorepb.TargetChange_CURRENT,
+			TargetIds:        []int32{id},
+			ResumeToken:      EncodeResumeToken(ls.srv.svc.CurrentSeq()),
+			ReadTime:         timestamppb.New(ls.nextReadTime()),
+		},
+	}}); err != nil {
+		return err
+	}
+
+	// Emit NO_CHANGE after CURRENT: the Go Firestore SDK concludes a snapshot
+	// only on a TargetChange with TargetChangeType NO_CHANGE, empty target_ids
+	// ("all targets on this stream"), a non-nil read_time, and a non-empty
+	// resume token (see cloud.google.com/go/firestore watch.go). Without it,
+	// Collection.Snapshots / DocumentRef.Snapshots / OnSnapshotsInSync hang.
+	return ls.sendNoChange()
+}
+
+// sendNoChange emits a NO_CHANGE frame with empty target_ids (meaning "all
+// targets on this stream"), a monotonic read_time, and the current change-feed
+// resume token. The SDK concludes a snapshot epoch on this frame.
+func (ls *listenSession) sendNoChange() error {
+	return ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_TargetChange{
+		TargetChange: &firestorepb.TargetChange{
+			TargetChangeType: firestorepb.TargetChange_NO_CHANGE,
+			ReadTime:         timestamppb.New(ls.nextReadTime()),
+			ResumeToken:      EncodeResumeToken(ls.srv.svc.CurrentSeq()),
+		},
+	}})
+}
+
+func (ls *listenSession) handleRemoveTarget(id int32) error {
+	delete(ls.targets, id)
+	return ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_TargetChange{
+		TargetChange: &firestorepb.TargetChange{
+			TargetChangeType: firestorepb.TargetChange_REMOVE,
+			TargetIds:        []int32{id},
+		},
+	}})
+}
+
+func (ls *listenSession) handleChange(ev firestoreprovider.ChangeEvent) {
+	sent := false
+	for id, t := range ls.targets {
+		if ls.targetMatches(t, ev) {
+			_ = ls.sendChange(id, ev)
+			sent = true
+		}
+	}
+	if !sent {
+		return
+	}
+	// Conclude the change epoch with a NO_CHANGE frame so the SDK returns the
+	// next snapshot: the SDK concludes every snapshot (initial and subsequent)
+	// on NO_CHANGE, so real-time deltas would otherwise never surface through
+	// Snapshots.
+	_ = ls.sendNoChange()
+}
+
+func (ls *listenSession) assignTargetID() int32 {
+	ls.nextID++
+	if ls.nextID == 0 {
+		ls.nextID = 1
+	}
+	return ls.nextID
+}
+
+func resolveTarget(t *firestorepb.Target) (listenTarget, error) {
+	switch tt := t.GetTargetType().(type) {
+	case *firestorepb.Target_Query:
+		q, err := decodeStructuredQuery(tt.Query.GetStructuredQuery())
+		if err != nil {
+			return listenTarget{}, mapError(model.NewProviderError("InvalidArgument", err.Error(), 400))
+		}
+		return listenTarget{query: q, parent: tt.Query.GetParent()}, nil
+	case *firestorepb.Target_Documents:
+		return listenTarget{documents: tt.Documents.GetDocuments()}, nil
+	default:
+		return listenTarget{}, status.Error(codes.InvalidArgument, "target must specify a query or documents")
+	}
+}
+
+// sendSnapshot streams one DocumentChange per matching document for the initial
+// state of a target.
+func (ls *listenSession) sendSnapshot(id int32, t listenTarget) error {
+	if t.isQuery() {
+		project, database, rel, ok := splitParent(t.parent)
+		if !ok {
+			return status.Error(codes.InvalidArgument, "invalid query parent resource name")
+		}
+		if project == "" {
+			project = ls.srv.resolveProject(ls.stream.Context())
+		}
+		docs, err := ls.srv.svc.RunQuery(ls.stream.Context(), project, database, rel, t.query, nil)
+		if err != nil {
+			return mapError(err)
+		}
+		for _, d := range docs {
+			if err := ls.sendDocumentChange(id, d); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for _, name := range t.documents {
+		doc, err := ls.srv.svc.GetDocument(ls.stream.Context(), name, nil, nil)
+		if err != nil {
+			var pe *model.ProviderError
+			if errors.As(err, &pe) && pe.HTTPStatus == 404 {
+				continue
+			}
+			return mapError(err)
+		}
+		if err := ls.sendDocumentChange(id, doc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (ls *listenSession) sendDocumentChange(id int32, d firestorestore.Document) error {
+	return ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_DocumentChange{
+		DocumentChange: &firestorepb.DocumentChange{
+			Document:  encodeDocument(d),
+			TargetIds: []int32{id},
+		},
+	}})
+}
+
+func (ls *listenSession) sendChange(id int32, ev firestoreprovider.ChangeEvent) error {
+	if ev.Doc == nil {
+		return ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_DocumentDelete{
+			DocumentDelete: &firestorepb.DocumentDelete{Document: ev.Name},
+		}})
+	}
+	return ls.sendDocumentChange(id, *ev.Doc)
+}
+
+func (ls *listenSession) targetMatches(t listenTarget, ev firestoreprovider.ChangeEvent) bool {
+	if t.documents != nil {
+		for _, name := range t.documents {
+			if name == ev.Name {
+				return true
+			}
+		}
+		return false
+	}
+	if t.query == nil {
+		return false
+	}
+	return changeMatchesQuery(t.query, t.parent, ev.Name)
+}
+
+// changeMatchesQuery reports whether a document (identified by name) is in the
+// collection scope of a query target. It mirrors the provider's
+// matchesCollection semantics but operates on a bare name so deletes can be
+// matched without a document body.
+func changeMatchesQuery(q *firestoreprovider.StructuredQuery, parent, name string) bool {
+	project, database, path, ok := firestorestore.ParseDocumentName(name)
+	if !ok {
+		return false
+	}
+	segs := strings.Split(path, "/")
+	if len(segs) < 2 {
+		return false
+	}
+	collID := segs[len(segs)-2]
+	docParent := "projects/" + project + "/databases/" + database + "/documents/" + strings.Join(segs[:len(segs)-1], "/")
+
+	if len(q.From) == 0 {
+		return strings.HasPrefix(name, parent+"/")
+	}
+	for _, sel := range q.From {
+		if sel.CollectionID != collID {
+			continue
+		}
+		if sel.AllDescendants {
+			if strings.HasPrefix(name, parent+"/") {
+				return true
+			}
+			continue
+		}
+		if docParent == parent+"/"+sel.CollectionID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gcp/grpc/firestore/listen_test.go
+++ b/internal/gcp/grpc/firestore/listen_test.go
@@ -1,0 +1,599 @@
+package firestore
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	firestorepb "cloud.google.com/go/firestore/apiv1/firestorepb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	firestoreprovider "jaiscloud/internal/gcp/provider/firestore"
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+)
+
+const listenParent = "projects/test/databases/(default)/documents"
+
+func listenTestClient(t *testing.T) (firestorepb.FirestoreClient, *firestoreprovider.Service, func()) {
+	t.Helper()
+	store := firestorestore.NewMemoryStore()
+	providerSvc := firestoreprovider.New(store, nil).Service
+	grpcSvc := NewService(providerSvc, "test")
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	firestorepb.RegisterFirestoreServer(srv, grpcSvc)
+	go srv.Serve(ln)
+
+	conn, err := grpc.NewClient(ln.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		srv.Stop()
+		t.Fatalf("dial: %v", err)
+	}
+	client := firestorepb.NewFirestoreClient(conn)
+	cleanup := func() {
+		conn.Close()
+		srv.Stop()
+	}
+	return client, providerSvc, cleanup
+}
+
+func queryTarget(tid int32, collection string) *firestorepb.Target {
+	return &firestorepb.Target{
+		TargetId: tid,
+		TargetType: &firestorepb.Target_Query{
+			Query: &firestorepb.Target_QueryTarget{
+				Parent: listenParent,
+				QueryType: &firestorepb.Target_QueryTarget_StructuredQuery{
+					StructuredQuery: &firestorepb.StructuredQuery{
+						From: []*firestorepb.StructuredQuery_CollectionSelector{
+							{CollectionId: collection},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func addTargetReq(t *firestorepb.Target) *firestorepb.ListenRequest {
+	return &firestorepb.ListenRequest{
+		Database:     "projects/test/databases/(default)",
+		TargetChange: &firestorepb.ListenRequest_AddTarget{AddTarget: t},
+	}
+}
+
+func recvN(t *testing.T, stream firestorepb.Firestore_ListenClient, n int, timeout time.Duration) []*firestorepb.ListenResponse {
+	t.Helper()
+	var responses []*firestorepb.ListenResponse
+	deadline := time.After(timeout)
+	for i := 0; i < n; i++ {
+		type result struct {
+			resp *firestorepb.ListenResponse
+			err  error
+		}
+		ch := make(chan result, 1)
+		go func() {
+			resp, err := stream.Recv()
+			ch <- result{resp, err}
+		}()
+		select {
+		case r := <-ch:
+			if r.err != nil {
+				t.Fatalf("Recv %d/%d: %v", i+1, n, r.err)
+			}
+			responses = append(responses, r.resp)
+		case <-deadline:
+			t.Fatalf("timeout waiting for response %d/%d", i+1, n)
+		}
+	}
+	return responses
+}
+
+func recvWithTimeout(stream firestorepb.Firestore_ListenClient, timeout time.Duration) (*firestorepb.ListenResponse, error) {
+	type result struct {
+		resp *firestorepb.ListenResponse
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		resp, err := stream.Recv()
+		ch <- result{resp, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.resp, r.err
+	case <-time.After(timeout):
+		return nil, io.ErrUnexpectedEOF
+	}
+}
+
+func TestListenCollectionInitialSnapshot(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	svc.CreateDocument(ctx, "test", "(default)", "users", "alice", map[string]*firestorestore.Value{
+		"name": firestorestore.StringVal("alice"),
+	})
+	svc.CreateDocument(ctx, "test", "(default)", "users", "bob", map[string]*firestorestore.Value{
+		"name": firestorestore.StringVal("bob"),
+	})
+
+	lctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	if err := stream.Send(addTargetReq(queryTarget(1, "users"))); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	responses := recvN(t, stream, 5, 3*time.Second)
+	if tc := responses[0].GetTargetChange(); tc == nil || tc.TargetChangeType != firestorepb.TargetChange_ADD {
+		t.Fatalf("expected ADD, got %v", responses[0])
+	}
+	dc1, dc2 := responses[1].GetDocumentChange(), responses[2].GetDocumentChange()
+	if dc1 == nil || dc2 == nil {
+		t.Fatalf("expected DocumentChanges, got %v and %v", responses[1], responses[2])
+	}
+	if dc1.Document.Fields["name"].GetStringValue() != "alice" {
+		t.Fatalf("expected alice first, got %s", dc1.Document.Fields["name"].GetStringValue())
+	}
+	if dc2.Document.Fields["name"].GetStringValue() != "bob" {
+		t.Fatalf("expected bob second, got %s", dc2.Document.Fields["name"].GetStringValue())
+	}
+	if tc := responses[3].GetTargetChange(); tc == nil || tc.TargetChangeType != firestorepb.TargetChange_CURRENT {
+		t.Fatalf("expected CURRENT, got %v", responses[3])
+	}
+	if tc := responses[4].GetTargetChange(); tc == nil || tc.TargetChangeType != firestorepb.TargetChange_NO_CHANGE {
+		t.Fatalf("expected NO_CHANGE, got %v", responses[4])
+	}
+}
+
+func TestListenCollectionRealTimeUpdates(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	lctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	if err := stream.Send(addTargetReq(queryTarget(1, "items"))); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	responses := recvN(t, stream, 3, 3*time.Second) // ADD + CURRENT + NO_CHANGE (empty)
+	if responses[0].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_ADD {
+		t.Fatal("expected ADD")
+	}
+	if responses[1].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_CURRENT {
+		t.Fatal("expected CURRENT")
+	}
+	if responses[2].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_NO_CHANGE {
+		t.Fatal("expected NO_CHANGE")
+	}
+
+	// Create → DocumentChange + NO_CHANGE.
+	svc.CreateDocument(ctx, "test", "(default)", "items", "item1", map[string]*firestorestore.Value{
+		"title": firestorestore.StringVal("first item"),
+	})
+	responses = recvN(t, stream, 2, 3*time.Second)
+	dc := responses[0].GetDocumentChange()
+	if dc == nil || dc.Document.Fields["title"].GetStringValue() != "first item" {
+		t.Fatalf("expected create DocumentChange, got %v", responses[0])
+	}
+	if responses[1].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_NO_CHANGE {
+		t.Fatalf("expected NO_CHANGE after create, got %v", responses[1])
+	}
+
+	// Update → DocumentChange + NO_CHANGE.
+	svc.PatchDocument(ctx, "test", "(default)", "items/item1", map[string]*firestorestore.Value{
+		"title": firestorestore.StringVal("updated item"),
+	}, nil, nil)
+	responses = recvN(t, stream, 2, 3*time.Second)
+	dc = responses[0].GetDocumentChange()
+	if dc == nil || dc.Document.Fields["title"].GetStringValue() != "updated item" {
+		t.Fatalf("expected update DocumentChange, got %v", responses[0])
+	}
+	if responses[1].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_NO_CHANGE {
+		t.Fatalf("expected NO_CHANGE after update, got %v", responses[1])
+	}
+
+	// Delete → DocumentDelete + NO_CHANGE.
+	svc.DeleteDocument(ctx, "test", "(default)", "items/item1", nil)
+	responses = recvN(t, stream, 2, 3*time.Second)
+	dd := responses[0].GetDocumentDelete()
+	if dd == nil || dd.Document != listenParent+"/items/item1" {
+		t.Fatalf("expected DocumentDelete, got %v", responses[0])
+	}
+	if responses[1].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_NO_CHANGE {
+		t.Fatalf("expected NO_CHANGE after delete, got %v", responses[1])
+	}
+}
+
+func TestListenDocumentTarget(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	docPath := listenParent + "/config/settings"
+	svc.CreateDocument(ctx, "test", "(default)", "config", "settings", map[string]*firestorestore.Value{
+		"theme": firestorestore.StringVal("dark"),
+	})
+
+	lctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	err = stream.Send(&firestorepb.ListenRequest{
+		Database: "projects/test/databases/(default)",
+		TargetChange: &firestorepb.ListenRequest_AddTarget{
+			AddTarget: &firestorepb.Target{
+				TargetId: 42,
+				TargetType: &firestorepb.Target_Documents{
+					Documents: &firestorepb.Target_DocumentsTarget{Documents: []string{docPath}},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	responses := recvN(t, stream, 4, 3*time.Second)
+	if responses[0].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_ADD {
+		t.Fatal("expected ADD")
+	}
+	dc := responses[1].GetDocumentChange()
+	if dc == nil || dc.Document.Fields["theme"].GetStringValue() != "dark" {
+		t.Fatal("expected document with theme=dark")
+	}
+	if responses[2].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_CURRENT {
+		t.Fatal("expected CURRENT")
+	}
+	if responses[3].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_NO_CHANGE {
+		t.Fatal("expected NO_CHANGE")
+	}
+}
+
+func TestListenRemoveTarget(t *testing.T) {
+	client, _, cleanup := listenTestClient(t)
+	defer cleanup()
+
+	lctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	if err := stream.Send(addTargetReq(queryTarget(1, "col"))); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	recvN(t, stream, 3, 3*time.Second) // ADD + CURRENT + NO_CHANGE
+
+	if err := stream.Send(&firestorepb.ListenRequest{
+		Database:     "projects/test/databases/(default)",
+		TargetChange: &firestorepb.ListenRequest_RemoveTarget{RemoveTarget: 1},
+	}); err != nil {
+		t.Fatalf("Send remove: %v", err)
+	}
+
+	responses := recvN(t, stream, 1, 3*time.Second)
+	tc := responses[0].GetTargetChange()
+	if tc == nil || tc.TargetChangeType != firestorepb.TargetChange_REMOVE {
+		t.Fatalf("expected REMOVE, got %v", responses[0])
+	}
+}
+
+func TestListenIgnoresUnrelatedCollections(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	lctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	if err := stream.Send(addTargetReq(queryTarget(1, "users"))); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	recvN(t, stream, 3, 3*time.Second) // ADD + CURRENT + NO_CHANGE
+
+	svc.CreateDocument(ctx, "test", "(default)", "posts", "post1", map[string]*firestorestore.Value{
+		"title": firestorestore.StringVal("hello"),
+	})
+
+	time.Sleep(200 * time.Millisecond)
+	if resp, err := recvWithTimeout(stream, 300*time.Millisecond); err == nil {
+		t.Fatalf("expected no event for unrelated collection, got %v", resp)
+	}
+}
+
+func TestListenMultipleClients(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel1()
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel2()
+
+	stream1, _ := client.Listen(ctx1)
+	stream2, _ := client.Listen(ctx2)
+
+	stream1.Send(addTargetReq(queryTarget(1, "shared")))
+	stream2.Send(addTargetReq(queryTarget(2, "shared")))
+
+	recvN(t, stream1, 3, 3*time.Second) // ADD + CURRENT + NO_CHANGE
+	recvN(t, stream2, 3, 3*time.Second)
+
+	svc.CreateDocument(ctx, "test", "(default)", "shared", "doc1", map[string]*firestorestore.Value{
+		"v": firestorestore.StringVal("hello"),
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if r := recvN(t, stream1, 1, 3*time.Second); r[0].GetDocumentChange() == nil {
+			t.Error("stream1: expected DocumentChange")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if r := recvN(t, stream2, 1, 3*time.Second); r[0].GetDocumentChange() == nil {
+			t.Error("stream2: expected DocumentChange")
+		}
+	}()
+	wg.Wait()
+}
+
+func TestListenResumeTokenBasic(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	svc.CreateDocument(ctx, "test", "(default)", "tasks", "t1", map[string]*firestorestore.Value{
+		"status": firestorestore.StringVal("open"),
+	})
+
+	lctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	if err := stream.Send(addTargetReq(queryTarget(1, "tasks"))); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	responses := recvN(t, stream, 4, 3*time.Second) // ADD, t1, CURRENT, NO_CHANGE
+	tc := responses[2].GetTargetChange()
+	if tc == nil || tc.TargetChangeType != firestorepb.TargetChange_CURRENT {
+		t.Fatal("expected CURRENT")
+	}
+	if len(tc.ResumeToken) != 8 {
+		t.Fatalf("expected 8-byte resume token, got %d bytes", len(tc.ResumeToken))
+	}
+	resumeToken := tc.ResumeToken
+
+	svc.CreateDocument(ctx, "test", "(default)", "tasks", "t2", map[string]*firestorestore.Value{
+		"status": firestorestore.StringVal("pending"),
+	})
+	recvN(t, stream, 2, 3*time.Second) // consume real-time event (DocumentChange + NO_CHANGE)
+
+	stream.Send(&firestorepb.ListenRequest{
+		Database:     "projects/test/databases/(default)",
+		TargetChange: &firestorepb.ListenRequest_RemoveTarget{RemoveTarget: 1},
+	})
+	recvN(t, stream, 1, 3*time.Second) // REMOVE
+
+	rt := queryTarget(2, "tasks")
+	rt.ResumeType = &firestorepb.Target_ResumeToken{ResumeToken: resumeToken}
+	if err := stream.Send(addTargetReq(rt)); err != nil {
+		t.Fatalf("Send resume: %v", err)
+	}
+
+	responses = recvN(t, stream, 4, 3*time.Second) // ADD, t2 only, CURRENT, NO_CHANGE
+	if responses[0].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_ADD {
+		t.Fatal("expected ADD")
+	}
+	dc := responses[1].GetDocumentChange()
+	if dc == nil || dc.Document.Fields["status"].GetStringValue() != "pending" {
+		t.Fatalf("expected t2 (pending) incremental, got %v", responses[1])
+	}
+	if responses[2].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_CURRENT {
+		t.Fatal("expected CURRENT")
+	}
+	if responses[3].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_NO_CHANGE {
+		t.Fatal("expected NO_CHANGE")
+	}
+}
+
+func TestListenResumeTokenFallsBackToSnapshot(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	svc.CreateDocument(ctx, "test", "(default)", "items", "a", map[string]*firestorestore.Value{
+		"v": firestorestore.StringVal("1"),
+	})
+
+	lctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	rt := queryTarget(1, "items")
+	rt.ResumeType = &firestorepb.Target_ResumeToken{ResumeToken: []byte("bad")}
+	if err := stream.Send(addTargetReq(rt)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	responses := recvN(t, stream, 4, 3*time.Second) // ADD, a (full snapshot), CURRENT, NO_CHANGE
+	if responses[0].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_ADD {
+		t.Fatal("expected ADD")
+	}
+	dc := responses[1].GetDocumentChange()
+	if dc == nil || dc.Document.Fields["v"].GetStringValue() != "1" {
+		t.Fatal("expected full snapshot with item a")
+	}
+	if responses[2].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_CURRENT {
+		t.Fatal("expected CURRENT")
+	}
+	if responses[3].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_NO_CHANGE {
+		t.Fatal("expected NO_CHANGE")
+	}
+}
+
+func TestResumeTokenEncodeDecode(t *testing.T) {
+	for _, seq := range []uint64{0, 1, 42, 1<<32 - 1, 1 << 63} {
+		token := EncodeResumeToken(seq)
+		got, ok := DecodeResumeToken(token)
+		if !ok || got != seq {
+			t.Fatalf("round-trip failed for seq=%d: got %d ok=%v", seq, got, ok)
+		}
+	}
+	if _, ok := DecodeResumeToken(nil); ok {
+		t.Fatal("expected decode failure for nil")
+	}
+	if _, ok := DecodeResumeToken([]byte("short")); ok {
+		t.Fatal("expected decode failure for wrong length")
+	}
+}
+
+func TestListenNoChangeAfterCurrent(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	svc.CreateDocument(ctx, "test", "(default)", "users", "alice", map[string]*firestorestore.Value{
+		"name": firestorestore.StringVal("alice"),
+	})
+
+	lctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	if err := stream.Send(addTargetReq(queryTarget(1, "users"))); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	responses := recvN(t, stream, 4, 3*time.Second) // ADD, DocumentChange, CURRENT, NO_CHANGE
+	if tc := responses[0].GetTargetChange(); tc == nil || tc.TargetChangeType != firestorepb.TargetChange_ADD {
+		t.Fatalf("frame 0: expected ADD, got %v", responses[0])
+	}
+	if dc := responses[1].GetDocumentChange(); dc == nil || dc.Document.Fields["name"].GetStringValue() != "alice" {
+		t.Fatalf("frame 1: expected DocumentChange, got %v", responses[1])
+	}
+	if tc := responses[2].GetTargetChange(); tc == nil || tc.TargetChangeType != firestorepb.TargetChange_CURRENT {
+		t.Fatalf("frame 2: expected CURRENT, got %v", responses[2])
+	}
+	nc := responses[3].GetTargetChange()
+	if nc == nil || nc.TargetChangeType != firestorepb.TargetChange_NO_CHANGE {
+		t.Fatalf("frame 3: expected NO_CHANGE, got %v", responses[3])
+	}
+	if len(nc.TargetIds) != 0 {
+		t.Fatalf("NO_CHANGE must have empty target_ids, got %v", nc.TargetIds)
+	}
+	if nc.ReadTime == nil {
+		t.Fatal("NO_CHANGE must have a non-nil read_time")
+	}
+	if len(nc.ResumeToken) == 0 {
+		t.Fatal("NO_CHANGE must have a non-empty resume_token")
+	}
+}
+
+func TestListenReadTimeMonotonic(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	svc.CreateDocument(ctx, "test", "(default)", "users", "alice", map[string]*firestorestore.Value{
+		"name": firestorestore.StringVal("alice"),
+	})
+
+	lctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	noChangeReadTime := func(tid int32) time.Time {
+		if err := stream.Send(addTargetReq(queryTarget(tid, "users"))); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		rs := recvN(t, stream, 4, 3*time.Second)
+		nc := rs[3].GetTargetChange()
+		if nc == nil || nc.TargetChangeType != firestorepb.TargetChange_NO_CHANGE {
+			t.Fatalf("expected NO_CHANGE, got %v", rs[3])
+		}
+		if nc.ReadTime == nil {
+			t.Fatal("expected non-nil read_time")
+		}
+		return nc.ReadTime.AsTime()
+	}
+
+	rt1 := noChangeReadTime(1)
+	rt2 := noChangeReadTime(2)
+
+	if rt2.Before(rt1) {
+		t.Fatalf("read_time went backwards: first=%v second=%v", rt1, rt2)
+	}
+}
+
+func TestPublishChangeNonBlocking(t *testing.T) {
+	store := firestorestore.NewMemoryStore()
+	svc := firestoreprovider.New(store, nil).Service
+	ctx := context.Background()
+
+	sub := svc.SubscribeChange()
+	defer sub.Cancel()
+
+	// Fill the subscriber's buffered channel (capacity 1024) without draining.
+	const n = 1024
+	for i := 0; i < n; i++ {
+		if _, err := svc.CreateDocument(ctx, "test", "(default)", "bulk", fmt.Sprintf("d%03d", i), map[string]*firestorestore.Value{
+			"v": firestorestore.StringVal("x"),
+		}); err != nil {
+			t.Fatalf("fill %d: %v", i, err)
+		}
+	}
+
+	// The buffer is now full. A subsequent publish must return promptly: it
+	// drops the event (and detaches the subscriber) rather than blocking.
+	done := make(chan struct{})
+	go func() {
+		_, _ = svc.CreateDocument(ctx, "test", "(default)", "bulk", "overflow", map[string]*firestorestore.Value{
+			"v": firestorestore.StringVal("y"),
+		})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("publishChange blocked on a full subscriber channel")
+	}
+}

--- a/internal/gcp/grpc/firestore/service.go
+++ b/internal/gcp/grpc/firestore/service.go
@@ -4,20 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/url"
-	"regexp"
 	"strings"
 	"time"
 
 	firestorepb "cloud.google.com/go/firestore/apiv1/firestorepb"
 	"jaiscloud/internal/clock"
-	"jaiscloud/internal/gcp/identity"
+	grpcutil "jaiscloud/internal/gcp/grpc"
 	firestoreprovider "jaiscloud/internal/gcp/provider/firestore"
 	firestorestore "jaiscloud/internal/gcp/store/firestore"
 	"jaiscloud/internal/model"
 
 	"google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -44,59 +41,17 @@ func (s *Service) Reset(ctx context.Context) { s.svc.Reset(ctx) }
 
 // ─── identity (project over gRPC metadata) ───────────────────────────────────
 
-var routingProjectRE = regexp.MustCompile(`projects/([^/]+)`)
-
-// resolveProject derives the project for an RPC: x-goog-request-params routing
-// metadata, then the bearer token's JWT project_id claim, then the configured
-// default. The Firestore unary request messages themselves carry full resource
-// names, so the message is authoritative; this is the fallback.
+// resolveProject derives the project for an RPC via the shared gRPC metadata
+// resolver, falling back to the configured default. The Firestore unary request
+// messages themselves carry full resource names, so the message is
+// authoritative; this is the fallback.
 func (s *Service) resolveProject(ctx context.Context) string {
-	if p := projectFromMetadata(ctx); p != "" {
-		return p
-	}
-	return s.defaultProj
+	return grpcutil.ProjectFromMetadata(ctx, s.defaultProj)
 }
 
-func projectFromMetadata(ctx context.Context) string {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return ""
-	}
-	if vals := md.Get("x-goog-request-params"); len(vals) > 0 {
-		if p := routingProject(vals[0]); p != "" {
-			return p
-		}
-	}
-	if vals := md.Get("authorization"); len(vals) > 0 {
-		if p := identity.ProjectFromToken(identity.BearerToken(vals[0])); p != "" {
-			return p
-		}
-	}
-	return ""
-}
-
-func routingProject(params string) string {
-	for _, kv := range strings.Split(params, "&") {
-		if kv == "" {
-			continue
-		}
-		key, val, ok := strings.Cut(kv, "=")
-		if !ok {
-			continue
-		}
-		unesc, err := url.QueryUnescape(val)
-		if err != nil {
-			unesc = val
-		}
-		if key == "project_id" {
-			return unesc
-		}
-		if m := routingProjectRE.FindStringSubmatch(unesc); len(m) == 2 {
-			return m[1]
-		}
-	}
-	return ""
-}
+// mapError converts a provider/service error into a gRPC status error via the
+// shared grpc.GRPCStatus mapping.
+func mapError(err error) error { return grpcutil.GRPCStatus(err) }
 
 // ─── resource-name parsing ────────────────────────────────────────────────────
 

--- a/internal/gcp/grpc/iam.go
+++ b/internal/gcp/grpc/iam.go
@@ -1,0 +1,66 @@
+package grpc
+
+import (
+	"context"
+
+	iampb "cloud.google.com/go/iam/apiv1/iampb"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// IAMResourceServer implements the google.iam.v1.IAMPolicy surface for one
+// class of resources (Pub/Sub topics+subscriptions, KMS keyrings/keys/versions).
+// Owns reports whether the handler recognizes a resource name.
+type IAMResourceServer interface {
+	iampb.IAMPolicyServer
+	Owns(resource string) bool
+}
+
+// IAMRouter implements iampb.IAMPolicyServer by delegating each call to the
+// first handler that owns the resource name. gRPC permits only a single
+// registration per service, so this unifies the Pub/Sub and KMS IAM surfaces
+// behind one google.iam.v1.IAMPolicy server.
+type IAMRouter struct {
+	iampb.UnimplementedIAMPolicyServer
+	handlers []IAMResourceServer
+}
+
+// NewIAMRouter returns a router that dispatches to handlers in registration
+// order.
+func NewIAMRouter(handlers ...IAMResourceServer) *IAMRouter {
+	return &IAMRouter{handlers: handlers}
+}
+
+func (r *IAMRouter) route(resource string) iampb.IAMPolicyServer {
+	for _, h := range r.handlers {
+		if h.Owns(resource) {
+			return h
+		}
+	}
+	return nil
+}
+
+func (r *IAMRouter) GetIamPolicy(ctx context.Context, req *iampb.GetIamPolicyRequest) (*iampb.Policy, error) {
+	h := r.route(req.GetResource())
+	if h == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid resource name")
+	}
+	return h.GetIamPolicy(ctx, req)
+}
+
+func (r *IAMRouter) SetIamPolicy(ctx context.Context, req *iampb.SetIamPolicyRequest) (*iampb.Policy, error) {
+	h := r.route(req.GetResource())
+	if h == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid resource name")
+	}
+	return h.SetIamPolicy(ctx, req)
+}
+
+func (r *IAMRouter) TestIamPermissions(ctx context.Context, req *iampb.TestIamPermissionsRequest) (*iampb.TestIamPermissionsResponse, error) {
+	h := r.route(req.GetResource())
+	if h == nil {
+		return nil, status.Error(codes.InvalidArgument, "invalid resource name")
+	}
+	return h.TestIamPermissions(ctx, req)
+}

--- a/internal/gcp/grpc/iam_test.go
+++ b/internal/gcp/grpc/iam_test.go
@@ -1,0 +1,56 @@
+package grpc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	iampb "cloud.google.com/go/iam/apiv1/iampb"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// stubIAM records which handler served a call, keyed by the resource name the
+// handler claims to own.
+type stubIAM struct {
+	iampb.UnimplementedIAMPolicyServer
+	prefix string
+}
+
+func (s *stubIAM) Owns(resource string) bool { return strings.HasPrefix(resource, s.prefix) }
+
+func (s *stubIAM) GetIamPolicy(ctx context.Context, req *iampb.GetIamPolicyRequest) (*iampb.Policy, error) {
+	return &iampb.Policy{Version: 1}, nil
+}
+
+func (s *stubIAM) SetIamPolicy(ctx context.Context, req *iampb.SetIamPolicyRequest) (*iampb.Policy, error) {
+	return &iampb.Policy{Version: 1}, nil
+}
+
+func (s *stubIAM) TestIamPermissions(ctx context.Context, req *iampb.TestIamPermissionsRequest) (*iampb.TestIamPermissionsResponse, error) {
+	return &iampb.TestIamPermissionsResponse{Permissions: req.GetPermissions()}, nil
+}
+
+func TestIAMRouterDispatchesByOwnership(t *testing.T) {
+	router := NewIAMRouter(&stubIAM{prefix: "projects/p/topics/"}, &stubIAM{prefix: "projects/p/locations/"})
+
+	ctx := context.Background()
+
+	// A topic is owned by the first handler.
+	if _, err := router.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: "projects/p/topics/t"}); err != nil {
+		t.Fatalf("GetIamPolicy topic: %v", err)
+	}
+	// A KMS resource is owned by the second handler.
+	if _, err := router.SetIamPolicy(ctx, &iampb.SetIamPolicyRequest{Resource: "projects/p/locations/global/keyRings/kr"}); err != nil {
+		t.Fatalf("SetIamPolicy keyring: %v", err)
+	}
+	if _, err := router.TestIamPermissions(ctx, &iampb.TestIamPermissionsRequest{Resource: "projects/p/locations/global/keyRings/kr", Permissions: []string{"a"}}); err != nil {
+		t.Fatalf("TestIamPermissions keyring: %v", err)
+	}
+
+	// An unrecognized resource is rejected.
+	if _, err := router.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: "projects/p/secrets/s"}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("GetIamPolicy unknown err = %v, want InvalidArgument", err)
+	}
+}

--- a/internal/gcp/grpc/identity.go
+++ b/internal/gcp/grpc/identity.go
@@ -1,0 +1,67 @@
+package grpc
+
+import (
+	"context"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"jaiscloud/internal/gcp/identity"
+
+	"google.golang.org/grpc/metadata"
+)
+
+var routingProjectRE = regexp.MustCompile(`projects/([^/]+)`)
+
+// ProjectFromMetadata resolves the project for an RPC from gRPC metadata:
+// x-goog-request-params routing metadata, then the bearer token's JWT
+// project_id claim, then the configured default. The request messages of the
+// individual services usually carry full resource names, so those are
+// authoritative; this is the fallback when a request omits the project.
+func ProjectFromMetadata(ctx context.Context, defaultProject string) string {
+	if p := projectFromMetadata(ctx); p != "" {
+		return p
+	}
+	return defaultProject
+}
+
+func projectFromMetadata(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ""
+	}
+	if vals := md.Get("x-goog-request-params"); len(vals) > 0 {
+		if p := routingProject(vals[0]); p != "" {
+			return p
+		}
+	}
+	if vals := md.Get("authorization"); len(vals) > 0 {
+		if p := identity.ProjectFromToken(identity.BearerToken(vals[0])); p != "" {
+			return p
+		}
+	}
+	return ""
+}
+
+func routingProject(params string) string {
+	for _, kv := range strings.Split(params, "&") {
+		if kv == "" {
+			continue
+		}
+		key, val, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		unesc, err := url.QueryUnescape(val)
+		if err != nil {
+			unesc = val
+		}
+		if key == "project_id" {
+			return unesc
+		}
+		if m := routingProjectRE.FindStringSubmatch(unesc); len(m) == 2 {
+			return m[1]
+		}
+	}
+	return ""
+}

--- a/internal/gcp/grpc/kms/service.go
+++ b/internal/gcp/grpc/kms/service.go
@@ -1,0 +1,939 @@
+// Package kms implements the Cloud KMS gRPC service
+// (google.cloud.kms.v1.KeyManagementService plus the google.iam.v1.IAMPolicy
+// surface for keyring/crypto-key/version IAM) over the same shared
+// kmsstore.Store + policy backing the REST provider, so REST and gRPC share
+// state.
+package kms
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"errors"
+	"hash/crc32"
+	"strings"
+
+	iampb "cloud.google.com/go/iam/apiv1/iampb"
+	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
+
+	"jaiscloud/internal/clock"
+	gcpcrypto "jaiscloud/internal/gcp/crypto"
+	grpcutil "jaiscloud/internal/gcp/grpc"
+	"jaiscloud/internal/gcp/paging"
+	"jaiscloud/internal/gcp/policy"
+	kmsstore "jaiscloud/internal/gcp/store/kms"
+	"jaiscloud/internal/model"
+	"jaiscloud/internal/store"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// Resource-type strings for KMS IAM policies stored in the shared resource
+// store. These mirror the Pub/Sub / Secret Manager policy types; KMS has no
+// REST IAM provider, so these types are gRPC-only.
+const (
+	rtKeyRingPolicy   = "gcp_keyring_policy"
+	rtCryptoKeyPolicy = "gcp_cryptokey_policy"
+	rtVersionPolicy   = "gcp_cryptokeyversion_policy"
+)
+
+// Service implements kmspb.KeyManagementServiceServer and
+// iampb.IAMPolicyServer over the shared stores. KMS generates and DEK-wraps its
+// own key material via the store (CreateCryptoKey/CreateVersion), so the
+// envelope encryptor is retained only for constructor parity with the Pub/Sub
+// and Secret Manager gRPC services and is unused here.
+type Service struct {
+	kmspb.UnimplementedKeyManagementServiceServer
+	iampb.UnimplementedIAMPolicyServer
+
+	keys        kmsstore.Store
+	resources   store.ResourceStore // IAM policies (control-plane)
+	encryptor   gcpcrypto.EnvelopeEncryptor
+	defaultProj string
+}
+
+// NewService returns a KMS gRPC service backed by the shared stores.
+// defaultProj is the config-default project used when a request carries none.
+func NewService(keys kmsstore.Store, resources store.ResourceStore, encryptor gcpcrypto.EnvelopeEncryptor, defaultProj string) *Service {
+	return &Service{keys: keys, resources: resources, encryptor: encryptor, defaultProj: defaultProj}
+}
+
+func mapError(err error) error { return grpcutil.GRPCStatus(err) }
+
+func keyRingErr(err error) error {
+	if errors.Is(err, kmsstore.ErrNoSuchKeyRing) {
+		return mapError(model.NewProviderError("NotFound", "key ring not found", 404))
+	}
+	return mapError(err)
+}
+
+func keyErr(err error) error {
+	if errors.Is(err, kmsstore.ErrNoSuchCryptoKey) {
+		return mapError(model.NewProviderError("NotFound", "crypto key not found", 404))
+	}
+	return mapError(err)
+}
+
+func versionErr(err error) error {
+	switch {
+	case errors.Is(err, kmsstore.ErrNoSuchCryptoKey):
+		return mapError(model.NewProviderError("NotFound", "crypto key not found", 404))
+	case errors.Is(err, kmsstore.ErrNoSuchVersion):
+		return mapError(model.NewProviderError("NotFound", "crypto key version not found", 404))
+	}
+	return mapError(err)
+}
+
+// ─── resource-name parsing ────────────────────────────────────────────────────
+
+func keyRingName(project, location, id string) string {
+	return "projects/" + project + "/locations/" + location + "/keyRings/" + id
+}
+
+func cryptoKeyName(project, location, kr, key string) string {
+	return keyRingName(project, location, kr) + "/cryptoKeys/" + key
+}
+
+func versionName(project, location, kr, key, v string) string {
+	return cryptoKeyName(project, location, kr, key) + "/cryptoKeyVersions/" + v
+}
+
+// splitLocationName parses "projects/{p}/locations/{l}".
+func splitLocationName(name string) (project, location string, ok bool) {
+	parts := strings.Split(name, "/")
+	if len(parts) == 4 && parts[0] == "projects" && parts[2] == "locations" {
+		return parts[1], parts[3], true
+	}
+	return "", "", false
+}
+
+// splitKeyRingName parses "projects/{p}/locations/{l}/keyRings/{kr}".
+func splitKeyRingName(name string) (project, location, id string, ok bool) {
+	parts := strings.Split(name, "/")
+	if len(parts) == 6 && parts[0] == "projects" && parts[2] == "locations" && parts[4] == "keyRings" {
+		return parts[1], parts[3], parts[5], true
+	}
+	return "", "", "", false
+}
+
+// splitCryptoKeyName parses "projects/{p}/locations/{l}/keyRings/{kr}/cryptoKeys/{k}".
+func splitCryptoKeyName(name string) (project, location, kr, key string, ok bool) {
+	parts := strings.Split(name, "/")
+	if len(parts) == 8 && parts[0] == "projects" && parts[2] == "locations" && parts[4] == "keyRings" && parts[6] == "cryptoKeys" {
+		return parts[1], parts[3], parts[5], parts[7], true
+	}
+	return "", "", "", "", false
+}
+
+// splitVersionName parses
+// "projects/{p}/locations/{l}/keyRings/{kr}/cryptoKeys/{k}/cryptoKeyVersions/{v}".
+func splitVersionName(name string) (project, location, kr, key, version string, ok bool) {
+	parts := strings.Split(name, "/")
+	if len(parts) == 10 && parts[0] == "projects" && parts[2] == "locations" && parts[4] == "keyRings" && parts[6] == "cryptoKeys" && parts[8] == "cryptoKeyVersions" {
+		return parts[1], parts[3], parts[5], parts[7], parts[9], true
+	}
+	return "", "", "", "", "", false
+}
+
+// splitKeyOrVersionName accepts either a crypto key name (version empty) or a
+// crypto key version name, so Encrypt/Decrypt can be addressed by either.
+func splitKeyOrVersionName(name string) (project, location, kr, key, version string, ok bool) {
+	if p, l, kr, k, v, ok := splitVersionName(name); ok {
+		return p, l, kr, k, v, true
+	}
+	if p, l, kr, k, ok := splitCryptoKeyName(name); ok {
+		return p, l, kr, k, "", true
+	}
+	return "", "", "", "", "", false
+}
+
+// splitLocationParent resolves the project + location from a ListKeyRings /
+// CreateKeyRing parent ("projects/{p}/locations/{l}"). A bare location id (or a
+// "locations/{l}" suffix) falls back to the metadata-derived project.
+func (s *Service) splitLocationParent(ctx context.Context, parent string) (project, location string, ok bool) {
+	if p, l, ok := splitLocationName(parent); ok {
+		return p, l, true
+	}
+	loc := strings.TrimPrefix(parent, "locations/")
+	if loc != "" && !strings.Contains(loc, "/") {
+		return grpcutil.ProjectFromMetadata(ctx, s.defaultProj), loc, true
+	}
+	return "", "", false
+}
+
+// ─── KeyRings ─────────────────────────────────────────────────────────────────
+
+func (s *Service) ListKeyRings(ctx context.Context, req *kmspb.ListKeyRingsRequest) (*kmspb.ListKeyRingsResponse, error) {
+	project, loc, ok := s.splitLocationParent(ctx, req.GetParent())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid parent resource name", 400))
+	}
+	krs, err := s.keys.ListKeyRings(ctx, project, loc)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	page, next := paging.Page(krs, func(kr kmsstore.KeyRing) string { return kr.ID },
+		map[string]any{"pageSize": int(req.GetPageSize()), "pageToken": req.GetPageToken()})
+	out := make([]*kmspb.KeyRing, 0, len(page))
+	for _, kr := range page {
+		out = append(out, keyRingToProto(project, loc, kr))
+	}
+	return &kmspb.ListKeyRingsResponse{KeyRings: out, NextPageToken: next, TotalSize: int32(len(krs))}, nil
+}
+
+func (s *Service) CreateKeyRing(ctx context.Context, req *kmspb.CreateKeyRingRequest) (*kmspb.KeyRing, error) {
+	project, loc, ok := s.splitLocationParent(ctx, req.GetParent())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid parent resource name", 400))
+	}
+	id := req.GetKeyRingId()
+	if id == "" {
+		if req.GetKeyRing() != nil {
+			_, _, id, _ = splitKeyRingName(req.GetKeyRing().GetName())
+		}
+	}
+	if id == "" {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "missing keyRingId", 400))
+	}
+	now := clock.Now()
+	kr := kmsstore.KeyRing{Location: loc, ID: id, CreateTime: now}
+	if err := s.keys.CreateKeyRing(ctx, project, loc, id, kr); err != nil {
+		if errors.Is(err, kmsstore.ErrAlreadyExists) {
+			return nil, mapError(model.NewProviderError("AlreadyExists", "key ring already exists", 409))
+		}
+		return nil, mapError(err)
+	}
+	return keyRingToProto(project, loc, kr), nil
+}
+
+func (s *Service) GetKeyRing(ctx context.Context, req *kmspb.GetKeyRingRequest) (*kmspb.KeyRing, error) {
+	project, loc, id, ok := splitKeyRingName(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	kr, err := s.keys.GetKeyRing(ctx, project, loc, id)
+	if err != nil {
+		return nil, keyRingErr(err)
+	}
+	return keyRingToProto(project, loc, kr), nil
+}
+
+// ─── CryptoKeys ───────────────────────────────────────────────────────────────
+
+func (s *Service) ListCryptoKeys(ctx context.Context, req *kmspb.ListCryptoKeysRequest) (*kmspb.ListCryptoKeysResponse, error) {
+	project, loc, kr, ok := splitKeyRingName(req.GetParent())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid parent resource name", 400))
+	}
+	keys, err := s.keys.ListCryptoKeys(ctx, project, loc, kr)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	page, next := paging.Page(keys, func(k kmsstore.CryptoKey) string { return k.ID },
+		map[string]any{"pageSize": int(req.GetPageSize()), "pageToken": req.GetPageToken()})
+	out := make([]*kmspb.CryptoKey, 0, len(page))
+	for _, k := range page {
+		out = append(out, cryptoKeyToProto(project, k))
+	}
+	return &kmspb.ListCryptoKeysResponse{CryptoKeys: out, NextPageToken: next, TotalSize: int32(len(keys))}, nil
+}
+
+func (s *Service) CreateCryptoKey(ctx context.Context, req *kmspb.CreateCryptoKeyRequest) (*kmspb.CryptoKey, error) {
+	project, loc, kr, ok := splitKeyRingName(req.GetParent())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid parent resource name", 400))
+	}
+	key := req.GetCryptoKeyId()
+	if key == "" {
+		if ck := req.GetCryptoKey(); ck != nil {
+			_, _, _, key, _ = splitCryptoKeyName(ck.GetName())
+		}
+	}
+	if key == "" {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "missing cryptoKeyId", 400))
+	}
+	purpose := "ENCRYPT_DECRYPT"
+	algorithm := ""
+	if ck := req.GetCryptoKey(); ck != nil {
+		purpose = purposeFromProto(ck.GetPurpose())
+		if vt := ck.GetVersionTemplate(); vt != nil {
+			algorithm = algorithmFromProto(vt.GetAlgorithm())
+		}
+	}
+	if algorithm == "" {
+		algorithm = defaultAlgorithmForPurpose(purpose)
+	}
+	now := clock.Now()
+	ck := kmsstore.CryptoKey{Location: loc, KeyRingID: kr, ID: key, Purpose: purpose, CreateTime: now, PrimaryVersion: "1", Algorithm: algorithm}
+	if err := s.keys.CreateCryptoKey(ctx, project, loc, kr, key, ck); err != nil {
+		if errors.Is(err, kmsstore.ErrAlreadyExists) {
+			return nil, mapError(model.NewProviderError("AlreadyExists", "crypto key already exists", 409))
+		}
+		return nil, mapError(err)
+	}
+	return cryptoKeyToProto(project, ck), nil
+}
+
+func (s *Service) GetCryptoKey(ctx context.Context, req *kmspb.GetCryptoKeyRequest) (*kmspb.CryptoKey, error) {
+	project, loc, kr, key, ok := splitCryptoKeyName(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	k, err := s.keys.GetCryptoKey(ctx, project, loc, kr, key)
+	if err != nil {
+		return nil, keyErr(err)
+	}
+	return cryptoKeyToProto(project, k), nil
+}
+
+// UpdateCryptoKey reads back the current key. Purpose and algorithm are
+// immutable, and the store persists no other mutable metadata (labels,
+// rotation schedule), so this is effectively an idempotent read matching the
+// emulator's minimal surface.
+func (s *Service) UpdateCryptoKey(ctx context.Context, req *kmspb.UpdateCryptoKeyRequest) (*kmspb.CryptoKey, error) {
+	ck := req.GetCryptoKey()
+	if ck == nil {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "crypto key is required", 400))
+	}
+	project, loc, kr, key, ok := splitCryptoKeyName(ck.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	k, err := s.keys.GetCryptoKey(ctx, project, loc, kr, key)
+	if err != nil {
+		return nil, keyErr(err)
+	}
+	return cryptoKeyToProto(project, k), nil
+}
+
+func (s *Service) UpdateCryptoKeyPrimaryVersion(ctx context.Context, req *kmspb.UpdateCryptoKeyPrimaryVersionRequest) (*kmspb.CryptoKey, error) {
+	project, loc, kr, key, ok := splitCryptoKeyName(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	versionID := req.GetCryptoKeyVersionId()
+	if versionID == "" {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "missing cryptoKeyVersionId", 400))
+	}
+	if err := s.keys.UpdatePrimaryVersion(ctx, project, loc, kr, key, versionID); err != nil {
+		return nil, versionErr(err)
+	}
+	ck, _ := s.keys.GetCryptoKey(ctx, project, loc, kr, key)
+	return cryptoKeyToProto(project, ck), nil
+}
+
+// ─── CryptoKeyVersions ────────────────────────────────────────────────────────
+
+func (s *Service) CreateCryptoKeyVersion(ctx context.Context, req *kmspb.CreateCryptoKeyVersionRequest) (*kmspb.CryptoKeyVersion, error) {
+	project, loc, kr, key, ok := splitCryptoKeyName(req.GetParent())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid parent resource name", 400))
+	}
+	ck, err := s.keys.GetCryptoKey(ctx, project, loc, kr, key)
+	if err != nil {
+		return nil, keyErr(err)
+	}
+	now := clock.Now()
+	version, err := s.keys.CreateVersion(ctx, project, loc, kr, key, kmsstore.Version{CreateTime: now, Algorithm: ck.Algorithm})
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	return versionToProto(project, loc, kr, key, kmsstore.Version{Version: version, State: "ENABLED", Algorithm: ck.Algorithm, CreateTime: now}), nil
+}
+
+func (s *Service) ListCryptoKeyVersions(ctx context.Context, req *kmspb.ListCryptoKeyVersionsRequest) (*kmspb.ListCryptoKeyVersionsResponse, error) {
+	project, loc, kr, key, ok := splitCryptoKeyName(req.GetParent())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid parent resource name", 400))
+	}
+	versions, err := s.keys.ListVersions(ctx, project, loc, kr, key)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	page, next := paging.Page(versions, func(v kmsstore.Version) string { return v.Version },
+		map[string]any{"pageSize": int(req.GetPageSize()), "pageToken": req.GetPageToken()})
+	out := make([]*kmspb.CryptoKeyVersion, 0, len(page))
+	for _, v := range page {
+		out = append(out, versionToProto(project, loc, kr, key, v))
+	}
+	return &kmspb.ListCryptoKeyVersionsResponse{CryptoKeyVersions: out, NextPageToken: next, TotalSize: int32(len(versions))}, nil
+}
+
+func (s *Service) GetCryptoKeyVersion(ctx context.Context, req *kmspb.GetCryptoKeyVersionRequest) (*kmspb.CryptoKeyVersion, error) {
+	project, loc, kr, key, version, ok := splitVersionName(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	v, err := s.keys.GetVersion(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	return versionToProto(project, loc, kr, key, v), nil
+}
+
+func (s *Service) DestroyCryptoKeyVersion(ctx context.Context, req *kmspb.DestroyCryptoKeyVersionRequest) (*kmspb.CryptoKeyVersion, error) {
+	return s.setVersionState(ctx, req.GetName(), "DESTROYED")
+}
+
+func (s *Service) RestoreCryptoKeyVersion(ctx context.Context, req *kmspb.RestoreCryptoKeyVersionRequest) (*kmspb.CryptoKeyVersion, error) {
+	return s.setVersionState(ctx, req.GetName(), "DISABLED")
+}
+
+func (s *Service) UpdateCryptoKeyVersion(ctx context.Context, req *kmspb.UpdateCryptoKeyVersionRequest) (*kmspb.CryptoKeyVersion, error) {
+	p := req.GetCryptoKeyVersion()
+	if p == nil {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "crypto key version is required", 400))
+	}
+	project, loc, kr, key, version, ok := splitVersionName(p.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	if state := stateFromProto(p.GetState()); state != "" {
+		if err := s.keys.UpdateVersionState(ctx, project, loc, kr, key, version, state); err != nil {
+			return nil, versionErr(err)
+		}
+	}
+	v, err := s.keys.GetVersion(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	return versionToProto(project, loc, kr, key, v), nil
+}
+
+func (s *Service) setVersionState(ctx context.Context, name, state string) (*kmspb.CryptoKeyVersion, error) {
+	project, loc, kr, key, version, ok := splitVersionName(name)
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	if err := s.keys.UpdateVersionState(ctx, project, loc, kr, key, version, state); err != nil {
+		return nil, versionErr(err)
+	}
+	v, _ := s.keys.GetVersion(ctx, project, loc, kr, key, version)
+	return versionToProto(project, loc, kr, key, v), nil
+}
+
+// ─── Crypto operations ────────────────────────────────────────────────────────
+
+func (s *Service) Encrypt(ctx context.Context, req *kmspb.EncryptRequest) (*kmspb.EncryptResponse, error) {
+	project, loc, kr, key, version, ok := splitKeyOrVersionName(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	ck, err := s.keys.GetCryptoKey(ctx, project, loc, kr, key)
+	if err != nil {
+		return nil, keyErr(err)
+	}
+	if version == "" {
+		version = ck.PrimaryVersion
+	}
+	keyMat, err := s.keys.KeyMaterial(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	ct, err := kmsstore.EncryptData(keyMat, req.GetPlaintext(), req.GetAdditionalAuthenticatedData())
+	if err != nil {
+		return nil, mapError(model.NewProviderError("Internal", "encryption failed", 500))
+	}
+	blob := kmsstore.EncodeVersionedCiphertext(version, ct)
+	return &kmspb.EncryptResponse{
+		Name:                    versionName(project, loc, kr, key, version),
+		Ciphertext:              blob,
+		CiphertextCrc32C:        wrapperspb.Int64(crc32cOf(blob)),
+		VerifiedPlaintextCrc32C: req.GetPlaintextCrc32C() != nil,
+		VerifiedAdditionalAuthenticatedDataCrc32C: req.GetAdditionalAuthenticatedDataCrc32C() != nil,
+		ProtectionLevel: kmspb.ProtectionLevel_SOFTWARE,
+	}, nil
+}
+
+func (s *Service) Decrypt(ctx context.Context, req *kmspb.DecryptRequest) (*kmspb.DecryptResponse, error) {
+	project, loc, kr, key, ok := splitCryptoKeyName(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	ck, err := s.keys.GetCryptoKey(ctx, project, loc, kr, key)
+	if err != nil {
+		return nil, keyErr(err)
+	}
+	version, ct, err := kmsstore.DecodeVersionedCiphertext(req.GetCiphertext())
+	if err != nil {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid ciphertext", 400))
+	}
+	keyMat, err := s.keys.KeyMaterial(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	pt, err := kmsstore.DecryptData(keyMat, ct, req.GetAdditionalAuthenticatedData())
+	if err != nil {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "decryption failed", 400))
+	}
+	return &kmspb.DecryptResponse{
+		Plaintext:       pt,
+		PlaintextCrc32C: wrapperspb.Int64(crc32cOf(pt)),
+		UsedPrimary:     version == ck.PrimaryVersion,
+		ProtectionLevel: kmspb.ProtectionLevel_SOFTWARE,
+	}, nil
+}
+
+func (s *Service) AsymmetricSign(ctx context.Context, req *kmspb.AsymmetricSignRequest) (*kmspb.AsymmetricSignResponse, error) {
+	project, loc, kr, key, version, ok := splitVersionName(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	v, err := s.keys.GetVersion(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	digest, err := digestBytes(req.GetDigest(), req.GetData(), v.Algorithm)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	priv, err := s.keys.PrivateKey(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	var sig []byte
+	switch {
+	case strings.HasPrefix(v.Algorithm, "RSA_SIGN"):
+		sig, err = kmsstore.RSASign(priv, digest, v.Algorithm)
+	case strings.HasPrefix(v.Algorithm, "EC_SIGN"):
+		sig, err = kmsstore.ECSign(priv, digest)
+	default:
+		return nil, mapError(model.NewProviderError("FailedPrecondition", "key is not for asymmetric signing", 400))
+	}
+	if err != nil {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "signing failed", 400))
+	}
+	return &kmspb.AsymmetricSignResponse{
+		Name:                 versionName(project, loc, kr, key, version),
+		Signature:            sig,
+		SignatureCrc32C:      wrapperspb.Int64(crc32cOf(sig)),
+		VerifiedDigestCrc32C: req.GetDigestCrc32C() != nil,
+		VerifiedDataCrc32C:   req.GetDataCrc32C() != nil,
+		ProtectionLevel:      kmspb.ProtectionLevel_SOFTWARE,
+	}, nil
+}
+
+func (s *Service) AsymmetricDecrypt(ctx context.Context, req *kmspb.AsymmetricDecryptRequest) (*kmspb.AsymmetricDecryptResponse, error) {
+	project, loc, kr, key, version, ok := splitVersionName(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	v, err := s.keys.GetVersion(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	priv, err := s.keys.PrivateKey(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	if !strings.HasPrefix(v.Algorithm, "RSA_DECRYPT") {
+		return nil, mapError(model.NewProviderError("FailedPrecondition", "key is not for asymmetric decryption", 400))
+	}
+	pt, err := kmsstore.RSADecryptOAEP(priv, req.GetCiphertext(), v.Algorithm)
+	if err != nil {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "decryption failed", 400))
+	}
+	return &kmspb.AsymmetricDecryptResponse{
+		Plaintext:                pt,
+		PlaintextCrc32C:          wrapperspb.Int64(crc32cOf(pt)),
+		VerifiedCiphertextCrc32C: req.GetCiphertextCrc32C() != nil,
+		ProtectionLevel:          kmspb.ProtectionLevel_SOFTWARE,
+	}, nil
+}
+
+// GenerateRandomBytes returns length_bytes of cryptographically-secure random
+// bytes for the given location, mirroring the real KMS API shape. The emulator
+// always produces software-protection-level randomness regardless of the
+// requested protection level.
+func (s *Service) GenerateRandomBytes(ctx context.Context, req *kmspb.GenerateRandomBytesRequest) (*kmspb.GenerateRandomBytesResponse, error) {
+	length := int(req.GetLengthBytes())
+	if length <= 0 {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "length_bytes must be positive", 400))
+	}
+	data := make([]byte, length)
+	if _, err := rand.Read(data); err != nil {
+		return nil, mapError(model.NewProviderError("Internal", "random generation failed", 500))
+	}
+	return &kmspb.GenerateRandomBytesResponse{
+		Data:       data,
+		DataCrc32C: wrapperspb.Int64(crc32cOf(data)),
+	}, nil
+}
+
+func (s *Service) GetPublicKey(ctx context.Context, req *kmspb.GetPublicKeyRequest) (*kmspb.PublicKey, error) {
+	project, loc, kr, key, version, ok := splitVersionName(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	v, err := s.keys.GetVersion(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	pub, err := s.keys.PublicKey(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	pemStr, err := kmsstore.PublicKeyPEM(pub)
+	if err != nil {
+		return nil, mapError(model.NewProviderError("Internal", "public key encode failed", 500))
+	}
+	return &kmspb.PublicKey{
+		Pem:             pemStr,
+		Algorithm:       algorithmToProto(v.Algorithm),
+		PemCrc32C:       wrapperspb.Int64(crc32cOf([]byte(pemStr))),
+		Name:            versionName(project, loc, kr, key, version),
+		ProtectionLevel: kmspb.ProtectionLevel_SOFTWARE,
+	}, nil
+}
+
+func (s *Service) MacSign(ctx context.Context, req *kmspb.MacSignRequest) (*kmspb.MacSignResponse, error) {
+	project, loc, kr, key, version, ok := splitVersionName(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	v, err := s.keys.GetVersion(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	if !strings.HasPrefix(v.Algorithm, "HMAC_") {
+		return nil, mapError(model.NewProviderError("FailedPrecondition", "key is not for MAC", 400))
+	}
+	mat, err := s.keys.KeyMaterial(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	mac, err := kmsstore.HMACSign(mat, req.GetData(), v.Algorithm)
+	if err != nil {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "mac sign failed", 400))
+	}
+	return &kmspb.MacSignResponse{
+		Name:               versionName(project, loc, kr, key, version),
+		Mac:                mac,
+		MacCrc32C:          wrapperspb.Int64(crc32cOf(mac)),
+		VerifiedDataCrc32C: req.GetDataCrc32C() != nil,
+		ProtectionLevel:    kmspb.ProtectionLevel_SOFTWARE,
+	}, nil
+}
+
+func (s *Service) MacVerify(ctx context.Context, req *kmspb.MacVerifyRequest) (*kmspb.MacVerifyResponse, error) {
+	project, loc, kr, key, version, ok := splitVersionName(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	v, err := s.keys.GetVersion(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	if !strings.HasPrefix(v.Algorithm, "HMAC_") {
+		return nil, mapError(model.NewProviderError("FailedPrecondition", "key is not for MAC", 400))
+	}
+	mat, err := s.keys.KeyMaterial(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return nil, versionErr(err)
+	}
+	return &kmspb.MacVerifyResponse{
+		Name:               versionName(project, loc, kr, key, version),
+		Success:            kmsstore.HMACVerify(mat, req.GetData(), req.GetMac(), v.Algorithm),
+		VerifiedDataCrc32C: req.GetDataCrc32C() != nil,
+		VerifiedMacCrc32C:  req.GetMacCrc32C() != nil,
+		ProtectionLevel:    kmspb.ProtectionLevel_SOFTWARE,
+	}, nil
+}
+
+// ─── IAM (google.iam.v1.IAMPolicy over keyrings/keys/versions) ────────────────
+
+// Owns reports whether the KMS service handles IAM for this resource name.
+func (s *Service) Owns(resource string) bool {
+	_, _, _, ok := s.parseIamResource(resource)
+	return ok
+}
+
+// parseIamResource resolves a keyring/crypto-key/version IAM resource name to
+// its policy resource type + id (location-qualified so IDs stay unique within a
+// project).
+func (s *Service) parseIamResource(resource string) (project, policyType, id string, ok bool) {
+	if p, l, kr, ok := splitKeyRingName(resource); ok {
+		return p, rtKeyRingPolicy, l + "/" + kr, true
+	}
+	if p, l, kr, k, ok := splitCryptoKeyName(resource); ok {
+		return p, rtCryptoKeyPolicy, l + "/" + kr + "/" + k, true
+	}
+	if p, l, kr, k, v, ok := splitVersionName(resource); ok {
+		return p, rtVersionPolicy, l + "/" + kr + "/" + k + "/" + v, true
+	}
+	return "", "", "", false
+}
+
+// requireIamResource verifies the KMS resource backing an IAM request exists.
+func (s *Service) requireIamResource(ctx context.Context, resource string) error {
+	if p, l, kr, ok := splitKeyRingName(resource); ok {
+		if _, err := s.keys.GetKeyRing(ctx, p, l, kr); err != nil {
+			if errors.Is(err, kmsstore.ErrNoSuchKeyRing) {
+				return model.NewProviderError("NotFound", "key ring not found", 404)
+			}
+			return err
+		}
+		return nil
+	}
+	if p, l, kr, k, ok := splitCryptoKeyName(resource); ok {
+		if _, err := s.keys.GetCryptoKey(ctx, p, l, kr, k); err != nil {
+			if errors.Is(err, kmsstore.ErrNoSuchCryptoKey) {
+				return model.NewProviderError("NotFound", "crypto key not found", 404)
+			}
+			return err
+		}
+		return nil
+	}
+	if p, l, kr, k, v, ok := splitVersionName(resource); ok {
+		if _, err := s.keys.GetVersion(ctx, p, l, kr, k, v); err != nil {
+			if errors.Is(err, kmsstore.ErrNoSuchVersion) {
+				return model.NewProviderError("NotFound", "crypto key version not found", 404)
+			}
+			return err
+		}
+		return nil
+	}
+	return model.NewProviderError("InvalidArgument", "invalid resource name", 400)
+}
+
+func (s *Service) GetIamPolicy(ctx context.Context, req *iampb.GetIamPolicyRequest) (*iampb.Policy, error) {
+	project, rt, id, ok := s.parseIamResource(req.GetResource())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	if err := s.requireIamResource(ctx, req.GetResource()); err != nil {
+		return nil, mapError(err)
+	}
+	return policyToProto(policy.Load(ctx, s.resources, project, rt, id)), nil
+}
+
+func (s *Service) SetIamPolicy(ctx context.Context, req *iampb.SetIamPolicyRequest) (*iampb.Policy, error) {
+	project, rt, id, ok := s.parseIamResource(req.GetResource())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	if err := s.requireIamResource(ctx, req.GetResource()); err != nil {
+		return nil, mapError(err)
+	}
+	pol, err := policy.Set(ctx, s.resources, project, rt, id, protoPolicyToBody(req.GetPolicy()))
+	if err != nil {
+		return nil, mapError(err)
+	}
+	return policyToProto(pol), nil
+}
+
+func (s *Service) TestIamPermissions(ctx context.Context, req *iampb.TestIamPermissionsRequest) (*iampb.TestIamPermissionsResponse, error) {
+	_, _, _, ok := s.parseIamResource(req.GetResource())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	if err := s.requireIamResource(ctx, req.GetResource()); err != nil {
+		return nil, mapError(err)
+	}
+	return &iampb.TestIamPermissionsResponse{Permissions: policy.TestPermissions(req.GetPermissions())}, nil
+}
+
+// ─── proto ↔ internal transcoding ─────────────────────────────────────────────
+
+func keyRingToProto(project, location string, kr kmsstore.KeyRing) *kmspb.KeyRing {
+	out := &kmspb.KeyRing{Name: keyRingName(project, location, kr.ID)}
+	if !kr.CreateTime.IsZero() {
+		out.CreateTime = timestamppb.New(kr.CreateTime)
+	}
+	return out
+}
+
+func cryptoKeyToProto(project string, k kmsstore.CryptoKey) *kmspb.CryptoKey {
+	out := &kmspb.CryptoKey{
+		Name:    cryptoKeyName(project, k.Location, k.KeyRingID, k.ID),
+		Purpose: purposeToProto(k.Purpose),
+		Primary: &kmspb.CryptoKeyVersion{
+			Name:            versionName(project, k.Location, k.KeyRingID, k.ID, k.PrimaryVersion),
+			State:           kmspb.CryptoKeyVersion_ENABLED,
+			Algorithm:       algorithmToProto(k.Algorithm),
+			ProtectionLevel: kmspb.ProtectionLevel_SOFTWARE,
+		},
+		VersionTemplate: &kmspb.CryptoKeyVersionTemplate{
+			Algorithm:       algorithmToProto(k.Algorithm),
+			ProtectionLevel: kmspb.ProtectionLevel_SOFTWARE,
+		},
+	}
+	if !k.CreateTime.IsZero() {
+		out.CreateTime = timestamppb.New(k.CreateTime)
+	}
+	return out
+}
+
+func versionToProto(project, location, kr, key string, v kmsstore.Version) *kmspb.CryptoKeyVersion {
+	out := &kmspb.CryptoKeyVersion{
+		Name:            versionName(project, location, kr, key, v.Version),
+		State:           stateToProto(v.State),
+		Algorithm:       algorithmToProto(v.Algorithm),
+		ProtectionLevel: kmspb.ProtectionLevel_SOFTWARE,
+	}
+	if !v.CreateTime.IsZero() {
+		out.CreateTime = timestamppb.New(v.CreateTime)
+	}
+	return out
+}
+
+// defaultAlgorithmForPurpose maps a GCP KMS purpose to its default algorithm
+// (mirrors the REST provider).
+func defaultAlgorithmForPurpose(purpose string) string {
+	switch purpose {
+	case "ASYMMETRIC_SIGN":
+		return "RSA_SIGN_PKCS1_2048_SHA256"
+	case "ASYMMETRIC_DECRYPT":
+		return "RSA_DECRYPT_OAEP_2048_SHA256"
+	case "MAC":
+		return "HMAC_SHA256"
+	default:
+		return "GOOGLE_SYMMETRIC_ENCRYPTION"
+	}
+}
+
+func purposeFromProto(p kmspb.CryptoKey_CryptoKeyPurpose) string {
+	if p == kmspb.CryptoKey_CRYPTO_KEY_PURPOSE_UNSPECIFIED {
+		return "ENCRYPT_DECRYPT"
+	}
+	return p.String()
+}
+
+func purposeToProto(s string) kmspb.CryptoKey_CryptoKeyPurpose {
+	if v, ok := kmspb.CryptoKey_CryptoKeyPurpose_value[s]; ok {
+		return kmspb.CryptoKey_CryptoKeyPurpose(v)
+	}
+	return kmspb.CryptoKey_CRYPTO_KEY_PURPOSE_UNSPECIFIED
+}
+
+func algorithmFromProto(a kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm) string {
+	if a == kmspb.CryptoKeyVersion_CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED {
+		return ""
+	}
+	return a.String()
+}
+
+func algorithmToProto(s string) kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm {
+	if v, ok := kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm_value[s]; ok {
+		return kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm(v)
+	}
+	return kmspb.CryptoKeyVersion_CRYPTO_KEY_VERSION_ALGORITHM_UNSPECIFIED
+}
+
+func stateFromProto(s kmspb.CryptoKeyVersion_CryptoKeyVersionState) string {
+	switch s {
+	case kmspb.CryptoKeyVersion_ENABLED:
+		return "ENABLED"
+	case kmspb.CryptoKeyVersion_DISABLED:
+		return "DISABLED"
+	case kmspb.CryptoKeyVersion_DESTROYED:
+		return "DESTROYED"
+	}
+	return ""
+}
+
+func stateToProto(s string) kmspb.CryptoKeyVersion_CryptoKeyVersionState {
+	if v, ok := kmspb.CryptoKeyVersion_CryptoKeyVersionState_value[s]; ok {
+		return kmspb.CryptoKeyVersion_CryptoKeyVersionState(v)
+	}
+	return kmspb.CryptoKeyVersion_CRYPTO_KEY_VERSION_STATE_UNSPECIFIED
+}
+
+// digestBytes extracts the signing digest from the request: the Digest oneof
+// (sha256/sha384/sha512) takes precedence, then the raw data field is hashed
+// with the algorithm's digest. Mirrors the REST provider's digest handling and
+// additionally supports the proto's raw-data form.
+func digestBytes(d *kmspb.Digest, data []byte, algo string) ([]byte, error) {
+	if d != nil {
+		if dg := d.GetSha256(); len(dg) > 0 {
+			return dg, nil
+		}
+		if dg := d.GetSha384(); len(dg) > 0 {
+			return dg, nil
+		}
+		if dg := d.GetSha512(); len(dg) > 0 {
+			return dg, nil
+		}
+	}
+	if len(data) > 0 {
+		h := signHashFor(algo).New()
+		if _, err := h.Write(data); err != nil {
+			return nil, err
+		}
+		return h.Sum(nil), nil
+	}
+	return nil, model.NewProviderError("InvalidArgument", "digest is required", 400)
+}
+
+// signHashFor mirrors the store's digest-hash selection for the raw-data path.
+func signHashFor(algo string) crypto.Hash {
+	switch {
+	case strings.Contains(algo, "SHA512"):
+		return crypto.SHA512
+	case strings.Contains(algo, "SHA384"):
+		return crypto.SHA384
+	default:
+		return crypto.SHA256
+	}
+}
+
+// crc32cOf returns the CRC32C-Castagnoli checksum of b as an int64
+// (google.protobuf.Int64Value encoding).
+func crc32cOf(b []byte) int64 {
+	return int64(crc32.Checksum(b, crc32.MakeTable(crc32.Castagnoli)))
+}
+
+func protoPolicyToBody(p *iampb.Policy) map[string]any {
+	body := map[string]any{}
+	if p == nil {
+		return body
+	}
+	bindings := make([]any, 0, len(p.GetBindings()))
+	for _, b := range p.GetBindings() {
+		members := make([]any, 0, len(b.GetMembers()))
+		for _, m := range b.GetMembers() {
+			members = append(members, m)
+		}
+		bindings = append(bindings, map[string]any{"role": b.GetRole(), "members": members})
+	}
+	body["bindings"] = bindings
+	if et := p.GetEtag(); len(et) > 0 {
+		body["etag"] = string(et)
+	}
+	if p.GetVersion() != 0 {
+		body["version"] = int(p.GetVersion())
+	}
+	return body
+}
+
+func policyToProto(p policy.Policy) *iampb.Policy {
+	out := &iampb.Policy{Version: int32(p.Version)}
+	if p.Etag != "" {
+		out.Etag = []byte(p.Etag)
+	}
+	for _, b := range p.Bindings {
+		m, ok := b.(map[string]any)
+		if !ok {
+			continue
+		}
+		binding := &iampb.Binding{}
+		binding.Role, _ = m["role"].(string)
+		for _, v := range toStrings(m["members"]) {
+			binding.Members = append(binding.Members, v)
+		}
+		out.Bindings = append(out.Bindings, binding)
+	}
+	return out
+}
+
+func toStrings(v any) []string {
+	items, _ := v.([]any)
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		if s, ok := it.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/gcp/grpc/kms/service_test.go
+++ b/internal/gcp/grpc/kms/service_test.go
@@ -1,0 +1,447 @@
+package kms
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"testing"
+
+	iampb "cloud.google.com/go/iam/apiv1/iampb"
+	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
+
+	gcpcrypto "jaiscloud/internal/gcp/crypto"
+	kmsstore "jaiscloud/internal/gcp/store/kms"
+	"jaiscloud/internal/store"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+// kmsTestService dials a real in-process gRPC server backed by the memory
+// stores and returns the KMS and IAM clients.
+func kmsTestService(t *testing.T) (kmspb.KeyManagementServiceClient, iampb.IAMPolicyClient, func()) {
+	t.Helper()
+	keys := kmsstore.NewMemoryStore()
+	resources := store.NewMemoryResourceStore()
+	svc := NewService(keys, resources, gcpcrypto.NewEnvelopeEncryptor(keys), "test")
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	kmspb.RegisterKeyManagementServiceServer(srv, svc)
+	iampb.RegisterIAMPolicyServer(srv, svc)
+	go srv.Serve(ln)
+
+	conn, err := grpc.NewClient(ln.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		srv.Stop()
+		t.Fatalf("dial: %v", err)
+	}
+	cleanup := func() {
+		conn.Close()
+		srv.Stop()
+	}
+	return kmspb.NewKeyManagementServiceClient(conn), iampb.NewIAMPolicyClient(conn), cleanup
+}
+
+const (
+	keyRing = "projects/test/locations/global/keyRings/kr"
+	symKey  = keyRing + "/cryptoKeys/sym"
+	signKey = keyRing + "/cryptoKeys/sign"
+	macKey  = keyRing + "/cryptoKeys/mac"
+)
+
+func createKeyRing(t *testing.T, client kmspb.KeyManagementServiceClient, name string) {
+	t.Helper()
+	if _, err := client.CreateKeyRing(context.Background(), &kmspb.CreateKeyRingRequest{
+		Parent: "projects/test/locations/global", KeyRingId: name,
+	}); err != nil {
+		t.Fatalf("CreateKeyRing: %v", err)
+	}
+}
+
+func TestKMSKeyRingKeyVersionCRUD(t *testing.T) {
+	client, _, cleanup := kmsTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// KeyRing create + get + list.
+	createdKR, err := client.CreateKeyRing(ctx, &kmspb.CreateKeyRingRequest{
+		Parent: "projects/test/locations/global", KeyRingId: "kr",
+	})
+	if err != nil {
+		t.Fatalf("CreateKeyRing: %v", err)
+	}
+	if createdKR.GetName() != keyRing {
+		t.Fatalf("CreateKeyRing name = %q, want %q", createdKR.GetName(), keyRing)
+	}
+	if _, err := client.CreateKeyRing(ctx, &kmspb.CreateKeyRingRequest{
+		Parent: "projects/test/locations/global", KeyRingId: "kr",
+	}); status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("duplicate CreateKeyRing err = %v, want AlreadyExists", err)
+	}
+	gotKR, err := client.GetKeyRing(ctx, &kmspb.GetKeyRingRequest{Name: keyRing})
+	if err != nil {
+		t.Fatalf("GetKeyRing: %v", err)
+	}
+	if gotKR.GetName() != keyRing {
+		t.Fatalf("GetKeyRing name = %q, want %q", gotKR.GetName(), keyRing)
+	}
+	krs, err := client.ListKeyRings(ctx, &kmspb.ListKeyRingsRequest{Parent: "projects/test/locations/global"})
+	if err != nil {
+		t.Fatalf("ListKeyRings: %v", err)
+	}
+	if len(krs.GetKeyRings()) != 1 || krs.GetKeyRings()[0].GetName() != keyRing {
+		t.Fatalf("ListKeyRings = %v, want exactly [%s]", krs.GetKeyRings(), keyRing)
+	}
+
+	// CryptoKey create + get + list (symmetric default).
+	createdKey, err := client.CreateCryptoKey(ctx, &kmspb.CreateCryptoKeyRequest{
+		Parent: keyRing, CryptoKeyId: "sym",
+	})
+	if err != nil {
+		t.Fatalf("CreateCryptoKey: %v", err)
+	}
+	if createdKey.GetName() != symKey {
+		t.Fatalf("CreateCryptoKey name = %q, want %q", createdKey.GetName(), symKey)
+	}
+	if createdKey.GetPurpose() != kmspb.CryptoKey_ENCRYPT_DECRYPT {
+		t.Fatalf("CreateCryptoKey purpose = %v, want ENCRYPT_DECRYPT", createdKey.GetPurpose())
+	}
+	if createdKey.GetPrimary().GetName() != symKey+"/cryptoKeyVersions/1" {
+		t.Fatalf("CreateCryptoKey primary = %q, want version 1", createdKey.GetPrimary().GetName())
+	}
+	gotKey, err := client.GetCryptoKey(ctx, &kmspb.GetCryptoKeyRequest{Name: symKey})
+	if err != nil {
+		t.Fatalf("GetCryptoKey: %v", err)
+	}
+	if gotKey.GetName() != symKey {
+		t.Fatalf("GetCryptoKey name = %q, want %q", gotKey.GetName(), symKey)
+	}
+	cks, err := client.ListCryptoKeys(ctx, &kmspb.ListCryptoKeysRequest{Parent: keyRing})
+	if err != nil {
+		t.Fatalf("ListCryptoKeys: %v", err)
+	}
+	if len(cks.GetCryptoKeys()) != 1 || cks.GetCryptoKeys()[0].GetName() != symKey {
+		t.Fatalf("ListCryptoKeys = %v, want exactly [%s]", cks.GetCryptoKeys(), symKey)
+	}
+
+	// CryptoKeyVersion create + get + list.
+	createdVer, err := client.CreateCryptoKeyVersion(ctx, &kmspb.CreateCryptoKeyVersionRequest{
+		Parent: symKey,
+	})
+	if err != nil {
+		t.Fatalf("CreateCryptoKeyVersion: %v", err)
+	}
+	if createdVer.GetName() != symKey+"/cryptoKeyVersions/2" {
+		t.Fatalf("CreateCryptoKeyVersion name = %q, want version 2", createdVer.GetName())
+	}
+	if createdVer.GetState() != kmspb.CryptoKeyVersion_ENABLED {
+		t.Fatalf("CreateCryptoKeyVersion state = %v, want ENABLED", createdVer.GetState())
+	}
+	gotVer, err := client.GetCryptoKeyVersion(ctx, &kmspb.GetCryptoKeyVersionRequest{Name: symKey + "/cryptoKeyVersions/2"})
+	if err != nil {
+		t.Fatalf("GetCryptoKeyVersion: %v", err)
+	}
+	if gotVer.GetName() != symKey+"/cryptoKeyVersions/2" {
+		t.Fatalf("GetCryptoKeyVersion name = %q, want version 2", gotVer.GetName())
+	}
+	vers, err := client.ListCryptoKeyVersions(ctx, &kmspb.ListCryptoKeyVersionsRequest{Parent: symKey})
+	if err != nil {
+		t.Fatalf("ListCryptoKeyVersions: %v", err)
+	}
+	if len(vers.GetCryptoKeyVersions()) != 2 {
+		t.Fatalf("ListCryptoKeyVersions = %d versions, want 2", len(vers.GetCryptoKeyVersions()))
+	}
+
+	// Missing key → NotFound.
+	if _, err := client.GetCryptoKey(ctx, &kmspb.GetCryptoKeyRequest{Name: keyRing + "/cryptoKeys/missing"}); status.Code(err) != codes.NotFound {
+		t.Fatalf("GetCryptoKey missing err = %v, want NotFound", err)
+	}
+}
+
+func TestKMSSymmetricEncryptDecrypt(t *testing.T) {
+	client, _, cleanup := kmsTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createKeyRing(t, client, "kr")
+	if _, err := client.CreateCryptoKey(ctx, &kmspb.CreateCryptoKeyRequest{Parent: keyRing, CryptoKeyId: "sym"}); err != nil {
+		t.Fatalf("CreateCryptoKey: %v", err)
+	}
+
+	plaintext := []byte("the quick brown fox")
+	aad := []byte("context")
+
+	enc, err := client.Encrypt(ctx, &kmspb.EncryptRequest{
+		Name:                        symKey,
+		Plaintext:                   plaintext,
+		AdditionalAuthenticatedData: aad,
+	})
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if len(enc.GetCiphertext()) == 0 {
+		t.Fatal("Encrypt ciphertext is empty")
+	}
+	if enc.GetProtectionLevel() != kmspb.ProtectionLevel_SOFTWARE {
+		t.Fatalf("Encrypt protectionLevel = %v, want SOFTWARE", enc.GetProtectionLevel())
+	}
+
+	// Decrypt with the matching AAD recovers the plaintext.
+	dec, err := client.Decrypt(ctx, &kmspb.DecryptRequest{
+		Name:                        symKey,
+		Ciphertext:                  enc.GetCiphertext(),
+		AdditionalAuthenticatedData: aad,
+	})
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if string(dec.GetPlaintext()) != string(plaintext) {
+		t.Fatalf("Decrypt plaintext = %q, want %q", dec.GetPlaintext(), plaintext)
+	}
+	if !dec.GetUsedPrimary() {
+		t.Fatal("Decrypt usedPrimary = false, want true")
+	}
+
+	// Decrypt with the wrong AAD fails.
+	if _, err := client.Decrypt(ctx, &kmspb.DecryptRequest{
+		Name: symKey, Ciphertext: enc.GetCiphertext(),
+		AdditionalAuthenticatedData: []byte("wrong"),
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("Decrypt wrong AAD err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestKMSAsymmetricSignAndPublicKey(t *testing.T) {
+	client, _, cleanup := kmsTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createKeyRing(t, client, "kr")
+	if _, err := client.CreateCryptoKey(ctx, &kmspb.CreateCryptoKeyRequest{
+		Parent:      keyRing,
+		CryptoKeyId: "sign",
+		CryptoKey: &kmspb.CryptoKey{
+			Purpose: kmspb.CryptoKey_ASYMMETRIC_SIGN,
+		},
+	}); err != nil {
+		t.Fatalf("CreateCryptoKey: %v", err)
+	}
+
+	verName := signKey + "/cryptoKeyVersions/1"
+	msg := []byte("message to sign")
+	digest := sha256.Sum256(msg)
+
+	signResp, err := client.AsymmetricSign(ctx, &kmspb.AsymmetricSignRequest{
+		Name:   verName,
+		Digest: &kmspb.Digest{Digest: &kmspb.Digest_Sha256{Sha256: digest[:]}},
+	})
+	if err != nil {
+		t.Fatalf("AsymmetricSign: %v", err)
+	}
+	if len(signResp.GetSignature()) == 0 {
+		t.Fatal("AsymmetricSign signature is empty")
+	}
+
+	// GetPublicKey returns a verifiable PEM.
+	pub, err := client.GetPublicKey(ctx, &kmspb.GetPublicKeyRequest{Name: verName})
+	if err != nil {
+		t.Fatalf("GetPublicKey: %v", err)
+	}
+	if pub.GetProtectionLevel() != kmspb.ProtectionLevel_SOFTWARE {
+		t.Fatalf("GetPublicKey protectionLevel = %v, want SOFTWARE", pub.GetProtectionLevel())
+	}
+	block, _ := pem.Decode([]byte(pub.GetPem()))
+	if block == nil {
+		t.Fatalf("GetPublicKey pem is not valid PEM: %q", pub.GetPem())
+	}
+	pubKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse public key: %v", err)
+	}
+	rsaPub, ok := pubKey.(*rsa.PublicKey)
+	if !ok {
+		t.Fatalf("public key type = %T, want *rsa.PublicKey", pubKey)
+	}
+	if err := rsa.VerifyPKCS1v15(rsaPub, crypto.SHA256, digest[:], signResp.GetSignature()); err != nil {
+		t.Fatalf("signature verify failed: %v", err)
+	}
+}
+
+func TestKMSMacSignVerify(t *testing.T) {
+	client, _, cleanup := kmsTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createKeyRing(t, client, "kr")
+	if _, err := client.CreateCryptoKey(ctx, &kmspb.CreateCryptoKeyRequest{
+		Parent:      keyRing,
+		CryptoKeyId: "mac",
+		CryptoKey: &kmspb.CryptoKey{
+			Purpose: kmspb.CryptoKey_MAC,
+		},
+	}); err != nil {
+		t.Fatalf("CreateCryptoKey: %v", err)
+	}
+
+	verName := macKey + "/cryptoKeyVersions/1"
+	data := []byte("mac this data")
+
+	signResp, err := client.MacSign(ctx, &kmspb.MacSignRequest{Name: verName, Data: data})
+	if err != nil {
+		t.Fatalf("MacSign: %v", err)
+	}
+	if len(signResp.GetMac()) == 0 {
+		t.Fatal("MacSign mac is empty")
+	}
+
+	verifyResp, err := client.MacVerify(ctx, &kmspb.MacVerifyRequest{Name: verName, Data: data, Mac: signResp.GetMac()})
+	if err != nil {
+		t.Fatalf("MacVerify: %v", err)
+	}
+	if !verifyResp.GetSuccess() {
+		t.Fatal("MacVerify success = false, want true")
+	}
+
+	// Tampered data fails verification.
+	badVerify, err := client.MacVerify(ctx, &kmspb.MacVerifyRequest{Name: verName, Data: []byte("tampered"), Mac: signResp.GetMac()})
+	if err != nil {
+		t.Fatalf("MacVerify tampered: %v", err)
+	}
+	if badVerify.GetSuccess() {
+		t.Fatal("MacVerify tampered success = true, want false")
+	}
+}
+
+func TestKMSDestroyVersion(t *testing.T) {
+	client, _, cleanup := kmsTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createKeyRing(t, client, "kr")
+	if _, err := client.CreateCryptoKey(ctx, &kmspb.CreateCryptoKeyRequest{Parent: keyRing, CryptoKeyId: "sym"}); err != nil {
+		t.Fatalf("CreateCryptoKey: %v", err)
+	}
+
+	verName := symKey + "/cryptoKeyVersions/1"
+
+	destroyed, err := client.DestroyCryptoKeyVersion(ctx, &kmspb.DestroyCryptoKeyVersionRequest{Name: verName})
+	if err != nil {
+		t.Fatalf("DestroyCryptoKeyVersion: %v", err)
+	}
+	if destroyed.GetState() != kmspb.CryptoKeyVersion_DESTROYED {
+		t.Fatalf("DestroyCryptoKeyVersion state = %v, want DESTROYED", destroyed.GetState())
+	}
+
+	// Restore brings it back to DISABLED (GCP semantics).
+	restored, err := client.RestoreCryptoKeyVersion(ctx, &kmspb.RestoreCryptoKeyVersionRequest{Name: verName})
+	if err != nil {
+		t.Fatalf("RestoreCryptoKeyVersion: %v", err)
+	}
+	if restored.GetState() != kmspb.CryptoKeyVersion_DISABLED {
+		t.Fatalf("RestoreCryptoKeyVersion state = %v, want DISABLED", restored.GetState())
+	}
+
+	// UpdateCryptoKeyVersion moves it back to ENABLED.
+	enabled, err := client.UpdateCryptoKeyVersion(ctx, &kmspb.UpdateCryptoKeyVersionRequest{
+		CryptoKeyVersion: &kmspb.CryptoKeyVersion{Name: verName, State: kmspb.CryptoKeyVersion_ENABLED},
+	})
+	if err != nil {
+		t.Fatalf("UpdateCryptoKeyVersion: %v", err)
+	}
+	if enabled.GetState() != kmspb.CryptoKeyVersion_ENABLED {
+		t.Fatalf("UpdateCryptoKeyVersion state = %v, want ENABLED", enabled.GetState())
+	}
+}
+
+func TestKMSKeyRingIamPolicy(t *testing.T) {
+	client, iam, cleanup := kmsTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createKeyRing(t, client, "kr")
+
+	// Empty policy by default.
+	pol, err := iam.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: keyRing})
+	if err != nil {
+		t.Fatalf("GetIamPolicy: %v", err)
+	}
+	if len(pol.GetBindings()) != 0 {
+		t.Fatalf("GetIamPolicy bindings = %v, want empty", pol.GetBindings())
+	}
+
+	// Set IAM policy.
+	if _, err := iam.SetIamPolicy(ctx, &iampb.SetIamPolicyRequest{
+		Resource: keyRing,
+		Policy: &iampb.Policy{
+			Bindings: []*iampb.Binding{{Role: "roles/cloudkms.cryptoKeyEncrypter", Members: []string{"allUsers"}}},
+		},
+	}); err != nil {
+		t.Fatalf("SetIamPolicy: %v", err)
+	}
+
+	pol, err = iam.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: keyRing})
+	if err != nil {
+		t.Fatalf("GetIamPolicy after set: %v", err)
+	}
+	if len(pol.GetBindings()) != 1 || pol.GetBindings()[0].GetRole() != "roles/cloudkms.cryptoKeyEncrypter" {
+		t.Fatalf("GetIamPolicy bindings = %v, want roles/cloudkms.cryptoKeyEncrypter", pol.GetBindings())
+	}
+
+	// Test permissions echoes the request (no-authz posture).
+	tp, err := iam.TestIamPermissions(ctx, &iampb.TestIamPermissionsRequest{
+		Resource: keyRing, Permissions: []string{"cloudkms.cryptoKeys.get", "cloudkms.cryptoKeys.create"},
+	})
+	if err != nil {
+		t.Fatalf("TestIamPermissions: %v", err)
+	}
+	if len(tp.GetPermissions()) != 2 {
+		t.Fatalf("TestIamPermissions = %v, want 2 granted", tp.GetPermissions())
+	}
+
+	// IAM on a missing keyring → NotFound.
+	if _, err := iam.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{
+		Resource: "projects/test/locations/global/keyRings/missing",
+	}); status.Code(err) != codes.NotFound {
+		t.Fatalf("GetIamPolicy missing err = %v, want NotFound", err)
+	}
+}
+
+func TestKMSGenerateRandomBytes(t *testing.T) {
+	client, _, cleanup := kmsTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resp, err := client.GenerateRandomBytes(ctx, &kmspb.GenerateRandomBytesRequest{
+		Location:        "projects/test/locations/us-central1",
+		LengthBytes:     32,
+		ProtectionLevel: kmspb.ProtectionLevel_SOFTWARE,
+	})
+	if err != nil {
+		t.Fatalf("GenerateRandomBytes: %v", err)
+	}
+	if len(resp.GetData()) != 32 {
+		t.Fatalf("GenerateRandomBytes data length = %d, want 32", len(resp.GetData()))
+	}
+	// Two calls must not produce identical bytes.
+	resp2, err := client.GenerateRandomBytes(ctx, &kmspb.GenerateRandomBytesRequest{
+		Location: "projects/test/locations/us-central1", LengthBytes: 32,
+	})
+	if err != nil {
+		t.Fatalf("GenerateRandomBytes (2): %v", err)
+	}
+	if string(resp.GetData()) == string(resp2.GetData()) {
+		t.Fatal("GenerateRandomBytes returned identical bytes across calls")
+	}
+
+	// Negative length is rejected.
+	if _, err := client.GenerateRandomBytes(ctx, &kmspb.GenerateRandomBytesRequest{
+		Location: "projects/test/locations/us-central1", LengthBytes: 0,
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("GenerateRandomBytes length 0 err = %v, want InvalidArgument", err)
+	}
+}

--- a/internal/gcp/grpc/pubsub/service.go
+++ b/internal/gcp/grpc/pubsub/service.go
@@ -1,0 +1,969 @@
+// Package pubsub implements the Cloud Pub/Sub gRPC services (Publisher,
+// Subscriber, and the google.iam.v1.IAMPolicy surface for topic/subscription
+// IAM) over the same shared store.ResourceStore + pubsubstore.Messages + policy
+// + crypto.EnvelopeEncryptor backing the REST provider, so REST and gRPC share
+// state.
+package pubsub
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	iampb "cloud.google.com/go/iam/apiv1/iampb"
+	pubsubpb "cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
+
+	"jaiscloud/internal/clock"
+	"jaiscloud/internal/gcp/crypto"
+	grpcutil "jaiscloud/internal/gcp/grpc"
+	"jaiscloud/internal/gcp/paging"
+	"jaiscloud/internal/gcp/policy"
+	kmsstore "jaiscloud/internal/gcp/store/kms"
+	pubsubstore "jaiscloud/internal/gcp/store/pubsub"
+	"jaiscloud/internal/model"
+	"jaiscloud/internal/store"
+
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Resource-type strings mirror the REST provider's persisted types so both
+// transports share the same control-plane entries.
+const (
+	rtTopic              = "gcp_topic"
+	rtSubscription       = "gcp_subscription"
+	rtTopicPolicy        = "gcp_topic_policy"
+	rtSubscriptionPolicy = "gcp_subscription_policy"
+
+	// longPollTimeout bounds the returnImmediately=false poll window. Real GCP
+	// waits ~20s for a message; the emulator uses a 1s window so empty-pull
+	// tests don't hang.
+	longPollTimeout  = time.Second
+	longPollInterval = 50 * time.Millisecond
+
+	// streamPullBatch bounds how many messages StreamingPull claims per poll so
+	// the stream keeps up with flow-control without over-claiming.
+	streamPullBatch = 100
+)
+
+// pushClient bounds push-subscription delivery so a hung or slow endpoint
+// cannot block a publish request indefinitely.
+var pushClient = &http.Client{Timeout: 10 * time.Second}
+
+// Service implements pubsubpb.PublisherServer, pubsubpb.SubscriberServer, and
+// iampb.IAMPolicyServer over the shared stores.
+type Service struct {
+	pubsubpb.UnimplementedPublisherServer
+	pubsubpb.UnimplementedSubscriberServer
+	iampb.UnimplementedIAMPolicyServer
+
+	resources   store.ResourceStore  // topics + subscriptions (control-plane)
+	messages    pubsubstore.Messages // published messages (data plane)
+	encryptor   crypto.EnvelopeEncryptor
+	defaultProj string
+}
+
+// NewService returns a Pub/Sub gRPC service backed by the shared stores.
+// defaultProj is the config-default project used when a request carries none.
+func NewService(resources store.ResourceStore, messages pubsubstore.Messages, encryptor crypto.EnvelopeEncryptor, defaultProj string) *Service {
+	return &Service{resources: resources, messages: messages, encryptor: encryptor, defaultProj: defaultProj}
+}
+
+func mapError(err error) error { return grpcutil.GRPCStatus(err) }
+
+// ─── resource-name parsing ────────────────────────────────────────────────────
+
+func topicName(project, id string) string {
+	return "projects/" + project + "/topics/" + id
+}
+
+func subscriptionName(project, id string) string {
+	return "projects/" + project + "/subscriptions/" + id
+}
+
+// splitTopicName parses "projects/{p}/topics/{t}".
+func splitTopicName(name string) (project, topic string, ok bool) {
+	parts := strings.Split(name, "/")
+	if len(parts) != 4 || parts[0] != "projects" || parts[2] != "topics" {
+		return "", "", false
+	}
+	return parts[1], parts[3], true
+}
+
+// splitSubscriptionName parses "projects/{p}/subscriptions/{s}".
+func splitSubscriptionName(name string) (project, sub string, ok bool) {
+	parts := strings.Split(name, "/")
+	if len(parts) != 4 || parts[0] != "projects" || parts[2] != "subscriptions" {
+		return "", "", false
+	}
+	return parts[1], parts[3], true
+}
+
+// projectFromListProject resolves the project for a List* request, which
+// carries "projects/{p}" (or a bare project id) in the Project field.
+func (s *Service) projectFromListProject(ctx context.Context, p string) string {
+	if p != "" {
+		return strings.TrimPrefix(p, "projects/")
+	}
+	return grpcutil.ProjectFromMetadata(ctx, s.defaultProj)
+}
+
+// ─── Publisher ────────────────────────────────────────────────────────────────
+
+func (s *Service) CreateTopic(ctx context.Context, req *pubsubpb.Topic) (*pubsubpb.Topic, error) {
+	project, t, ok := splitTopicName(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid topic name", 400))
+	}
+	if project == "" {
+		project = grpcutil.ProjectFromMetadata(ctx, s.defaultProj)
+	}
+	meta := map[string]any{"name": topicName(project, t)}
+	if req.GetMessageRetentionDuration() != nil {
+		meta["messageRetentionDuration"] = req.GetMessageRetentionDuration().AsDuration().String()
+	}
+	if k := req.GetKmsKeyName(); k != "" {
+		meta["kmsKeyName"] = k
+	}
+	if len(req.GetLabels()) > 0 {
+		meta["labels"] = req.GetLabels()
+	}
+	data, _ := json.Marshal(meta)
+	if err := s.resources.Create(ctx, project, store.GlobalRegion, store.ResourceEntry{Type: rtTopic, ID: t, Data: data}); err != nil {
+		if errors.Is(err, store.ErrAlreadyExists) {
+			return nil, mapError(model.NewProviderError("AlreadyExists", "topic already exists", 409))
+		}
+		return nil, mapError(err)
+	}
+	return topicToProto(project, t, meta), nil
+}
+
+func (s *Service) GetTopic(ctx context.Context, req *pubsubpb.GetTopicRequest) (*pubsubpb.Topic, error) {
+	project, t, ok := splitTopicName(req.GetTopic())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid topic name", 400))
+	}
+	e, err := s.resources.Get(ctx, project, store.GlobalRegion, rtTopic, t)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, mapError(model.NewProviderError("NotFound", "topic not found", 404))
+		}
+		return nil, mapError(err)
+	}
+	var m map[string]any
+	json.Unmarshal(e.Data, &m)
+	if m == nil {
+		m = map[string]any{"name": topicName(project, t)}
+	}
+	return topicToProto(project, t, m), nil
+}
+
+func (s *Service) ListTopics(ctx context.Context, req *pubsubpb.ListTopicsRequest) (*pubsubpb.ListTopicsResponse, error) {
+	project := s.projectFromListProject(ctx, req.GetProject())
+	entries, err := s.resources.List(ctx, project, store.GlobalRegion, rtTopic, "")
+	if err != nil {
+		return nil, mapError(err)
+	}
+	page, nextToken := paging.Apply(entries, map[string]any{"pageSize": int(req.GetPageSize()), "pageToken": req.GetPageToken()})
+	topics := make([]*pubsubpb.Topic, 0, len(page))
+	for _, e := range page {
+		var m map[string]any
+		if json.Unmarshal(e.Data, &m) == nil {
+			topics = append(topics, topicToProto(project, e.ID, m))
+		}
+	}
+	return &pubsubpb.ListTopicsResponse{Topics: topics, NextPageToken: nextToken}, nil
+}
+
+func (s *Service) DeleteTopic(ctx context.Context, req *pubsubpb.DeleteTopicRequest) (*emptypb.Empty, error) {
+	project, t, ok := splitTopicName(req.GetTopic())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid topic name", 400))
+	}
+	if err := s.resources.Delete(ctx, project, store.GlobalRegion, rtTopic, t); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, mapError(model.NewProviderError("NotFound", "topic not found", 404))
+		}
+		return nil, mapError(err)
+	}
+	return &emptypb.Empty{}, nil
+}
+
+func (s *Service) Publish(ctx context.Context, req *pubsubpb.PublishRequest) (*pubsubpb.PublishResponse, error) {
+	project, t, ok := splitTopicName(req.GetTopic())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid topic name", 400))
+	}
+	topicEntry, err := s.resources.Get(ctx, project, store.GlobalRegion, rtTopic, t)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, mapError(model.NewProviderError("NotFound", "topic not found", 404))
+		}
+		return nil, mapError(err)
+	}
+	kmsKeyName := ""
+	var topicMeta map[string]any
+	if json.Unmarshal(topicEntry.Data, &topicMeta) == nil {
+		kmsKeyName, _ = topicMeta["kmsKeyName"].(string)
+	}
+
+	publishTime := clock.Now()
+	ids := make([]string, 0, len(req.GetMessages()))
+	stored := make([]pubsubstore.Message, 0, len(req.GetMessages()))
+	plainData := make([]string, 0, len(req.GetMessages()))
+	for _, m := range req.GetMessages() {
+		id, err := s.messages.NextID(ctx)
+		if err != nil {
+			return nil, mapError(err)
+		}
+		// Envelope-encrypt the payload: AES-GCM with a fresh DEK, wrapping the
+		// DEK under the topic's CMEK key (or the server DEK when no key).
+		rawDEK, wrappedDEK, err := s.encryptor.Wrap(ctx, project, kmsKeyName)
+		if err != nil {
+			return nil, mapError(err)
+		}
+		ciphertext, err := kmsstore.EncryptData(rawDEK, m.GetData(), nil)
+		if err != nil {
+			return nil, mapError(err)
+		}
+
+		msg := pubsubstore.Message{
+			Topic: t, MessageID: id, Data: base64.StdEncoding.EncodeToString(ciphertext),
+			Attributes: m.GetAttributes(), PublishTime: publishTime,
+			KmsKeyName: kmsKeyName, WrappedDEK: wrappedDEK,
+		}
+		if ok := m.GetOrderingKey(); ok != "" {
+			msg.OrderingKey = ok
+		}
+		if err := s.messages.Put(ctx, msg); err != nil {
+			return nil, mapError(err)
+		}
+		stored = append(stored, msg)
+		plainData = append(plainData, base64.StdEncoding.EncodeToString(m.GetData()))
+		ids = append(ids, id)
+	}
+
+	topicFull := topicName(project, t)
+	for i, msg := range stored {
+		s.deliverPush(ctx, project, topicFull, msg, plainData[i])
+	}
+	return &pubsubpb.PublishResponse{MessageIds: ids}, nil
+}
+
+// deliverPush POSTs a message to every push subscription of the topic (SNS
+// deliverToHTTP analogue).
+func (s *Service) deliverPush(ctx context.Context, accountID, topicFull string, msg pubsubstore.Message, data string) {
+	entries, err := s.resources.List(ctx, accountID, store.GlobalRegion, rtSubscription, "")
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		var sub map[string]any
+		if json.Unmarshal(e.Data, &sub) != nil {
+			continue
+		}
+		if st, _ := sub["topic"].(string); st != topicFull {
+			continue
+		}
+		pc, _ := sub["pushConfig"].(map[string]any)
+		endpoint, _ := pc["pushEndpoint"].(string)
+		if endpoint == "" {
+			continue
+		}
+		payload := map[string]any{
+			"message": map[string]any{
+				"messageId":   msg.MessageID,
+				"data":        data,
+				"publishTime": msg.PublishTime.UTC().Format("2006-01-02T15:04:05.000000Z"),
+			},
+			"subscription": sub["name"],
+		}
+		if len(msg.Attributes) > 0 {
+			payload["message"].(map[string]any)["attributes"] = msg.Attributes
+		}
+		body, _ := json.Marshal(payload)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+		if err != nil {
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if resp, err := pushClient.Do(req); err == nil {
+			resp.Body.Close()
+		}
+	}
+}
+
+// ─── Subscriber ───────────────────────────────────────────────────────────────
+
+func (s *Service) CreateSubscription(ctx context.Context, req *pubsubpb.Subscription) (*pubsubpb.Subscription, error) {
+	project, sub, ok := splitSubscriptionName(req.GetName())
+	if !ok || sub == "" {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid subscription name", 400))
+	}
+	if project == "" {
+		project = grpcutil.ProjectFromMetadata(ctx, s.defaultProj)
+	}
+	ackDeadline := 10
+	if req.GetAckDeadlineSeconds() != 0 {
+		ackDeadline = int(req.GetAckDeadlineSeconds())
+	}
+	meta := map[string]any{
+		"name":               subscriptionName(project, sub),
+		"topic":              req.GetTopic(),
+		"ackDeadlineSeconds": ackDeadline,
+	}
+	if dlp := req.GetDeadLetterPolicy(); dlp != nil {
+		meta["deadLetterPolicy"] = map[string]any{
+			"deadLetterTopic":     dlp.GetDeadLetterTopic(),
+			"maxDeliveryAttempts": int(dlp.GetMaxDeliveryAttempts()),
+		}
+	}
+	if pc := req.GetPushConfig(); pc != nil && pc.GetPushEndpoint() != "" {
+		meta["pushConfig"] = map[string]any{"pushEndpoint": pc.GetPushEndpoint()}
+	}
+	data, _ := json.Marshal(meta)
+	if err := s.resources.Create(ctx, project, store.GlobalRegion, store.ResourceEntry{Type: rtSubscription, ID: sub, Data: data}); err != nil {
+		if errors.Is(err, store.ErrAlreadyExists) {
+			return nil, mapError(model.NewProviderError("AlreadyExists", "subscription already exists", 409))
+		}
+		return nil, mapError(err)
+	}
+	return subToProto(meta), nil
+}
+
+func (s *Service) GetSubscription(ctx context.Context, req *pubsubpb.GetSubscriptionRequest) (*pubsubpb.Subscription, error) {
+	project, sub, ok := splitSubscriptionName(req.GetSubscription())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid subscription name", 400))
+	}
+	e, err := s.resources.Get(ctx, project, store.GlobalRegion, rtSubscription, sub)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, mapError(model.NewProviderError("NotFound", "subscription not found", 404))
+		}
+		return nil, mapError(err)
+	}
+	var m map[string]any
+	json.Unmarshal(e.Data, &m)
+	return subToProto(m), nil
+}
+
+func (s *Service) ListSubscriptions(ctx context.Context, req *pubsubpb.ListSubscriptionsRequest) (*pubsubpb.ListSubscriptionsResponse, error) {
+	project := s.projectFromListProject(ctx, req.GetProject())
+	entries, err := s.resources.List(ctx, project, store.GlobalRegion, rtSubscription, "")
+	if err != nil {
+		return nil, mapError(err)
+	}
+	page, nextToken := paging.Apply(entries, map[string]any{"pageSize": int(req.GetPageSize()), "pageToken": req.GetPageToken()})
+	subs := make([]*pubsubpb.Subscription, 0, len(page))
+	for _, e := range page {
+		var m map[string]any
+		if json.Unmarshal(e.Data, &m) == nil {
+			subs = append(subs, subToProto(m))
+		}
+	}
+	return &pubsubpb.ListSubscriptionsResponse{Subscriptions: subs, NextPageToken: nextToken}, nil
+}
+
+func (s *Service) DeleteSubscription(ctx context.Context, req *pubsubpb.DeleteSubscriptionRequest) (*emptypb.Empty, error) {
+	project, sub, ok := splitSubscriptionName(req.GetSubscription())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid subscription name", 400))
+	}
+	if err := s.resources.Delete(ctx, project, store.GlobalRegion, rtSubscription, sub); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, mapError(model.NewProviderError("NotFound", "subscription not found", 404))
+		}
+		return nil, mapError(err)
+	}
+	return &emptypb.Empty{}, nil
+}
+
+func (s *Service) Pull(ctx context.Context, req *pubsubpb.PullRequest) (*pubsubpb.PullResponse, error) {
+	project, sub, ok := splitSubscriptionName(req.GetSubscription())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid subscription name", 400))
+	}
+	e, err := s.resources.Get(ctx, project, store.GlobalRegion, rtSubscription, sub)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, mapError(model.NewProviderError("NotFound", "subscription not found", 404))
+		}
+		return nil, mapError(err)
+	}
+	var meta map[string]any
+	json.Unmarshal(e.Data, &meta)
+	topic, _ := meta["topic"].(string)
+	topicID := topic
+	if i := strings.LastIndex(topicID, "/"); i >= 0 {
+		topicID = topicID[i+1:]
+	}
+
+	// Dead-letter policy (mirrors SQS RedrivePolicy/maxReceiveCount).
+	dlqTopic := ""
+	maxDeliveryAttempts := 0
+	if dp, ok := meta["deadLetterPolicy"].(map[string]any); ok {
+		if dt, _ := dp["deadLetterTopic"].(string); dt != "" {
+			dlqTopic = dt
+			if i := strings.LastIndex(dlqTopic, "/"); i >= 0 {
+				dlqTopic = dlqTopic[i+1:]
+			}
+		}
+		if mda, ok := dp["maxDeliveryAttempts"].(float64); ok {
+			maxDeliveryAttempts = int(mda)
+		}
+	}
+
+	ackDeadline := 10
+	if ad, ok := meta["ackDeadlineSeconds"].(float64); ok {
+		ackDeadline = int(ad)
+	}
+	retention := s.topicRetention(ctx, project, topicID)
+
+	maxMsgs := 100
+	if req.GetMaxMessages() > 0 {
+		maxMsgs = int(req.GetMaxMessages())
+	}
+
+	var msgs []pubsubstore.Message
+	if req.GetReturnImmediately() {
+		msgs, err = s.messages.Pull(ctx, topicID, maxMsgs, ackDeadline, retention, clock.Now())
+	} else {
+		msgs, err = s.longPoll(ctx, topicID, maxMsgs, ackDeadline, retention)
+	}
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	received, err := s.buildReceivedMessages(ctx, project, topicID, dlqTopic, maxDeliveryAttempts, msgs)
+	if err != nil {
+		return nil, err
+	}
+	return &pubsubpb.PullResponse{ReceivedMessages: received}, nil
+}
+
+// buildReceivedMessages transcodes claimed messages into wire ReceivedMessages,
+// applying DLQ republish + envelope decryption. Shared by Pull and StreamingPull
+// so both transports emit the same ack-id scheme and payload shape.
+func (s *Service) buildReceivedMessages(ctx context.Context, project, topicID, dlqTopic string, maxDeliveryAttempts int, msgs []pubsubstore.Message) ([]*pubsubpb.ReceivedMessage, error) {
+	received := make([]*pubsubpb.ReceivedMessage, 0, len(msgs))
+	for _, m := range msgs {
+		// DLQ: once delivery attempts exceed maxDeliveryAttempts, republish to
+		// the dead-letter topic and drop the original.
+		if dlqTopic != "" && maxDeliveryAttempts > 0 && m.DeliveryAttempt > maxDeliveryAttempts {
+			_ = s.messages.Delete(ctx, topicID, m.MessageID)
+			_ = s.messages.Put(ctx, pubsubstore.Message{
+				Topic: dlqTopic, MessageID: m.MessageID, Data: m.Data, Attributes: m.Attributes,
+				PublishTime: m.PublishTime, DeliveryAttempt: 0,
+				KmsKeyName: m.KmsKeyName, WrappedDEK: m.WrappedDEK,
+			})
+			continue
+		}
+
+		// Decrypt the stored ciphertext back to the plaintext payload.
+		rawDEK, err := s.encryptor.Unwrap(ctx, project, m.KmsKeyName, m.WrappedDEK)
+		if err != nil {
+			return nil, mapError(err)
+		}
+		ciphertext, err := base64.StdEncoding.DecodeString(m.Data)
+		if err != nil {
+			return nil, mapError(err)
+		}
+		plain, err := kmsstore.DecryptData(rawDEK, ciphertext, nil)
+		if err != nil {
+			return nil, mapError(err)
+		}
+
+		pm := &pubsubpb.PubsubMessage{
+			MessageId:   m.MessageID,
+			Data:        plain,
+			PublishTime: timestamppb.New(m.PublishTime),
+		}
+		if len(m.Attributes) > 0 {
+			pm.Attributes = m.Attributes
+		}
+		if m.OrderingKey != "" {
+			pm.OrderingKey = m.OrderingKey
+		}
+		received = append(received, &pubsubpb.ReceivedMessage{
+			AckId:           encodeAckID(topicID, m.MessageID),
+			Message:         pm,
+			DeliveryAttempt: int32(m.DeliveryAttempt),
+		})
+	}
+	return received, nil
+}
+
+// longPoll repeatedly claims messages until at least one is deliverable or the
+// bounded window elapses.
+func (s *Service) longPoll(ctx context.Context, topicID string, maxMsgs, ackDeadline, retention int) ([]pubsubstore.Message, error) {
+	deadline := clock.Now().Add(longPollTimeout)
+	for {
+		msgs, err := s.messages.Pull(ctx, topicID, maxMsgs, ackDeadline, retention, clock.Now())
+		if err != nil {
+			return nil, err
+		}
+		if len(msgs) > 0 || !clock.Now().Before(deadline) {
+			return msgs, nil
+		}
+		time.Sleep(longPollInterval)
+	}
+}
+
+// StreamingPull implements the bidirectional streaming pull used by the
+// official Go SDK's Subscription.Receive. It mirrors unary Pull's
+// subscription→topic resolution and ack-deadline handling, but streams messages
+// back continuously and folds the client's ackIds / modifyDeadline* fields into
+// the same store operations as Acknowledge / ModifyAckDeadline.
+func (s *Service) StreamingPull(stream pubsubpb.Subscriber_StreamingPullServer) error {
+	ctx := stream.Context()
+
+	// The first request carries the subscription name.
+	first, err := stream.Recv()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+
+	project, sub, ok := splitSubscriptionName(first.GetSubscription())
+	if !ok {
+		return mapError(model.NewProviderError("InvalidArgument", "invalid subscription name", 400))
+	}
+	e, err := s.resources.Get(ctx, project, store.GlobalRegion, rtSubscription, sub)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return mapError(model.NewProviderError("NotFound", "subscription not found", 404))
+		}
+		return mapError(err)
+	}
+	var meta map[string]any
+	json.Unmarshal(e.Data, &meta)
+	topic, _ := meta["topic"].(string)
+	topicID := topic
+	if i := strings.LastIndex(topicID, "/"); i >= 0 {
+		topicID = topicID[i+1:]
+	}
+
+	// Dead-letter policy (mirrors Pull).
+	dlqTopic := ""
+	maxDeliveryAttempts := 0
+	if dp, ok := meta["deadLetterPolicy"].(map[string]any); ok {
+		if dt, _ := dp["deadLetterTopic"].(string); dt != "" {
+			dlqTopic = dt
+			if i := strings.LastIndex(dlqTopic, "/"); i >= 0 {
+				dlqTopic = dlqTopic[i+1:]
+			}
+		}
+		if mda, ok := dp["maxDeliveryAttempts"].(float64); ok {
+			maxDeliveryAttempts = int(mda)
+		}
+	}
+
+	// Ack deadline: streamAckDeadlineSeconds wins over the subscription default.
+	ackDeadline := 10
+	if ad, ok := meta["ackDeadlineSeconds"].(float64); ok {
+		ackDeadline = int(ad)
+	}
+	if first.GetStreamAckDeadlineSeconds() > 0 {
+		ackDeadline = int(first.GetStreamAckDeadlineSeconds())
+	}
+	retention := s.topicRetention(ctx, project, topicID)
+
+	// Handle the initial request's control fields.
+	s.applyStreamAcks(ctx, topicID, first)
+	s.applyStreamModifyDeadlines(ctx, topicID, first)
+
+	// recvLoop consumes subsequent requests (acks / modify-deadlines) as they
+	// arrive, so message delivery is never blocked on the client's control flow.
+	recvErr := make(chan error, 1)
+	go func() {
+		for {
+			r, err := stream.Recv()
+			if err != nil {
+				recvErr <- err
+				return
+			}
+			s.applyStreamAcks(ctx, topicID, r)
+			s.applyStreamModifyDeadlines(ctx, topicID, r)
+		}
+	}()
+
+	// sendLoop streams claimed messages until the stream is closed.
+	for {
+		msgs, err := s.messages.Pull(ctx, topicID, streamPullBatch, ackDeadline, retention, clock.Now())
+		if err != nil {
+			return mapError(err)
+		}
+		if len(msgs) > 0 {
+			received, err := s.buildReceivedMessages(ctx, project, topicID, dlqTopic, maxDeliveryAttempts, msgs)
+			if err != nil {
+				return err
+			}
+			if len(received) > 0 {
+				if err := stream.Send(&pubsubpb.StreamingPullResponse{ReceivedMessages: received}); err != nil {
+					if errors.Is(err, io.EOF) {
+						return nil
+					}
+					return err
+				}
+			}
+			continue
+		}
+
+		// No messages: long-poll by waiting a short interval rather than
+		// busy-spinning, and stop promptly on stream close / context cancel.
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-recvErr:
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		case <-time.After(longPollInterval):
+		}
+	}
+}
+
+// applyStreamAcks acknowledges the ackIds in a StreamingPull request.
+func (s *Service) applyStreamAcks(ctx context.Context, topicID string, req *pubsubpb.StreamingPullRequest) {
+	for _, a := range req.GetAckIds() {
+		decoded, ok := decodeAckID(a)
+		if !ok {
+			continue
+		}
+		parts := strings.SplitN(decoded, "/", 2)
+		if len(parts) == 2 {
+			_ = s.messages.Delete(ctx, parts[0], parts[1])
+		}
+	}
+}
+
+// applyStreamModifyDeadlines applies the parallel modifyDeadlineAckIds /
+// modifyDeadlineSeconds arrays, resetting each message's visibility deadline.
+func (s *Service) applyStreamModifyDeadlines(ctx context.Context, topicID string, req *pubsubpb.StreamingPullRequest) {
+	ackIDs := req.GetModifyDeadlineAckIds()
+	seconds := req.GetModifyDeadlineSeconds()
+	n := len(seconds)
+	if len(ackIDs) < n {
+		n = len(ackIDs)
+	}
+	for i := 0; i < n; i++ {
+		decoded, ok := decodeAckID(ackIDs[i])
+		if !ok {
+			continue
+		}
+		_ = s.messages.ModifyAckDeadline(ctx, topicID, []string{decoded}, int(seconds[i]), clock.Now())
+	}
+}
+
+func (s *Service) Acknowledge(ctx context.Context, req *pubsubpb.AcknowledgeRequest) (*emptypb.Empty, error) {
+	for _, a := range req.GetAckIds() {
+		decoded, ok := decodeAckID(a)
+		if !ok {
+			continue
+		}
+		parts := strings.SplitN(decoded, "/", 2)
+		if len(parts) == 2 {
+			_ = s.messages.Delete(ctx, parts[0], parts[1])
+		}
+	}
+	return &emptypb.Empty{}, nil
+}
+
+func (s *Service) ModifyAckDeadline(ctx context.Context, req *pubsubpb.ModifyAckDeadlineRequest) (*emptypb.Empty, error) {
+	project, sub, ok := splitSubscriptionName(req.GetSubscription())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid subscription name", 400))
+	}
+	e, err := s.resources.Get(ctx, project, store.GlobalRegion, rtSubscription, sub)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, mapError(model.NewProviderError("NotFound", "subscription not found", 404))
+		}
+		return nil, mapError(err)
+	}
+	var meta map[string]any
+	json.Unmarshal(e.Data, &meta)
+	topic, _ := meta["topic"].(string)
+	topicID := topic
+	if i := strings.LastIndex(topicID, "/"); i >= 0 {
+		topicID = topicID[i+1:]
+	}
+	decoded := make([]string, 0, len(req.GetAckIds()))
+	for _, id := range req.GetAckIds() {
+		if d, ok := decodeAckID(id); ok {
+			decoded = append(decoded, d)
+		}
+	}
+	if err := s.messages.ModifyAckDeadline(ctx, topicID, decoded, int(req.GetAckDeadlineSeconds()), clock.Now()); err != nil {
+		return nil, mapError(err)
+	}
+	return &emptypb.Empty{}, nil
+}
+
+// ─── IAM (google.iam.v1.IAMPolicy over topics and subscriptions) ─────────────
+
+// Owns reports whether the Pub/Sub service handles IAM for this resource name.
+func (s *Service) Owns(resource string) bool {
+	_, _, _, ok := s.parseIamResource(resource)
+	return ok
+}
+
+// parseIamResource resolves a topic or subscription IAM resource name to its
+// policy resource type + id (the underlying resource name disambiguates).
+func (s *Service) parseIamResource(resource string) (project, policyType, id string, ok bool) {
+	if p, t, ok := splitTopicName(resource); ok {
+		return p, rtTopicPolicy, t, true
+	}
+	if p, sub, ok := splitSubscriptionName(resource); ok {
+		return p, rtSubscriptionPolicy, sub, true
+	}
+	return "", "", "", false
+}
+
+// requireResource verifies the underlying topic/subscription exists before an
+// IAM operation, mirroring the REST provider's requireTopic/requireSubscription.
+func (s *Service) requireResource(ctx context.Context, project, policyType, id string) error {
+	rt := rtTopic
+	notFound := "topic not found"
+	if policyType == rtSubscriptionPolicy {
+		rt = rtSubscription
+		notFound = "subscription not found"
+	}
+	if _, err := s.resources.Get(ctx, project, store.GlobalRegion, rt, id); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return model.NewProviderError("NotFound", notFound, 404)
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *Service) GetIamPolicy(ctx context.Context, req *iampb.GetIamPolicyRequest) (*iampb.Policy, error) {
+	project, rt, id, ok := s.parseIamResource(req.GetResource())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	if err := s.requireResource(ctx, project, rt, id); err != nil {
+		return nil, mapError(err)
+	}
+	return policyToProto(policy.Load(ctx, s.resources, project, rt, id)), nil
+}
+
+func (s *Service) SetIamPolicy(ctx context.Context, req *iampb.SetIamPolicyRequest) (*iampb.Policy, error) {
+	project, rt, id, ok := s.parseIamResource(req.GetResource())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	if err := s.requireResource(ctx, project, rt, id); err != nil {
+		return nil, mapError(err)
+	}
+	pol, err := policy.Set(ctx, s.resources, project, rt, id, protoPolicyToBody(req.GetPolicy()))
+	if err != nil {
+		return nil, mapError(err)
+	}
+	return policyToProto(pol), nil
+}
+
+func (s *Service) TestIamPermissions(ctx context.Context, req *iampb.TestIamPermissionsRequest) (*iampb.TestIamPermissionsResponse, error) {
+	project, rt, id, ok := s.parseIamResource(req.GetResource())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	// Fail open: testIamPermissions is a pure authz probe and does not require
+	// the underlying resource to exist (unlike getIamPolicy/setIamPolicy). A
+	// missing topic/subscription yields an empty permission list rather than
+	// NotFound, matching real GCP and the REST provider.
+	perms := []string{}
+	if s.resourceExists(ctx, project, rt, id) {
+		perms = policy.TestPermissions(req.GetPermissions())
+	}
+	return &iampb.TestIamPermissionsResponse{Permissions: perms}, nil
+}
+
+// resourceExists reports whether the underlying topic/subscription exists,
+// without erroring (used by TestIamPermissions' fail-open behavior).
+func (s *Service) resourceExists(ctx context.Context, project, policyType, id string) bool {
+	rt := rtTopic
+	if policyType == rtSubscriptionPolicy {
+		rt = rtSubscription
+	}
+	_, err := s.resources.Get(ctx, project, store.GlobalRegion, rt, id)
+	return err == nil
+}
+
+// ─── proto ↔ internal transcoding ─────────────────────────────────────────────
+
+func topicToProto(project, id string, meta map[string]any) *pubsubpb.Topic {
+	t := &pubsubpb.Topic{Name: topicName(project, id)}
+	if k, _ := meta["kmsKeyName"].(string); k != "" {
+		t.KmsKeyName = k
+	}
+	switch ls := meta["labels"].(type) {
+	case map[string]string:
+		if len(ls) > 0 {
+			t.Labels = ls
+		}
+	case map[string]any:
+		for k, v := range ls {
+			if sv, ok := v.(string); ok {
+				if t.Labels == nil {
+					t.Labels = map[string]string{}
+				}
+				t.Labels[k] = sv
+			}
+		}
+	}
+	if ret, _ := meta["messageRetentionDuration"].(string); ret != "" {
+		if d, err := time.ParseDuration(ret); err == nil {
+			t.MessageRetentionDuration = durationpb.New(d)
+		}
+	}
+	return t
+}
+
+func subToProto(meta map[string]any) *pubsubpb.Subscription {
+	sub := &pubsubpb.Subscription{}
+	sub.Name, _ = meta["name"].(string)
+	sub.Topic, _ = meta["topic"].(string)
+	if ad, ok := asInt(meta["ackDeadlineSeconds"]); ok {
+		sub.AckDeadlineSeconds = int32(ad)
+	}
+	if dlp, ok := meta["deadLetterPolicy"].(map[string]any); ok {
+		p := &pubsubpb.DeadLetterPolicy{}
+		if dt, _ := dlp["deadLetterTopic"].(string); dt != "" {
+			p.DeadLetterTopic = dt
+		}
+		if mda, ok := asInt(dlp["maxDeliveryAttempts"]); ok {
+			p.MaxDeliveryAttempts = int32(mda)
+		}
+		sub.DeadLetterPolicy = p
+	}
+	if pc, ok := meta["pushConfig"].(map[string]any); ok {
+		p := &pubsubpb.PushConfig{}
+		if ep, _ := pc["pushEndpoint"].(string); ep != "" {
+			p.PushEndpoint = ep
+		}
+		sub.PushConfig = p
+	}
+	return sub
+}
+
+// asInt coerces a decoded JSON number (float64) or a freshly-built int into an
+// int, so the transcoder works for both the store-read and just-created shapes.
+func asInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int32:
+		return int(n), true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	case json.Number:
+		if i, err := n.Int64(); err == nil {
+			return int(i), true
+		}
+	}
+	return 0, false
+}
+
+func protoPolicyToBody(p *iampb.Policy) map[string]any {
+	body := map[string]any{}
+	if p == nil {
+		return body
+	}
+	bindings := make([]any, 0, len(p.GetBindings()))
+	for _, b := range p.GetBindings() {
+		members := make([]any, 0, len(b.GetMembers()))
+		for _, m := range b.GetMembers() {
+			members = append(members, m)
+		}
+		bindings = append(bindings, map[string]any{"role": b.GetRole(), "members": members})
+	}
+	body["bindings"] = bindings
+	if et := p.GetEtag(); len(et) > 0 {
+		body["etag"] = string(et)
+	}
+	if p.GetVersion() != 0 {
+		body["version"] = int(p.GetVersion())
+	}
+	return body
+}
+
+func policyToProto(p policy.Policy) *iampb.Policy {
+	out := &iampb.Policy{Version: int32(p.Version)}
+	if p.Etag != "" {
+		out.Etag = []byte(p.Etag)
+	}
+	for _, b := range p.Bindings {
+		m, ok := b.(map[string]any)
+		if !ok {
+			continue
+		}
+		binding := &iampb.Binding{}
+		binding.Role, _ = m["role"].(string)
+		for _, v := range toStrings(m["members"]) {
+			binding.Members = append(binding.Members, v)
+		}
+		out.Bindings = append(out.Bindings, binding)
+	}
+	return out
+}
+
+func toStrings(v any) []string {
+	items, _ := v.([]any)
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		if s, ok := it.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// ─── ack-id encoding (mirrors the REST provider's wire format) ────────────────
+
+// encodeAckID renders the opaque wire ackId: base64url of "topicID/messageID".
+func encodeAckID(topicID, messageID string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(topicID + "/" + messageID))
+}
+
+// decodeAckID reverses encodeAckID, returning "topicID/messageID".
+func decodeAckID(s string) (string, bool) {
+	raw, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return "", false
+	}
+	return string(raw), true
+}
+
+// topicRetention resolves a topic's messageRetentionDuration in seconds,
+// defaulting to GCP's 7-day default.
+func (s *Service) topicRetention(ctx context.Context, account, topicID string) int {
+	const defaultRetentionSecs = 604800
+	e, err := s.resources.Get(ctx, account, store.GlobalRegion, rtTopic, topicID)
+	if err != nil {
+		return defaultRetentionSecs
+	}
+	var meta map[string]any
+	if json.Unmarshal(e.Data, &meta) != nil {
+		return defaultRetentionSecs
+	}
+	ret, _ := meta["messageRetentionDuration"].(string)
+	if d, err := time.ParseDuration(ret); err == nil && d > 0 {
+		return int(d.Seconds())
+	}
+	return defaultRetentionSecs
+}

--- a/internal/gcp/grpc/pubsub/service_test.go
+++ b/internal/gcp/grpc/pubsub/service_test.go
@@ -1,0 +1,333 @@
+package pubsub
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	iampb "cloud.google.com/go/iam/apiv1/iampb"
+	pubsubpb "cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
+
+	"jaiscloud/internal/gcp/crypto"
+	kmsstore "jaiscloud/internal/gcp/store/kms"
+	pubsubstore "jaiscloud/internal/gcp/store/pubsub"
+	"jaiscloud/internal/store"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+// pubsubTestService dials a real in-process gRPC server backed by the memory
+// stores and returns the three clients (Publisher, Subscriber, IAMPolicy) plus
+// the raw message store (for asserting ack/delete effects).
+func pubsubTestService(t *testing.T) (pubsubpb.PublisherClient, pubsubpb.SubscriberClient, iampb.IAMPolicyClient, pubsubstore.Messages, func()) {
+	t.Helper()
+	resources := store.NewMemoryResourceStore()
+	messages := pubsubstore.NewMemoryMessages()
+	encryptor := crypto.NewEnvelopeEncryptor(kmsstore.NewMemoryStore())
+	svc := NewService(resources, messages, encryptor, "test")
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	pubsubpb.RegisterPublisherServer(srv, svc)
+	pubsubpb.RegisterSubscriberServer(srv, svc)
+	iampb.RegisterIAMPolicyServer(srv, svc)
+	go srv.Serve(ln)
+
+	conn, err := grpc.NewClient(ln.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		srv.Stop()
+		t.Fatalf("dial: %v", err)
+	}
+	cleanup := func() {
+		conn.Close()
+		srv.Stop()
+	}
+	return pubsubpb.NewPublisherClient(conn), pubsubpb.NewSubscriberClient(conn), iampb.NewIAMPolicyClient(conn), messages, cleanup
+}
+
+func TestPubSubEndToEnd(t *testing.T) {
+	pub, subc, iam, _, cleanup := pubsubTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const topic = "projects/test/topics/my-topic"
+	const subscription = "projects/test/subscriptions/my-sub"
+
+	// Create topic.
+	created, err := pub.CreateTopic(ctx, &pubsubpb.Topic{Name: topic})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	if created.GetName() != topic {
+		t.Fatalf("CreateTopic name = %q, want %q", created.GetName(), topic)
+	}
+
+	// Duplicate topic → AlreadyExists.
+	if _, err := pub.CreateTopic(ctx, &pubsubpb.Topic{Name: topic}); status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("duplicate CreateTopic err = %v, want AlreadyExists", err)
+	}
+
+	// Get topic.
+	got, err := pub.GetTopic(ctx, &pubsubpb.GetTopicRequest{Topic: topic})
+	if err != nil {
+		t.Fatalf("GetTopic: %v", err)
+	}
+	if got.GetName() != topic {
+		t.Fatalf("GetTopic name = %q, want %q", got.GetName(), topic)
+	}
+
+	// List topics.
+	listed, err := pub.ListTopics(ctx, &pubsubpb.ListTopicsRequest{Project: "projects/test"})
+	if err != nil {
+		t.Fatalf("ListTopics: %v", err)
+	}
+	if len(listed.GetTopics()) != 1 || listed.GetTopics()[0].GetName() != topic {
+		t.Fatalf("ListTopics = %v, want exactly [%s]", listed.GetTopics(), topic)
+	}
+
+	// Publish.
+	pubRes, err := pub.Publish(ctx, &pubsubpb.PublishRequest{
+		Topic: topic,
+		Messages: []*pubsubpb.PubsubMessage{
+			{Data: []byte("hello world"), Attributes: map[string]string{"k": "v"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if len(pubRes.GetMessageIds()) != 1 {
+		t.Fatalf("Publish messageIds = %v, want 1 id", pubRes.GetMessageIds())
+	}
+
+	// Create subscription.
+	sub, err := subc.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name: subscription, Topic: topic, AckDeadlineSeconds: 30,
+	})
+	if err != nil {
+		t.Fatalf("CreateSubscription: %v", err)
+	}
+	if sub.GetTopic() != topic || sub.GetAckDeadlineSeconds() != 30 {
+		t.Fatalf("CreateSubscription = %+v, want topic=%s ackDeadline=30", sub, topic)
+	}
+
+	// Pull (returnImmediately) → the published message.
+	pull, err := subc.Pull(ctx, &pubsubpb.PullRequest{Subscription: subscription, MaxMessages: 10, ReturnImmediately: true})
+	if err != nil {
+		t.Fatalf("Pull: %v", err)
+	}
+	if len(pull.GetReceivedMessages()) != 1 {
+		t.Fatalf("Pull received %d messages, want 1", len(pull.GetReceivedMessages()))
+	}
+	rm := pull.GetReceivedMessages()[0]
+	if rm.GetAckId() == "" {
+		t.Fatal("Pull ackId is empty")
+	}
+	if string(rm.GetMessage().GetData()) != "hello world" {
+		t.Fatalf("Pull data = %q, want %q", string(rm.GetMessage().GetData()), "hello world")
+	}
+	if rm.GetMessage().GetAttributes()["k"] != "v" {
+		t.Fatalf("Pull attributes = %v, want k=v", rm.GetMessage().GetAttributes())
+	}
+
+	// Ack.
+	if _, err := subc.Acknowledge(ctx, &pubsubpb.AcknowledgeRequest{Subscription: subscription, AckIds: []string{rm.GetAckId()}}); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+
+	// After ack, the message is gone.
+	pull2, err := subc.Pull(ctx, &pubsubpb.PullRequest{Subscription: subscription, MaxMessages: 10, ReturnImmediately: true})
+	if err != nil {
+		t.Fatalf("Pull after ack: %v", err)
+	}
+	if len(pull2.GetReceivedMessages()) != 0 {
+		t.Fatalf("Pull after ack received %d messages, want 0", len(pull2.GetReceivedMessages()))
+	}
+
+	// Topic IAM: empty policy by default.
+	pol, err := iam.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: topic})
+	if err != nil {
+		t.Fatalf("GetIamPolicy: %v", err)
+	}
+	if len(pol.GetBindings()) != 0 {
+		t.Fatalf("GetIamPolicy bindings = %v, want empty", pol.GetBindings())
+	}
+
+	// Set topic IAM policy.
+	_, err = iam.SetIamPolicy(ctx, &iampb.SetIamPolicyRequest{
+		Resource: topic,
+		Policy: &iampb.Policy{
+			Bindings: []*iampb.Binding{{Role: "roles/pubsub.publisher", Members: []string{"user:a@example.com"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SetIamPolicy: %v", err)
+	}
+
+	// Read it back.
+	pol, err = iam.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: topic})
+	if err != nil {
+		t.Fatalf("GetIamPolicy after set: %v", err)
+	}
+	if len(pol.GetBindings()) != 1 || pol.GetBindings()[0].GetRole() != "roles/pubsub.publisher" {
+		t.Fatalf("GetIamPolicy bindings = %v, want roles/pubsub.publisher", pol.GetBindings())
+	}
+
+	// Test permissions echoes the request (no-authz posture).
+	tp, err := iam.TestIamPermissions(ctx, &iampb.TestIamPermissionsRequest{
+		Resource: topic, Permissions: []string{"pubsub.topics.publish", "pubsub.topics.get"},
+	})
+	if err != nil {
+		t.Fatalf("TestIamPermissions: %v", err)
+	}
+	if len(tp.GetPermissions()) != 2 {
+		t.Fatalf("TestIamPermissions = %v, want 2 granted", tp.GetPermissions())
+	}
+}
+
+func TestPullOrderingKeyGating(t *testing.T) {
+	pub, subc, _, _, cleanup := pubsubTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const topic = "projects/test/topics/ordered"
+	const subscription = "projects/test/subscriptions/ordered-sub"
+
+	if _, err := pub.CreateTopic(ctx, &pubsubpb.Topic{Name: topic}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	if _, err := subc.CreateSubscription(ctx, &pubsubpb.Subscription{Name: subscription, Topic: topic}); err != nil {
+		t.Fatalf("CreateSubscription: %v", err)
+	}
+
+	// Two messages in the same ordering-key group, published in separate
+	// requests so the first has a strictly earlier publish time.
+	if _, err := pub.Publish(ctx, &pubsubpb.PublishRequest{
+		Topic:    topic,
+		Messages: []*pubsubpb.PubsubMessage{{Data: []byte("first"), OrderingKey: "grp"}},
+	}); err != nil {
+		t.Fatalf("Publish first: %v", err)
+	}
+	if _, err := pub.Publish(ctx, &pubsubpb.PublishRequest{
+		Topic:    topic,
+		Messages: []*pubsubpb.PubsubMessage{{Data: []byte("second"), OrderingKey: "grp"}},
+	}); err != nil {
+		t.Fatalf("Publish second: %v", err)
+	}
+
+	// A single pull must return only the first message of the group.
+	pull, err := subc.Pull(ctx, &pubsubpb.PullRequest{Subscription: subscription, MaxMessages: 10, ReturnImmediately: true})
+	if err != nil {
+		t.Fatalf("Pull: %v", err)
+	}
+	if len(pull.GetReceivedMessages()) != 1 {
+		t.Fatalf("Pull received %d messages, want 1 (ordering-key gate)", len(pull.GetReceivedMessages()))
+	}
+	if string(pull.GetReceivedMessages()[0].GetMessage().GetData()) != "first" {
+		t.Fatalf("Pull data = %q, want first", string(pull.GetReceivedMessages()[0].GetMessage().GetData()))
+	}
+}
+
+func TestStreamingPullDeliversAndAcks(t *testing.T) {
+	pub, subc, _, messages, cleanup := pubsubTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const topic = "projects/test/topics/stream-topic"
+	const subscription = "projects/test/subscriptions/stream-sub"
+
+	if _, err := pub.CreateTopic(ctx, &pubsubpb.Topic{Name: topic}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	if _, err := subc.CreateSubscription(ctx, &pubsubpb.Subscription{Name: subscription, Topic: topic}); err != nil {
+		t.Fatalf("CreateSubscription: %v", err)
+	}
+	if _, err := pub.Publish(ctx, &pubsubpb.PublishRequest{
+		Topic: topic,
+		Messages: []*pubsubpb.PubsubMessage{
+			{Data: []byte("msg-a")},
+			{Data: []byte("msg-b")},
+		},
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	stream, err := subc.StreamingPull(ctx)
+	if err != nil {
+		t.Fatalf("StreamingPull: %v", err)
+	}
+	if err := stream.Send(&pubsubpb.StreamingPullRequest{
+		Subscription:             subscription,
+		StreamAckDeadlineSeconds: 10,
+	}); err != nil {
+		t.Fatalf("StreamingPull Send: %v", err)
+	}
+
+	// Collect both published messages (bounded deadline so a failure doesn't hang).
+	got := map[string]bool{}
+	var ackIDs []string
+	deadline := time.Now().Add(5 * time.Second)
+	for len(got) < 2 {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for messages; received %v", got)
+		}
+		resp, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("StreamingPull Recv: %v", err)
+		}
+		for _, rm := range resp.GetReceivedMessages() {
+			got[string(rm.GetMessage().GetData())] = true
+			ackIDs = append(ackIDs, rm.GetAckId())
+		}
+	}
+	if !got["msg-a"] || !got["msg-b"] {
+		t.Fatalf("received = %v, want msg-a and msg-b", got)
+	}
+
+	// Ack both messages over the same stream.
+	if err := stream.Send(&pubsubpb.StreamingPullRequest{AckIds: ackIDs}); err != nil {
+		t.Fatalf("StreamingPull ack Send: %v", err)
+	}
+
+	// The server processes acks asynchronously; poll the store until the topic
+	// is drained or the deadline elapses.
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		remaining, err := messages.List(ctx, "stream-topic")
+		if err != nil {
+			t.Fatalf("List: %v", err)
+		}
+		if len(remaining) == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("messages not acked within deadline; %d remain", len(remaining))
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	stream.CloseSend()
+}
+
+func TestTestIamPermissionsFailsOpenOnMissingTopic(t *testing.T) {
+	_, _, iam, _, cleanup := pubsubTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	got, err := iam.TestIamPermissions(ctx, &iampb.TestIamPermissionsRequest{
+		Resource:    "projects/test/topics/missing",
+		Permissions: []string{"pubsub.topics.publish"},
+	})
+	if err != nil {
+		t.Fatalf("TestIamPermissions on missing topic = %v, want fail-open (nil)", err)
+	}
+	if len(got.GetPermissions()) != 0 {
+		t.Fatalf("TestIamPermissions on missing topic = %v, want empty", got.GetPermissions())
+	}
+}

--- a/internal/gcp/grpc/secretmanager/service.go
+++ b/internal/gcp/grpc/secretmanager/service.go
@@ -1,0 +1,636 @@
+// Package secretmanager implements the Cloud Secret Manager gRPC service
+// (SecretManagerService plus the google.iam.v1.IAMPolicy surface for secret
+// IAM) over the same shared secretmanagerstore.Store + policy +
+// crypto.EnvelopeEncryptor backing the REST provider, so REST and gRPC share
+// state.
+package secretmanager
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"hash/crc32"
+	"strconv"
+	"strings"
+	"time"
+
+	iampb "cloud.google.com/go/iam/apiv1/iampb"
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+
+	"jaiscloud/internal/clock"
+	"jaiscloud/internal/gcp/crypto"
+	grpcutil "jaiscloud/internal/gcp/grpc"
+	"jaiscloud/internal/gcp/paging"
+	"jaiscloud/internal/gcp/policy"
+	kmsstore "jaiscloud/internal/gcp/store/kms"
+	secretmanagerstore "jaiscloud/internal/gcp/store/secretmanager"
+	"jaiscloud/internal/model"
+	"jaiscloud/internal/store"
+
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// rtSecretPolicy is the generic ResourceStore type for secret IAM policies,
+// matching the REST provider's persisted type so both transports share state.
+const rtSecretPolicy = "gcp_secret_policy"
+
+// Service implements secretmanagerpb.SecretManagerServiceServer and
+// iampb.IAMPolicyServer over the shared stores.
+type Service struct {
+	secretmanagerpb.UnimplementedSecretManagerServiceServer
+	iampb.UnimplementedIAMPolicyServer
+
+	secrets     secretmanagerstore.Store
+	resources   store.ResourceStore // IAM policies (control-plane)
+	encryptor   crypto.EnvelopeEncryptor
+	defaultProj string
+}
+
+// NewService returns a Secret Manager gRPC service backed by the shared stores.
+// defaultProj is the config-default project used when a request carries none.
+func NewService(secrets secretmanagerstore.Store, resources store.ResourceStore, encryptor crypto.EnvelopeEncryptor, defaultProj string) *Service {
+	return &Service{secrets: secrets, resources: resources, encryptor: encryptor, defaultProj: defaultProj}
+}
+
+func mapError(err error) error { return grpcutil.GRPCStatus(err) }
+
+func mapSecretErr(err error) error {
+	if errors.Is(err, secretmanagerstore.ErrNoSuchSecret) {
+		return mapError(model.NewProviderError("NotFound", "secret not found", 404))
+	}
+	return mapError(err)
+}
+
+func mapVersionErr(err error) error {
+	if errors.Is(err, secretmanagerstore.ErrNoSuchVersion) {
+		return mapError(model.NewProviderError("NotFound", "secret version not found", 404))
+	}
+	return mapError(err)
+}
+
+// ─── resource-name parsing ────────────────────────────────────────────────────
+
+func secretName(project, id string) string {
+	return "projects/" + project + "/secrets/" + id
+}
+
+func versionName(project, id, ver string) string {
+	return secretName(project, id) + "/versions/" + ver
+}
+
+// splitSecretResource parses a full resource name into project, secret id, and
+// version. It accepts "projects/{p}/secrets/{s}" (4 parts) and
+// "projects/{p}/secrets/{s}/versions/{v}" (6 parts).
+func splitSecretResource(name string) (project, id, version string, ok bool) {
+	parts := strings.Split(name, "/")
+	switch len(parts) {
+	case 4:
+		if parts[0] == "projects" && parts[2] == "secrets" {
+			return parts[1], parts[3], "", true
+		}
+	case 6:
+		if parts[0] == "projects" && parts[2] == "secrets" && parts[4] == "versions" {
+			return parts[1], parts[3], parts[5], true
+		}
+	}
+	return "", "", "", false
+}
+
+// projectFromParent resolves the project from a "projects/{p}" parent (or a
+// bare project id), falling back to metadata-derived project.
+func (s *Service) projectFromParent(ctx context.Context, p string) string {
+	if p != "" {
+		return strings.TrimPrefix(p, "projects/")
+	}
+	return grpcutil.ProjectFromMetadata(ctx, s.defaultProj)
+}
+
+// ─── Secret Manager service ───────────────────────────────────────────────────
+
+func (s *Service) ListSecrets(ctx context.Context, req *secretmanagerpb.ListSecretsRequest) (*secretmanagerpb.ListSecretsResponse, error) {
+	project := s.projectFromParent(ctx, req.GetParent())
+	secrets, err := s.secrets.ListSecrets(ctx, project)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	page, next := paging.Page(secrets, func(sec secretmanagerstore.Secret) string { return sec.ID },
+		map[string]any{"pageSize": int(req.GetPageSize()), "pageToken": req.GetPageToken()})
+	out := make([]*secretmanagerpb.Secret, 0, len(page))
+	for _, sec := range page {
+		out = append(out, secretToProto(project, sec))
+	}
+	return &secretmanagerpb.ListSecretsResponse{
+		Secrets:       out,
+		NextPageToken: next,
+		TotalSize:     int32(len(secrets)),
+	}, nil
+}
+
+func (s *Service) CreateSecret(ctx context.Context, req *secretmanagerpb.CreateSecretRequest) (*secretmanagerpb.Secret, error) {
+	project := s.projectFromParent(ctx, req.GetParent())
+	id := req.GetSecretId()
+	proto := req.GetSecret()
+	if id == "" && proto != nil {
+		_, id, _, _ = splitSecretResource(proto.GetName())
+	}
+	if id == "" {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "missing secretId", 400))
+	}
+
+	sec := secretmanagerstore.Secret{
+		ID:         id,
+		CreateTime: clock.Now(),
+		NextVer:    1,
+	}
+	if proto != nil {
+		sec.Labels = proto.GetLabels()
+		if r := proto.GetRotation(); r != nil {
+			sec.Rotation = rotationFromProto(r)
+		}
+		if va := proto.GetVersionAliases(); va != nil {
+			sec.VersionAliases = make(map[string]int, len(va))
+			for k, v := range va {
+				sec.VersionAliases[k] = int(v)
+			}
+		}
+		sec.KmsKeyName = kmsKeyNameFromSecret(proto)
+	}
+
+	if err := s.secrets.CreateSecret(ctx, project, id, sec); err != nil {
+		if errors.Is(err, secretmanagerstore.ErrAlreadyExists) {
+			return nil, mapError(model.NewProviderError("AlreadyExists", "secret already exists", 409))
+		}
+		return nil, mapError(err)
+	}
+	return secretToProto(project, sec), nil
+}
+
+func (s *Service) GetSecret(ctx context.Context, req *secretmanagerpb.GetSecretRequest) (*secretmanagerpb.Secret, error) {
+	project, id, _, ok := splitSecretResource(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	sec, err := s.secrets.GetSecret(ctx, project, id)
+	if err != nil {
+		return nil, mapSecretErr(err)
+	}
+	sec = s.maybeRotate(ctx, project, id, sec)
+	return secretToProto(project, sec), nil
+}
+
+func (s *Service) UpdateSecret(ctx context.Context, req *secretmanagerpb.UpdateSecretRequest) (*secretmanagerpb.Secret, error) {
+	proto := req.GetSecret()
+	if proto == nil {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "secret is required", 400))
+	}
+	project, id, _, ok := splitSecretResource(proto.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	cur, err := s.secrets.GetSecret(ctx, project, id)
+	if err != nil {
+		return nil, mapSecretErr(err)
+	}
+	if labels := proto.GetLabels(); labels != nil {
+		cur.Labels = labels
+	}
+	if r := proto.GetRotation(); r != nil {
+		cur.Rotation = rotationFromProto(r)
+	}
+	if va := proto.GetVersionAliases(); va != nil {
+		cur.VersionAliases = make(map[string]int, len(va))
+		for k, v := range va {
+			cur.VersionAliases[k] = int(v)
+		}
+	}
+	if kmsKeyName := kmsKeyNameFromSecret(proto); kmsKeyName != "" {
+		cur.KmsKeyName = kmsKeyName
+	}
+	if err := s.secrets.UpdateSecret(ctx, project, id, cur); err != nil {
+		return nil, mapSecretErr(err)
+	}
+	return secretToProto(project, cur), nil
+}
+
+func (s *Service) DeleteSecret(ctx context.Context, req *secretmanagerpb.DeleteSecretRequest) (*emptypb.Empty, error) {
+	project, id, _, ok := splitSecretResource(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	if err := s.secrets.DeleteSecret(ctx, project, id); err != nil {
+		return nil, mapSecretErr(err)
+	}
+	return &emptypb.Empty{}, nil
+}
+
+func (s *Service) AddSecretVersion(ctx context.Context, req *secretmanagerpb.AddSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+	project, id, _, ok := splitSecretResource(req.GetParent())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid parent resource name", 400))
+	}
+	var data []byte
+	if payload := req.GetPayload(); payload != nil {
+		data = payload.GetData()
+	}
+
+	// Allocate the version number atomically (memory mutex / DB UPDATE
+	// ... RETURNING), avoiding a Get→increment→Update race.
+	ver, err := s.secrets.NextVersion(ctx, project, id)
+	if err != nil {
+		return nil, mapSecretErr(err)
+	}
+	version := strconv.Itoa(ver)
+
+	sec, err := s.secrets.GetSecret(ctx, project, id)
+	if err != nil {
+		return nil, mapSecretErr(err)
+	}
+
+	rawDEK, wrappedDEK, err := s.encryptor.Wrap(ctx, project, sec.KmsKeyName)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	encrypted, err := kmsstore.EncryptData(rawDEK, data, nil)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	stv := secretmanagerstore.Version{
+		SecretID: id, VersionID: version, State: "ENABLED",
+		CreateTime: clock.Now(), Data: base64.StdEncoding.EncodeToString(encrypted),
+		KmsKeyName: sec.KmsKeyName, WrappedDEK: wrappedDEK,
+	}
+	if err := s.secrets.CreateVersion(ctx, project, stv); err != nil {
+		return nil, mapError(err)
+	}
+	return versionToProto(project, stv), nil
+}
+
+func (s *Service) AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+	project, secret, version, ok := splitSecretResource(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	version, err := s.resolveVersion(ctx, project, secret, version)
+	if err != nil {
+		return nil, mapVersionErr(err)
+	}
+	v, err := s.secrets.GetVersion(ctx, project, secret, version)
+	if err != nil {
+		return nil, mapVersionErr(err)
+	}
+
+	encrypted, err := base64.StdEncoding.DecodeString(v.Data)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	rawDEK, err := s.encryptor.Unwrap(ctx, project, v.KmsKeyName, v.WrappedDEK)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	plain, err := kmsstore.DecryptData(rawDEK, encrypted, nil)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	crc := crc32cOf(plain)
+	return &secretmanagerpb.AccessSecretVersionResponse{
+		Name: versionName(project, secret, version),
+		Payload: &secretmanagerpb.SecretPayload{
+			Data:       plain,
+			DataCrc32C: &crc,
+		},
+	}, nil
+}
+
+func (s *Service) GetSecretVersion(ctx context.Context, req *secretmanagerpb.GetSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+	project, secret, version, ok := splitSecretResource(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	version, err := s.resolveVersion(ctx, project, secret, version)
+	if err != nil {
+		return nil, mapVersionErr(err)
+	}
+	v, err := s.secrets.GetVersion(ctx, project, secret, version)
+	if err != nil {
+		return nil, mapVersionErr(err)
+	}
+	return versionToProto(project, v), nil
+}
+
+// resolveVersion resolves the "latest" version alias to the highest existing
+// version number. Any other version id passes through unchanged.
+func (s *Service) resolveVersion(ctx context.Context, project, secret, version string) (string, error) {
+	if version != "latest" {
+		return version, nil
+	}
+	versions, err := s.secrets.ListVersions(ctx, project, secret)
+	if err != nil {
+		return "", err
+	}
+	latest := ""
+	latestN := -1
+	for _, v := range versions {
+		if n, err := strconv.Atoi(v.VersionID); err == nil && n > latestN {
+			latestN = n
+			latest = v.VersionID
+		}
+	}
+	if latest == "" {
+		return "", secretmanagerstore.ErrNoSuchVersion
+	}
+	return latest, nil
+}
+
+func (s *Service) ListSecretVersions(ctx context.Context, req *secretmanagerpb.ListSecretVersionsRequest) (*secretmanagerpb.ListSecretVersionsResponse, error) {
+	project, id, _, ok := splitSecretResource(req.GetParent())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid parent resource name", 400))
+	}
+	versions, err := s.secrets.ListVersions(ctx, project, id)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	page, next := paging.Page(versions, func(v secretmanagerstore.Version) string { return v.VersionID },
+		map[string]any{"pageSize": int(req.GetPageSize()), "pageToken": req.GetPageToken()})
+	out := make([]*secretmanagerpb.SecretVersion, 0, len(page))
+	for _, v := range page {
+		out = append(out, versionToProto(project, v))
+	}
+	return &secretmanagerpb.ListSecretVersionsResponse{
+		Versions:      out,
+		NextPageToken: next,
+		TotalSize:     int32(len(versions)),
+	}, nil
+}
+
+func (s *Service) DisableSecretVersion(ctx context.Context, req *secretmanagerpb.DisableSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+	return s.setVersionState(ctx, req.GetName(), "DISABLED")
+}
+
+func (s *Service) EnableSecretVersion(ctx context.Context, req *secretmanagerpb.EnableSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+	return s.setVersionState(ctx, req.GetName(), "ENABLED")
+}
+
+func (s *Service) DestroySecretVersion(ctx context.Context, req *secretmanagerpb.DestroySecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+	return s.setVersionState(ctx, req.GetName(), "DESTROYED")
+}
+
+// setVersionState applies a lifecycle transition (DISABLED/ENABLED/DESTROYED)
+// to a secret version.
+func (s *Service) setVersionState(ctx context.Context, name, state string) (*secretmanagerpb.SecretVersion, error) {
+	project, secret, version, ok := splitSecretResource(name)
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	v, err := s.secrets.GetVersion(ctx, project, secret, version)
+	if err != nil {
+		return nil, mapVersionErr(err)
+	}
+	v.State = state
+	if err := s.secrets.UpdateVersion(ctx, project, v); err != nil {
+		return nil, mapVersionErr(err)
+	}
+	return versionToProto(project, v), nil
+}
+
+// maybeRotate advances a secret's rotation schedule when it is due: it creates
+// an empty version and advances nextRotationTime by rotationPeriod. This is
+// GCP's automatic-rotation behavior, evaluated lazily on read (mirrors the
+// REST provider).
+func (s *Service) maybeRotate(ctx context.Context, account, id string, sec secretmanagerstore.Secret) secretmanagerstore.Secret {
+	if sec.Rotation == nil || sec.Rotation.NextRotationTime == "" {
+		return sec
+	}
+	next, err := time.Parse(time.RFC3339Nano, sec.Rotation.NextRotationTime)
+	if err != nil || clock.Now().Before(next) {
+		return sec
+	}
+	if sec.Rotation.RotationPeriod != "" {
+		if d, err := time.ParseDuration(sec.Rotation.RotationPeriod); err == nil {
+			sec.Rotation.NextRotationTime = clock.Now().Add(d).UTC().Format(time.RFC3339Nano)
+		}
+	}
+	ver, err := s.secrets.NextVersion(ctx, account, id)
+	if err != nil {
+		return sec
+	}
+	sec.NextVer = ver + 1
+	_ = s.secrets.CreateVersion(ctx, account, secretmanagerstore.Version{
+		SecretID: id, VersionID: strconv.Itoa(ver), State: "ENABLED", CreateTime: clock.Now(),
+	})
+	_ = s.secrets.UpdateSecret(ctx, account, id, sec)
+	return sec
+}
+
+// ─── IAM (google.iam.v1.IAMPolicy over secrets) ───────────────────────────────
+
+func (s *Service) requireSecret(ctx context.Context, project, id string) error {
+	if _, err := s.secrets.GetSecret(ctx, project, id); err != nil {
+		return mapSecretErr(err)
+	}
+	return nil
+}
+
+func (s *Service) GetIamPolicy(ctx context.Context, req *iampb.GetIamPolicyRequest) (*iampb.Policy, error) {
+	project, id, _, ok := splitSecretResource(req.GetResource())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	if err := s.requireSecret(ctx, project, id); err != nil {
+		return nil, err
+	}
+	return policyToProto(policy.Load(ctx, s.resources, project, rtSecretPolicy, id)), nil
+}
+
+func (s *Service) SetIamPolicy(ctx context.Context, req *iampb.SetIamPolicyRequest) (*iampb.Policy, error) {
+	project, id, _, ok := splitSecretResource(req.GetResource())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	if err := s.requireSecret(ctx, project, id); err != nil {
+		return nil, err
+	}
+	pol, err := policy.Set(ctx, s.resources, project, rtSecretPolicy, id, protoPolicyToBody(req.GetPolicy()))
+	if err != nil {
+		return nil, mapError(err)
+	}
+	return policyToProto(pol), nil
+}
+
+func (s *Service) TestIamPermissions(ctx context.Context, req *iampb.TestIamPermissionsRequest) (*iampb.TestIamPermissionsResponse, error) {
+	project, id, _, ok := splitSecretResource(req.GetResource())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	if err := s.requireSecret(ctx, project, id); err != nil {
+		return nil, err
+	}
+	return &iampb.TestIamPermissionsResponse{Permissions: policy.TestPermissions(req.GetPermissions())}, nil
+}
+
+// ─── proto ↔ internal transcoding ─────────────────────────────────────────────
+
+func secretToProto(project string, s secretmanagerstore.Secret) *secretmanagerpb.Secret {
+	out := &secretmanagerpb.Secret{
+		Name: secretName(project, s.ID),
+		// etag is a stable hash of name+createTime (matches GCP's
+		// immutable-etag semantics and the REST provider's computation).
+		Etag: policy.Etag(secretName(project, s.ID) + s.CreateTime.Format(time.RFC3339Nano)),
+		Replication: &secretmanagerpb.Replication{
+			Replication: &secretmanagerpb.Replication_Automatic_{
+				Automatic: &secretmanagerpb.Replication_Automatic{},
+			},
+		},
+	}
+	if !s.CreateTime.IsZero() {
+		out.CreateTime = timestamppb.New(s.CreateTime)
+	}
+	if s.Labels != nil {
+		out.Labels = s.Labels
+	}
+	if s.Rotation != nil {
+		out.Rotation = rotationToProto(s.Rotation)
+	}
+	if s.VersionAliases != nil {
+		out.VersionAliases = make(map[string]int64, len(s.VersionAliases))
+		for k, v := range s.VersionAliases {
+			out.VersionAliases[k] = int64(v)
+		}
+	}
+	return out
+}
+
+func versionToProto(project string, v secretmanagerstore.Version) *secretmanagerpb.SecretVersion {
+	out := &secretmanagerpb.SecretVersion{
+		Name:  versionName(project, v.SecretID, v.VersionID),
+		State: stateToProto(v.State),
+	}
+	if !v.CreateTime.IsZero() {
+		out.CreateTime = timestamppb.New(v.CreateTime)
+	}
+	return out
+}
+
+func stateToProto(state string) secretmanagerpb.SecretVersion_State {
+	switch state {
+	case "ENABLED":
+		return secretmanagerpb.SecretVersion_ENABLED
+	case "DISABLED":
+		return secretmanagerpb.SecretVersion_DISABLED
+	case "DESTROYED":
+		return secretmanagerpb.SecretVersion_DESTROYED
+	}
+	return secretmanagerpb.SecretVersion_STATE_UNSPECIFIED
+}
+
+func rotationFromProto(r *secretmanagerpb.Rotation) *secretmanagerstore.Rotation {
+	out := &secretmanagerstore.Rotation{}
+	if r.GetNextRotationTime() != nil {
+		out.NextRotationTime = r.GetNextRotationTime().AsTime().UTC().Format(time.RFC3339Nano)
+	}
+	if r.GetRotationPeriod() != nil {
+		out.RotationPeriod = r.GetRotationPeriod().AsDuration().String()
+	}
+	return out
+}
+
+func rotationToProto(r *secretmanagerstore.Rotation) *secretmanagerpb.Rotation {
+	out := &secretmanagerpb.Rotation{}
+	if r.NextRotationTime != "" {
+		if t, err := time.Parse(time.RFC3339Nano, r.NextRotationTime); err == nil {
+			out.NextRotationTime = timestamppb.New(t)
+		}
+	}
+	if r.RotationPeriod != "" {
+		if d, err := time.ParseDuration(r.RotationPeriod); err == nil {
+			out.RotationPeriod = durationpb.New(d)
+		}
+	}
+	return out
+}
+
+// kmsKeyNameFromSecret extracts the CMEK key name from the secret's
+// replication policy (mirrors the REST provider's kmsKeyNameFromBody).
+func kmsKeyNameFromSecret(sec *secretmanagerpb.Secret) string {
+	repl := sec.GetReplication()
+	if repl == nil {
+		return ""
+	}
+	if auto := repl.GetAutomatic(); auto != nil {
+		if cme := auto.GetCustomerManagedEncryption(); cme != nil {
+			return cme.GetKmsKeyName()
+		}
+	}
+	if um := repl.GetUserManaged(); um != nil {
+		if reps := um.GetReplicas(); len(reps) > 0 {
+			if cme := reps[0].GetCustomerManagedEncryption(); cme != nil {
+				return cme.GetKmsKeyName()
+			}
+		}
+	}
+	return ""
+}
+
+// crc32cOf returns the CRC32C-Castagnoli checksum of the payload as an int64
+// (google.protobuf.Int64Value encoding).
+func crc32cOf(data []byte) int64 {
+	return int64(crc32.Checksum(data, crc32.MakeTable(crc32.Castagnoli)))
+}
+
+func protoPolicyToBody(p *iampb.Policy) map[string]any {
+	body := map[string]any{}
+	if p == nil {
+		return body
+	}
+	bindings := make([]any, 0, len(p.GetBindings()))
+	for _, b := range p.GetBindings() {
+		members := make([]any, 0, len(b.GetMembers()))
+		for _, m := range b.GetMembers() {
+			members = append(members, m)
+		}
+		bindings = append(bindings, map[string]any{"role": b.GetRole(), "members": members})
+	}
+	body["bindings"] = bindings
+	if et := p.GetEtag(); len(et) > 0 {
+		body["etag"] = string(et)
+	}
+	if p.GetVersion() != 0 {
+		body["version"] = int(p.GetVersion())
+	}
+	return body
+}
+
+func policyToProto(p policy.Policy) *iampb.Policy {
+	out := &iampb.Policy{Version: int32(p.Version)}
+	if p.Etag != "" {
+		out.Etag = []byte(p.Etag)
+	}
+	for _, b := range p.Bindings {
+		m, ok := b.(map[string]any)
+		if !ok {
+			continue
+		}
+		binding := &iampb.Binding{}
+		binding.Role, _ = m["role"].(string)
+		for _, v := range toStrings(m["members"]) {
+			binding.Members = append(binding.Members, v)
+		}
+		out.Bindings = append(out.Bindings, binding)
+	}
+	return out
+}
+
+func toStrings(v any) []string {
+	items, _ := v.([]any)
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		if s, ok := it.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/gcp/grpc/secretmanager/service_test.go
+++ b/internal/gcp/grpc/secretmanager/service_test.go
@@ -1,0 +1,337 @@
+package secretmanager
+
+import (
+	"context"
+	"hash/crc32"
+	"net"
+	"testing"
+
+	iampb "cloud.google.com/go/iam/apiv1/iampb"
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+
+	"jaiscloud/internal/gcp/crypto"
+	kmsstore "jaiscloud/internal/gcp/store/kms"
+	secretmanagerstore "jaiscloud/internal/gcp/store/secretmanager"
+	"jaiscloud/internal/store"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+// secretTestService dials a real in-process gRPC server backed by the memory
+// stores and returns the Secret Manager and IAM clients.
+func secretTestService(t *testing.T) (secretmanagerpb.SecretManagerServiceClient, iampb.IAMPolicyClient, func()) {
+	t.Helper()
+	secrets := secretmanagerstore.NewMemoryStore()
+	resources := store.NewMemoryResourceStore()
+	encryptor := crypto.NewEnvelopeEncryptor(kmsstore.NewMemoryStore())
+	svc := NewService(secrets, resources, encryptor, "test")
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	secretmanagerpb.RegisterSecretManagerServiceServer(srv, svc)
+	iampb.RegisterIAMPolicyServer(srv, svc)
+	go srv.Serve(ln)
+
+	conn, err := grpc.NewClient(ln.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		srv.Stop()
+		t.Fatalf("dial: %v", err)
+	}
+	cleanup := func() {
+		conn.Close()
+		srv.Stop()
+	}
+	return secretmanagerpb.NewSecretManagerServiceClient(conn), iampb.NewIAMPolicyClient(conn), cleanup
+}
+
+func TestSecretManagerEndToEnd(t *testing.T) {
+	client, _, cleanup := secretTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const secret = "projects/test/secrets/my-secret"
+
+	// Create secret.
+	created, err := client.CreateSecret(ctx, &secretmanagerpb.CreateSecretRequest{
+		Parent:   "projects/test",
+		SecretId: "my-secret",
+		Secret:   &secretmanagerpb.Secret{Labels: map[string]string{"env": "dev"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+	if created.GetName() != secret {
+		t.Fatalf("CreateSecret name = %q, want %q", created.GetName(), secret)
+	}
+	if created.GetEtag() == "" {
+		t.Fatal("CreateSecret etag is empty")
+	}
+
+	// Duplicate → AlreadyExists.
+	if _, err := client.CreateSecret(ctx, &secretmanagerpb.CreateSecretRequest{
+		Parent: "projects/test", SecretId: "my-secret",
+	}); status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("duplicate CreateSecret err = %v, want AlreadyExists", err)
+	}
+
+	// Get returns a stable etag.
+	got, err := client.GetSecret(ctx, &secretmanagerpb.GetSecretRequest{Name: secret})
+	if err != nil {
+		t.Fatalf("GetSecret: %v", err)
+	}
+	if got.GetEtag() != created.GetEtag() {
+		t.Fatalf("GetSecret etag = %q, want %q", got.GetEtag(), created.GetEtag())
+	}
+	if got.GetLabels()["env"] != "dev" {
+		t.Fatalf("GetSecret labels = %v, want env=dev", got.GetLabels())
+	}
+
+	// List secrets.
+	listed, err := client.ListSecrets(ctx, &secretmanagerpb.ListSecretsRequest{Parent: "projects/test"})
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+	if len(listed.GetSecrets()) != 1 || listed.GetSecrets()[0].GetName() != secret {
+		t.Fatalf("ListSecrets = %v, want exactly [%s]", listed.GetSecrets(), secret)
+	}
+
+	// Add version.
+	payload := []byte("hello world")
+	addRes, err := client.AddSecretVersion(ctx, &secretmanagerpb.AddSecretVersionRequest{
+		Parent:  secret,
+		Payload: &secretmanagerpb.SecretPayload{Data: payload},
+	})
+	if err != nil {
+		t.Fatalf("AddSecretVersion: %v", err)
+	}
+	if addRes.GetName() != secret+"/versions/1" {
+		t.Fatalf("AddSecretVersion name = %q, want %q", addRes.GetName(), secret+"/versions/1")
+	}
+	if addRes.GetState() != secretmanagerpb.SecretVersion_ENABLED {
+		t.Fatalf("AddSecretVersion state = %v, want ENABLED", addRes.GetState())
+	}
+
+	// Access decrypts the payload and returns a matching crc32c.
+	access, err := client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{Name: secret + "/versions/1"})
+	if err != nil {
+		t.Fatalf("AccessSecretVersion: %v", err)
+	}
+	if string(access.GetPayload().GetData()) != string(payload) {
+		t.Fatalf("AccessSecretVersion data = %q, want %q", string(access.GetPayload().GetData()), string(payload))
+	}
+	wantCRC := int64(crc32.Checksum(payload, crc32.MakeTable(crc32.Castagnoli)))
+	if access.GetPayload().GetDataCrc32C() != wantCRC {
+		t.Fatalf("AccessSecretVersion crc32c = %d, want %d", access.GetPayload().GetDataCrc32C(), wantCRC)
+	}
+
+	// List versions.
+	versions, err := client.ListSecretVersions(ctx, &secretmanagerpb.ListSecretVersionsRequest{Parent: secret})
+	if err != nil {
+		t.Fatalf("ListSecretVersions: %v", err)
+	}
+	if len(versions.GetVersions()) != 1 || versions.GetVersions()[0].GetName() != secret+"/versions/1" {
+		t.Fatalf("ListSecretVersions = %v, want exactly [versions/1]", versions.GetVersions())
+	}
+
+	// Disable → Enable → Destroy lifecycle.
+	dis, err := client.DisableSecretVersion(ctx, &secretmanagerpb.DisableSecretVersionRequest{Name: secret + "/versions/1"})
+	if err != nil {
+		t.Fatalf("DisableSecretVersion: %v", err)
+	}
+	if dis.GetState() != secretmanagerpb.SecretVersion_DISABLED {
+		t.Fatalf("DisableSecretVersion state = %v, want DISABLED", dis.GetState())
+	}
+
+	en, err := client.EnableSecretVersion(ctx, &secretmanagerpb.EnableSecretVersionRequest{Name: secret + "/versions/1"})
+	if err != nil {
+		t.Fatalf("EnableSecretVersion: %v", err)
+	}
+	if en.GetState() != secretmanagerpb.SecretVersion_ENABLED {
+		t.Fatalf("EnableSecretVersion state = %v, want ENABLED", en.GetState())
+	}
+
+	des, err := client.DestroySecretVersion(ctx, &secretmanagerpb.DestroySecretVersionRequest{Name: secret + "/versions/1"})
+	if err != nil {
+		t.Fatalf("DestroySecretVersion: %v", err)
+	}
+	if des.GetState() != secretmanagerpb.SecretVersion_DESTROYED {
+		t.Fatalf("DestroySecretVersion state = %v, want DESTROYED", des.GetState())
+	}
+
+	// Get a missing version → NotFound.
+	if _, err := client.GetSecretVersion(ctx, &secretmanagerpb.GetSecretVersionRequest{Name: secret + "/versions/99"}); status.Code(err) != codes.NotFound {
+		t.Fatalf("GetSecretVersion missing err = %v, want NotFound", err)
+	}
+
+	// Delete secret.
+	if _, err := client.DeleteSecret(ctx, &secretmanagerpb.DeleteSecretRequest{Name: secret}); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+	if _, err := client.GetSecret(ctx, &secretmanagerpb.GetSecretRequest{Name: secret}); status.Code(err) != codes.NotFound {
+		t.Fatalf("GetSecret after delete err = %v, want NotFound", err)
+	}
+}
+
+func TestSecretManagerIamPolicy(t *testing.T) {
+	client, iam, cleanup := secretTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const secret = "projects/test/secrets/iam-secret"
+
+	if _, err := client.CreateSecret(ctx, &secretmanagerpb.CreateSecretRequest{
+		Parent: "projects/test", SecretId: "iam-secret",
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	// Empty policy by default.
+	pol, err := iam.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: secret})
+	if err != nil {
+		t.Fatalf("GetIamPolicy: %v", err)
+	}
+	if len(pol.GetBindings()) != 0 {
+		t.Fatalf("GetIamPolicy bindings = %v, want empty", pol.GetBindings())
+	}
+
+	// Set IAM policy.
+	_, err = iam.SetIamPolicy(ctx, &iampb.SetIamPolicyRequest{
+		Resource: secret,
+		Policy: &iampb.Policy{
+			Bindings: []*iampb.Binding{{Role: "roles/secretmanager.secretAccessor", Members: []string{"allUsers"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SetIamPolicy: %v", err)
+	}
+
+	// Read it back.
+	pol, err = iam.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: secret})
+	if err != nil {
+		t.Fatalf("GetIamPolicy after set: %v", err)
+	}
+	if len(pol.GetBindings()) != 1 || pol.GetBindings()[0].GetRole() != "roles/secretmanager.secretAccessor" {
+		t.Fatalf("GetIamPolicy bindings = %v, want roles/secretmanager.secretAccessor", pol.GetBindings())
+	}
+
+	// Test permissions echoes the request (no-authz posture).
+	tp, err := iam.TestIamPermissions(ctx, &iampb.TestIamPermissionsRequest{
+		Resource: secret, Permissions: []string{"secretmanager.secrets.get", "secretmanager.versions.access"},
+	})
+	if err != nil {
+		t.Fatalf("TestIamPermissions: %v", err)
+	}
+	if len(tp.GetPermissions()) != 2 {
+		t.Fatalf("TestIamPermissions = %v, want 2 granted", tp.GetPermissions())
+	}
+
+	// IAM on a missing secret → NotFound.
+	if _, err := iam.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: "projects/test/secrets/missing"}); status.Code(err) != codes.NotFound {
+		t.Fatalf("GetIamPolicy missing err = %v, want NotFound", err)
+	}
+}
+
+func TestSecretManagerVersionAliases(t *testing.T) {
+	client, _, cleanup := secretTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const secret = "projects/test/secrets/aliased"
+
+	// Create with a "latest" version alias (stored metadata, matching REST).
+	created, err := client.CreateSecret(ctx, &secretmanagerpb.CreateSecretRequest{
+		Parent:   "projects/test",
+		SecretId: "aliased",
+		Secret: &secretmanagerpb.Secret{
+			VersionAliases: map[string]int64{"latest": 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+	if created.GetVersionAliases()["latest"] != 1 {
+		t.Fatalf("CreateSecret versionAliases = %v, want latest=1", created.GetVersionAliases())
+	}
+
+	// Add a real version 1.
+	if _, err := client.AddSecretVersion(ctx, &secretmanagerpb.AddSecretVersionRequest{
+		Parent:  secret,
+		Payload: &secretmanagerpb.SecretPayload{Data: []byte("hi")},
+	}); err != nil {
+		t.Fatalf("AddSecretVersion: %v", err)
+	}
+
+	// Update the alias to point at the new version.
+	updated, err := client.UpdateSecret(ctx, &secretmanagerpb.UpdateSecretRequest{
+		Secret: &secretmanagerpb.Secret{
+			Name:           secret,
+			VersionAliases: map[string]int64{"latest": 2},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateSecret: %v", err)
+	}
+	if updated.GetVersionAliases()["latest"] != 2 {
+		t.Fatalf("UpdateSecret versionAliases = %v, want latest=2", updated.GetVersionAliases())
+	}
+}
+
+func TestSecretManagerLatestAlias(t *testing.T) {
+	client, _, cleanup := secretTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const secret = "projects/test/secrets/latest-secret"
+
+	if _, err := client.CreateSecret(ctx, &secretmanagerpb.CreateSecretRequest{
+		Parent: "projects/test", SecretId: "latest-secret",
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	// Add version 1.
+	if _, err := client.AddSecretVersion(ctx, &secretmanagerpb.AddSecretVersionRequest{
+		Parent: secret, Payload: &secretmanagerpb.SecretPayload{Data: []byte("v1")},
+	}); err != nil {
+		t.Fatalf("AddSecretVersion v1: %v", err)
+	}
+
+	// "latest" resolves to version 1.
+	access, err := client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{Name: secret + "/versions/latest"})
+	if err != nil {
+		t.Fatalf("AccessSecretVersion latest (first): %v", err)
+	}
+	if string(access.GetPayload().GetData()) != "v1" {
+		t.Fatalf("AccessSecretVersion latest data = %q, want v1", string(access.GetPayload().GetData()))
+	}
+
+	// Add version 2 → "latest" must now resolve to it.
+	if _, err := client.AddSecretVersion(ctx, &secretmanagerpb.AddSecretVersionRequest{
+		Parent: secret, Payload: &secretmanagerpb.SecretPayload{Data: []byte("v2")},
+	}); err != nil {
+		t.Fatalf("AddSecretVersion v2: %v", err)
+	}
+
+	access, err = client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{Name: secret + "/versions/latest"})
+	if err != nil {
+		t.Fatalf("AccessSecretVersion latest (second): %v", err)
+	}
+	if string(access.GetPayload().GetData()) != "v2" {
+		t.Fatalf("AccessSecretVersion latest data = %q, want v2", string(access.GetPayload().GetData()))
+	}
+
+	// GetSecretVersion with "latest" resolves the same way.
+	ver, err := client.GetSecretVersion(ctx, &secretmanagerpb.GetSecretVersionRequest{Name: secret + "/versions/latest"})
+	if err != nil {
+		t.Fatalf("GetSecretVersion latest: %v", err)
+	}
+	if ver.GetName() != secret+"/versions/2" {
+		t.Fatalf("GetSecretVersion latest name = %q, want %q", ver.GetName(), secret+"/versions/2")
+	}
+}

--- a/internal/gcp/grpc/status.go
+++ b/internal/gcp/grpc/status.go
@@ -1,4 +1,4 @@
-package firestore
+package grpc
 
 import (
 	"errors"
@@ -8,6 +8,33 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// GRPCStatus converts a provider/service error into a gRPC status error.
+// Provider errors are resolved in precedence order: google.rpc Status name,
+// then the provider Code alias, then the HTTP status; anything else is
+// INTERNAL. This is the shared error-mapping used by every GCP gRPC service
+// (Firestore, Pub/Sub, Secret Manager, KMS).
+func GRPCStatus(err error) error {
+	if err == nil {
+		return nil
+	}
+	var perr *model.ProviderError
+	if !errors.As(err, &perr) {
+		return status.Error(codes.Internal, err.Error())
+	}
+	if perr.Status != "" {
+		if c, ok := statusToCode(perr.Status); ok {
+			return status.Error(c, perr.Message)
+		}
+	}
+	if c, ok := codeAlias(perr.Code); ok {
+		return status.Error(c, perr.Message)
+	}
+	if c, ok := httpToCode(perr.HTTPStatus); ok {
+		return status.Error(c, perr.Message)
+	}
+	return status.Error(codes.Internal, perr.Message)
+}
 
 // statusToCode maps a google.rpc status name to its gRPC code. The bool is
 // false for unrecognized names so the caller can fall through to the HTTP/Code
@@ -90,29 +117,4 @@ func codeAlias(c string) (codes.Code, bool) {
 		return codes.Internal, true
 	}
 	return codes.Unknown, false
-}
-
-// mapError converts a provider/service error into a gRPC status error. Provider
-// errors are resolved in precedence order: google.rpc Status name, then the
-// provider Code alias, then the HTTP status; anything else is INTERNAL.
-func mapError(err error) error {
-	if err == nil {
-		return nil
-	}
-	var perr *model.ProviderError
-	if !errors.As(err, &perr) {
-		return status.Error(codes.Internal, err.Error())
-	}
-	if perr.Status != "" {
-		if c, ok := statusToCode(perr.Status); ok {
-			return status.Error(c, perr.Message)
-		}
-	}
-	if c, ok := codeAlias(perr.Code); ok {
-		return status.Error(c, perr.Message)
-	}
-	if c, ok := httpToCode(perr.HTTPStatus); ok {
-		return status.Error(c, perr.Message)
-	}
-	return status.Error(codes.Internal, perr.Message)
 }

--- a/internal/gcp/provider/firestore/change.go
+++ b/internal/gcp/provider/firestore/change.go
@@ -1,0 +1,128 @@
+package firestore
+
+import (
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+)
+
+// ChangeEvent describes a single document mutation published by the shared
+// change-feed. Every write through the Service (REST or gRPC) publishes exactly
+// one ChangeEvent, so Listen observes writes regardless of the transport that
+// performed them. Doc is nil when the document was deleted.
+type ChangeEvent struct {
+	Seq  uint64
+	Name string
+	Doc  *firestorestore.Document
+}
+
+// changeSub is one subscriber to the shared change-feed.
+type changeSub struct {
+	ch   chan ChangeEvent
+	done chan struct{}
+}
+
+// ChangeSubscription is a live subscription to the shared change-feed. C
+// delivers each published ChangeEvent in sequence order; Cancel unregisters the
+// subscription.
+type ChangeSubscription struct {
+	svc *Service
+	sub *changeSub
+	C   <-chan ChangeEvent
+}
+
+// Cancel unregisters the subscription from the change-feed. Safe to call more
+// than once.
+func (cs *ChangeSubscription) Cancel() {
+	cs.svc.unsubscribeChange(cs.sub)
+}
+
+// SubscribeChange registers a new subscriber on the shared change-feed. The
+// caller MUST call Cancel when done, or the subscription (and its buffered
+// channel) will leak.
+func (s *Service) SubscribeChange() *ChangeSubscription {
+	sub := s.subscribeChange()
+	return &ChangeSubscription{svc: s, sub: sub, C: sub.ch}
+}
+
+// CurrentSeq returns the change-feed's current monotonic sequence number. It is
+// the sequence encoded into snapshot resume tokens.
+func (s *Service) CurrentSeq() uint64 {
+	s.changeMu.Lock()
+	defer s.changeMu.Unlock()
+	return s.changeSeq
+}
+
+// ChangesSince returns the change-feed history for every event published after
+// seq, in order. Listen uses it to replay deltas from a resume token.
+func (s *Service) ChangesSince(seq uint64) []ChangeEvent {
+	s.changeMu.Lock()
+	defer s.changeMu.Unlock()
+	out := make([]ChangeEvent, 0)
+	for _, e := range s.changeLog {
+		if e.Seq > seq {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func (s *Service) subscribeChange() *changeSub {
+	s.changeMu.Lock()
+	defer s.changeMu.Unlock()
+	if s.changeSubs == nil {
+		s.changeSubs = make(map[*changeSub]struct{})
+	}
+	sub := &changeSub{ch: make(chan ChangeEvent, 1024), done: make(chan struct{})}
+	s.changeSubs[sub] = struct{}{}
+	return sub
+}
+
+func (s *Service) unsubscribeChange(sub *changeSub) {
+	s.changeMu.Lock()
+	defer s.changeMu.Unlock()
+	if _, ok := s.changeSubs[sub]; ok {
+		delete(s.changeSubs, sub)
+		close(sub.done)
+	}
+}
+
+// publishChange appends the event to the change-feed history (assigning the next
+// monotonic sequence) and fans it out to every subscriber.
+func (s *Service) publishChange(ev ChangeEvent) {
+	s.changeMu.Lock()
+	s.changeSeq++
+	ev.Seq = s.changeSeq
+	s.changeLog = append(s.changeLog, ev)
+	subs := make([]*changeSub, 0, len(s.changeSubs))
+	for sub := range s.changeSubs {
+		subs = append(subs, sub)
+	}
+	s.changeMu.Unlock()
+
+	for _, sub := range subs {
+		select {
+		case sub.ch <- ev:
+		case <-sub.done:
+		default:
+			// The subscriber's buffered channel is full — it has fallen behind
+			// and is not draining events. Drop this event and detach the
+			// subscriber so the write path never blocks on a listener and no
+			// further events are attempted for it. A subscriber that falls
+			// behind misses a delta and will NOT receive a later NO_CHANGE
+			// covering it, so it must re-listen (from a fresh or resume token)
+			// to resync.
+			s.detachChange(sub)
+		}
+	}
+}
+
+// detachChange removes a subscriber that has fallen behind from the change-feed
+// and closes its done channel so a Listen stream can observe the teardown and
+// exit. It is a no-op for an already-removed subscriber.
+func (s *Service) detachChange(sub *changeSub) {
+	s.changeMu.Lock()
+	defer s.changeMu.Unlock()
+	if _, ok := s.changeSubs[sub]; ok {
+		delete(s.changeSubs, sub)
+		close(sub.done)
+	}
+}

--- a/internal/gcp/provider/firestore/commit_liveness_test.go
+++ b/internal/gcp/provider/firestore/commit_liveness_test.go
@@ -1,0 +1,108 @@
+package firestore
+
+import (
+	"context"
+	"testing"
+)
+
+// TestCommitAfterRollbackRejected ensures a Commit (and a txn-carrying read)
+// with a transaction id that is no longer active is rejected with
+// INVALID_ARGUMENT rather than silently treated as a non-transactional
+// operation.
+func TestCommitAfterRollbackRejected(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	name := "projects/proj/databases/(default)/documents/cities/SF"
+
+	resp, err := p.BeginTransaction(ctx, testNR())
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	txnID, _ := resp.Data["transaction"].(string)
+	if txnID == "" {
+		t.Fatal("expected a non-empty transaction id")
+	}
+
+	// Roll the transaction back.
+	rollbackNR := testNR()
+	rollbackNR.Params["body"] = map[string]any{"transaction": txnID}
+	if _, err := p.Rollback(ctx, rollbackNR); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+
+	// Commit with the rolled-back transaction → INVALID_ARGUMENT.
+	commitNR := testNR()
+	commitNR.Params["body"] = map[string]any{
+		"transaction": txnID,
+		"writes": []any{
+			map[string]any{
+				"update": map[string]any{
+					"name":   name,
+					"fields": map[string]any{"b": map[string]any{"integerValue": "2"}},
+				},
+			},
+		},
+	}
+	if _, err := p.Commit(ctx, commitNR); err == nil {
+		t.Fatal("expected INVALID_ARGUMENT for commit after rollback")
+	} else {
+		assertInvalidArgumentErr(t, err)
+	}
+
+	// The write must not have been applied.
+	if _, err := p.store.GetDocument(ctx, name); err == nil {
+		t.Fatal("expected document to be absent after rejected commit")
+	}
+}
+
+func TestTxnReadAfterRollbackRejected(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+
+	resp, err := p.BeginTransaction(ctx, testNR())
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	txnID, _ := resp.Data["transaction"].(string)
+
+	rollbackNR := testNR()
+	rollbackNR.Params["body"] = map[string]any{"transaction": txnID}
+	if _, err := p.Rollback(ctx, rollbackNR); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+
+	getNR := testNR()
+	getNR.Params["name"] = "databases/(default)/documents/cities/SF"
+	getNR.Params["transaction"] = txnID
+	if _, err := p.DocumentsGet(ctx, getNR); err == nil {
+		t.Fatal("expected INVALID_ARGUMENT for read after rollback")
+	} else {
+		assertInvalidArgumentErr(t, err)
+	}
+}
+
+func TestCommitNeverBegunTransactionRejected(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	name := "projects/proj/databases/(default)/documents/cities/SF"
+
+	// A well-formed transaction id that was never begun.
+	txnID := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+	commitNR := testNR()
+	commitNR.Params["body"] = map[string]any{
+		"transaction": txnID,
+		"writes": []any{
+			map[string]any{
+				"update": map[string]any{
+					"name":   name,
+					"fields": map[string]any{"b": map[string]any{"integerValue": "2"}},
+				},
+			},
+		},
+	}
+	if _, err := p.Commit(ctx, commitNR); err == nil {
+		t.Fatal("expected INVALID_ARGUMENT for never-begun transaction")
+	} else {
+		assertInvalidArgumentErr(t, err)
+	}
+}

--- a/internal/gcp/provider/firestore/service.go
+++ b/internal/gcp/provider/firestore/service.go
@@ -31,6 +31,13 @@ type Service struct {
 	// (transactions are ephemeral and never persisted).
 	txnMu    sync.Mutex
 	readSets map[string]*readSet
+
+	// changeMu guards the change-feed: changeSeq (monotonic), changeLog (the
+	// full ordered history used for resume-token replay), and changeSubs.
+	changeMu   sync.Mutex
+	changeSeq  uint64
+	changeLog  []ChangeEvent
+	changeSubs map[*changeSub]struct{}
 }
 
 // newService returns a Firestore service backed by the given document store and
@@ -128,6 +135,22 @@ func (s *Service) clearReadSet(txn []byte) {
 	delete(s.readSets, string(txn))
 }
 
+// requireActive returns an InvalidArgument error when transaction is non-empty
+// but not currently active (rolled back, already committed, or never begun).
+// An empty transaction denotes a non-transactional operation and always passes.
+func (s *Service) requireActive(transaction []byte) error {
+	if len(transaction) == 0 {
+		return nil
+	}
+	s.txnMu.Lock()
+	defer s.txnMu.Unlock()
+	if s.readSets[string(transaction)] == nil {
+		return model.NewProviderError("InvalidArgument",
+			"transaction is no longer active (rolled back, committed, or never begun)", 400)
+	}
+	return nil
+}
+
 // ─── pagination ──────────────────────────────────────────────────────────────
 
 // pageParams carries cursor-pagination inputs (pageSize/pageToken) in a
@@ -146,6 +169,9 @@ func (p pageParams) params() map[string]any {
 // GetDocument returns a document by full name, recording the read in the
 // transaction read-set and applying the field mask when present.
 func (s *Service) GetDocument(ctx context.Context, name string, transaction []byte, mask []string) (firestorestore.Document, error) {
+	if err := s.requireActive(transaction); err != nil {
+		return firestorestore.Document{}, err
+	}
 	doc, err := s.store.GetDocument(ctx, name)
 	if err != nil {
 		if len(transaction) > 0 && errors.Is(err, firestorestore.ErrDocumentNotFound) {
@@ -190,6 +216,8 @@ func (s *Service) CreateDocument(ctx context.Context, project, database, path, d
 	if err := s.store.CreateDocument(ctx, doc); err != nil {
 		return firestorestore.Document{}, mapStoreError(err)
 	}
+	d := doc
+	s.publishChange(ChangeEvent{Name: d.Name, Doc: &d})
 	return doc, nil
 }
 
@@ -247,6 +275,8 @@ func (s *Service) PatchDocument(ctx context.Context, project, database, path str
 			return firestorestore.Document{}, mapStoreError(err)
 		}
 	}
+	d := doc
+	s.publishChange(ChangeEvent{Name: d.Name, Doc: &d})
 	return doc, nil
 }
 
@@ -271,11 +301,15 @@ func (s *Service) DeleteDocument(ctx context.Context, project, database, path st
 	if err := s.store.DeleteDocument(ctx, name); err != nil {
 		return mapStoreError(err)
 	}
+	s.publishChange(ChangeEvent{Name: name})
 	return nil
 }
 
 // ListDocuments returns the direct children of a collection, paginated.
 func (s *Service) ListDocuments(ctx context.Context, project, database, path string, transaction []byte, mask []string, page pageParams) ([]firestorestore.Document, string, error) {
+	if err := s.requireActive(transaction); err != nil {
+		return nil, "", err
+	}
 	docs, err := s.store.ListDocuments(ctx, project, database)
 	if err != nil {
 		return nil, "", err
@@ -339,6 +373,9 @@ func (s *Service) ListCollectionIds(ctx context.Context, project, database, path
 // enforcing composite-index requirements and recording reads in the
 // transaction read-set.
 func (s *Service) RunQuery(ctx context.Context, project, database, path string, q *structuredQuery, transaction []byte) ([]firestorestore.Document, error) {
+	if err := s.requireActive(transaction); err != nil {
+		return nil, err
+	}
 	parent := "projects/" + project + "/databases/" + database + "/documents"
 	if path != "" {
 		parent += "/" + path
@@ -407,6 +444,9 @@ func (s *Service) Rollback(ctx context.Context, transaction []byte) error {
 // Commit applies an atomic batch of writes with optimistic preconditions and
 // transaction read-set validation.
 func (s *Service) Commit(ctx context.Context, transaction []byte, writes []*writeWire) (time.Time, []map[string]any, error) {
+	if err := s.requireActive(transaction); err != nil {
+		return time.Time{}, nil, err
+	}
 	if len(writes) > maxWriteBatchSize {
 		return time.Time{}, nil, model.NewProviderError("InvalidArgument",
 			"a commit may contain at most "+strconv.Itoa(maxWriteBatchSize)+" writes", 400)
@@ -427,6 +467,14 @@ func (s *Service) Commit(ctx context.Context, transaction []byte, writes []*writ
 		return time.Time{}, nil, mapCommitError(err)
 	}
 	s.clearReadSet(transaction)
+	for _, w := range ws {
+		if w.Document == nil {
+			s.publishChange(ChangeEvent{Name: w.Name})
+		} else {
+			d := *w.Document
+			s.publishChange(ChangeEvent{Name: w.Name, Doc: &d})
+		}
+	}
 	return commitTime, results, nil
 }
 
@@ -460,6 +508,9 @@ func (s *Service) BatchWrite(ctx context.Context, writes []*writeWire) ([]any, [
 // BatchGet returns the documents (found/missing wire items) for the given
 // names, recording reads in the transaction read-set.
 func (s *Service) BatchGet(ctx context.Context, documents []string, transaction []byte) ([]map[string]any, error) {
+	if err := s.requireActive(transaction); err != nil {
+		return nil, err
+	}
 	seen := map[string]bool{}
 	readTime := clock.Now()
 	items := make([]map[string]any, 0, len(documents))

--- a/internal/gcp/provider/pubsub/pubsub.go
+++ b/internal/gcp/provider/pubsub/pubsub.go
@@ -684,11 +684,21 @@ func (p *Provider) TopicTestIamPermissions(ctx context.Context, nr *model.Normal
 		return nil, err
 	}
 	t := strings.TrimPrefix(name, "topics/")
-	if err := p.requireTopic(ctx, nr.AccountID, t); err != nil {
-		return nil, err
-	}
 	body, _ := nr.Params["body"].(map[string]any)
-	return provider.OK(map[string]any{"permissions": policy.TestPermissions(policy.Permissions(body))}), nil
+	// Fail open: testIamPermissions does not require the topic to exist. A
+	// missing topic yields an empty permission list rather than NotFound.
+	perms := []string{}
+	if p.topicExists(ctx, nr.AccountID, t) {
+		perms = policy.TestPermissions(policy.Permissions(body))
+	}
+	return provider.OK(map[string]any{"permissions": perms}), nil
+}
+
+// topicExists reports whether a topic exists without erroring (used by
+// testIamPermissions' fail-open behavior).
+func (p *Provider) topicExists(ctx context.Context, account, t string) bool {
+	_, err := p.resources.Get(ctx, account, store.GlobalRegion, rtTopic, t)
+	return err == nil
 }
 
 func (p *Provider) SubscriptionGetIamPolicy(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
@@ -726,9 +736,18 @@ func (p *Provider) SubscriptionTestIamPermissions(ctx context.Context, nr *model
 		return nil, err
 	}
 	s := strings.TrimPrefix(name, "subscriptions/")
-	if err := p.requireSubscription(ctx, nr.AccountID, s); err != nil {
-		return nil, err
-	}
 	body, _ := nr.Params["body"].(map[string]any)
-	return provider.OK(map[string]any{"permissions": policy.TestPermissions(policy.Permissions(body))}), nil
+	// Fail open: testIamPermissions does not require the subscription to exist.
+	perms := []string{}
+	if p.subscriptionExists(ctx, nr.AccountID, s) {
+		perms = policy.TestPermissions(policy.Permissions(body))
+	}
+	return provider.OK(map[string]any{"permissions": perms}), nil
+}
+
+// subscriptionExists reports whether a subscription exists without erroring
+// (used by testIamPermissions' fail-open behavior).
+func (p *Provider) subscriptionExists(ctx context.Context, account, s string) bool {
+	_, err := p.resources.Get(ctx, account, store.GlobalRegion, rtSubscription, s)
+	return err == nil
 }

--- a/internal/gcp/provider/secretmanager/secret.go
+++ b/internal/gcp/provider/secretmanager/secret.go
@@ -404,6 +404,10 @@ func (p *Provider) Access(ctx context.Context, nr *model.NormalizedRequest) (*mo
 		return nil, err
 	}
 	secret, version := parseSecretName(name)
+	version, err = p.resolveVersion(ctx, nr.AccountID, secret, version)
+	if err != nil {
+		return nil, mapVersionErr(err)
+	}
 	v, err := p.secrets.GetVersion(ctx, nr.AccountID, secret, version)
 	if err != nil {
 		return nil, mapVersionErr(err)
@@ -443,11 +447,39 @@ func (p *Provider) GetVersion(ctx context.Context, nr *model.NormalizedRequest) 
 		return nil, err
 	}
 	secret, version := parseSecretName(name)
+	version, err = p.resolveVersion(ctx, nr.AccountID, secret, version)
+	if err != nil {
+		return nil, mapVersionErr(err)
+	}
 	v, err := p.secrets.GetVersion(ctx, nr.AccountID, secret, version)
 	if err != nil {
 		return nil, mapVersionErr(err)
 	}
 	return provider.OK(versionToMap(fromStoreVersion(nr, v))), nil
+}
+
+// resolveVersion resolves the "latest" version alias to the highest existing
+// version number. Any other version id passes through unchanged.
+func (p *Provider) resolveVersion(ctx context.Context, project, secret, version string) (string, error) {
+	if version != "latest" {
+		return version, nil
+	}
+	versions, err := p.secrets.ListVersions(ctx, project, secret)
+	if err != nil {
+		return "", err
+	}
+	latest := ""
+	latestN := -1
+	for _, v := range versions {
+		if n, err := strconv.Atoi(v.VersionID); err == nil && n > latestN {
+			latestN = n
+			latest = v.VersionID
+		}
+	}
+	if latest == "" {
+		return "", secretmanagerstore.ErrNoSuchVersion
+	}
+	return latest, nil
 }
 
 func (p *Provider) DestroyVersion(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {

--- a/internal/gcp/provider/storage/compat_test.go
+++ b/internal/gcp/provider/storage/compat_test.go
@@ -1,0 +1,295 @@
+package storage
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"hash/crc32"
+	"strings"
+	"testing"
+
+	"jaiscloud/internal/gcp/wire"
+	"jaiscloud/internal/model"
+)
+
+// crc32cB64 computes the GCS crc32c checksum (Castagnoli, big-endian, base64)
+// the same way the provider does.
+func crc32cB64(raw []byte) string {
+	crc := crc32.Checksum(raw, crc32.MakeTable(crc32.Castagnoli))
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, crc)
+	return base64.StdEncoding.EncodeToString(b)
+}
+
+func TestCustomMetadataRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	insertTestObject(t, p, "bkt", "meta.txt", "text/plain", map[string]any{"env": "test", "owner": "sdk"})
+
+	// objects.get returns the metadata object.
+	resp, err := p.ObjectsGet(ctx, bucketParamsWithObj("bkt", "meta.txt"))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	md, _ := resp.Data["metadata"].(map[string]any)
+	if md["env"] != "test" || md["owner"] != "sdk" {
+		t.Fatalf("expected metadata {env:test owner:sdk}, got %v", md)
+	}
+
+	// objects.list returns the metadata object too.
+	list, err := p.ObjectsList(ctx, &model.NormalizedRequest{AccountID: "proj", Params: map[string]any{"bucket": "bkt"}})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	items, _ := list.Data["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	obj := items[0].(map[string]any)
+	lmd, _ := obj["metadata"].(map[string]any)
+	if lmd["env"] != "test" || lmd["owner"] != "sdk" {
+		t.Fatalf("expected list metadata {env:test owner:sdk}, got %v", lmd)
+	}
+
+	// Media download surfaces x-goog-meta-* headers (canonicalised key).
+	media, err := p.ObjectsGetMedia(ctx, bucketParamsWithObj("bkt", "meta.txt"))
+	if err != nil {
+		t.Fatalf("get media: %v", err)
+	}
+	hdr, _ := media.Data[wire.HeadersKey].(map[string]string)
+	if hdr["x-goog-meta-Env"] != "test" || hdr["x-goog-meta-Owner"] != "sdk" {
+		t.Fatalf("expected x-goog-meta-* headers, got %v", hdr)
+	}
+}
+
+func TestCustomMetadataFromHeadersRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+
+	// Upload with metadata supplied via x-goog-meta-* headers (simple upload).
+	nr = bucketParams()
+	nr.Params["bucket"] = "bkt"
+	nr.Params["object"] = "hdr.txt"
+	nr.Params[wire.MediaKey] = []byte("bytes")
+	nr.Params[wire.MetaHeadersKey] = map[string]string{"originalname": "file.dat"}
+	if _, err := p.ObjectsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	resp, err := p.ObjectsGet(ctx, bucketParamsWithObj("bkt", "hdr.txt"))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	md, _ := resp.Data["metadata"].(map[string]any)
+	if md["originalname"] != "file.dat" {
+		t.Fatalf("expected metadata originalname=file.dat, got %v", md)
+	}
+
+	media, err := p.ObjectsGetMedia(ctx, bucketParamsWithObj("bkt", "hdr.txt"))
+	if err != nil {
+		t.Fatalf("get media: %v", err)
+	}
+	hdr, _ := media.Data[wire.HeadersKey].(map[string]string)
+	if hdr["x-goog-meta-Originalname"] != "file.dat" {
+		t.Fatalf("expected x-goog-meta-Originalname header, got %v", hdr)
+	}
+}
+
+func TestObjectsRewriteCopiesContentAndNewGeneration(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	insertTestObject(t, p, "bkt", "src.txt", "text/plain", map[string]any{"keep": "yes"})
+
+	// Capture the source generation for comparison.
+	srcResp, err := p.ObjectsGet(ctx, bucketParamsWithObj("bkt", "src.txt"))
+	if err != nil {
+		t.Fatalf("get source: %v", err)
+	}
+	srcGen, _ := srcResp.Data["generation"].(string)
+
+	nr := bucketParams()
+	nr.Params["sourceBucket"] = "bkt"
+	nr.Params["sourceObject"] = "src.txt"
+	nr.Params["destinationBucket"] = "bkt"
+	nr.Params["destinationObject"] = "dst.txt"
+	resp, err := p.ObjectsRewrite(ctx, nr)
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	if resp.Data["kind"] != "storage#rewriteResponse" {
+		t.Errorf("expected kind storage#rewriteResponse, got %v", resp.Data["kind"])
+	}
+	if done, _ := resp.Data["done"].(bool); !done {
+		t.Error("expected done=true")
+	}
+	if resp.Data["totalBytesRewritten"] != "5" || resp.Data["objectSize"] != "5" {
+		t.Errorf("expected totalBytesRewritten/objectSize 5, got %v/%v",
+			resp.Data["totalBytesRewritten"], resp.Data["objectSize"])
+	}
+
+	resource, _ := resp.Data["resource"].(map[string]any)
+	if resource["name"] != "dst.txt" {
+		t.Errorf("expected resource name dst.txt, got %v", resource["name"])
+	}
+	dstGen, _ := resource["generation"].(string)
+	if dstGen == "" || dstGen == srcGen {
+		t.Errorf("expected a new generation, got %q (source %q)", dstGen, srcGen)
+	}
+	rmd, _ := resource["metadata"].(map[string]any)
+	if rmd["keep"] != "yes" {
+		t.Errorf("expected metadata copied, got %v", rmd)
+	}
+
+	// Destination bytes round-trip.
+	media, err := p.ObjectsGetMedia(ctx, bucketParamsWithObj("bkt", "dst.txt"))
+	if err != nil {
+		t.Fatalf("get media: %v", err)
+	}
+	if got := string(streamBytes(t, media)); got != "hello" {
+		t.Fatalf("expected copied content 'hello', got %q", got)
+	}
+
+	// Source survives the rewrite.
+	if _, err := p.ObjectsGet(ctx, bucketParamsWithObj("bkt", "src.txt")); err != nil {
+		t.Fatalf("source should remain after rewrite: %v", err)
+	}
+}
+
+func TestObjectsRewriteMissingSource(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+
+	nr = bucketParams()
+	nr.Params["sourceBucket"] = "bkt"
+	nr.Params["sourceObject"] = "missing.txt"
+	nr.Params["destinationBucket"] = "bkt"
+	nr.Params["destinationObject"] = "dst.txt"
+	if _, err := p.ObjectsRewrite(ctx, nr); err == nil {
+		t.Fatal("expected NotFound from rewrite of a missing source")
+	} else if pe, ok := err.(*model.ProviderError); !ok || pe.HTTPStatus != 404 {
+		t.Fatalf("expected 404 ProviderError, got %v", err)
+	}
+}
+
+func TestObjectsComposeConcatenates(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+	for _, name := range []string{"a.txt", "b.txt"} {
+		nr = bucketParams()
+		nr.Params["bucket"] = "bkt"
+		nr.Params["object"] = name
+		nr.Params[wire.MediaKey] = []byte(name)
+		if _, err := p.ObjectsInsert(ctx, nr); err != nil {
+			t.Fatalf("insert %s: %v", name, err)
+		}
+	}
+
+	// a.txt="a.txt", b.txt="b.txt" → concatenated "a.txtb.txt" (10 bytes).
+	nr = bucketParams()
+	nr.Params["bucket"] = "bkt"
+	nr.Params["object"] = "ab.txt"
+	nr.Params["body"] = map[string]any{
+		"sourceObjects": []any{
+			map[string]any{"name": "a.txt"},
+			map[string]any{"name": "b.txt"},
+		},
+	}
+	resp, err := p.ObjectsCompose(ctx, nr)
+	if err != nil {
+		t.Fatalf("compose: %v", err)
+	}
+
+	if cc, _ := resp.Data["componentCount"].(float64); int64(cc) != 2 {
+		t.Errorf("expected componentCount 2, got %v", resp.Data["componentCount"])
+	}
+	if _, present := resp.Data["md5Hash"]; present {
+		t.Errorf("expected empty MD5, got %v", resp.Data["md5Hash"])
+	}
+	gotCRC, _ := resp.Data["crc32c"].(string)
+	if gotCRC != crc32cB64([]byte("a.txtb.txt")) {
+		t.Errorf("expected crc32c %q, got %q", crc32cB64([]byte("a.txtb.txt")), gotCRC)
+	}
+	if resp.Data["size"] != "10" {
+		t.Errorf("expected size 10, got %v", resp.Data["size"])
+	}
+
+	// Bytes round-trip.
+	media, err := p.ObjectsGetMedia(ctx, bucketParamsWithObj("bkt", "ab.txt"))
+	if err != nil {
+		t.Fatalf("get media: %v", err)
+	}
+	if got := string(streamBytes(t, media)); got != "a.txtb.txt" {
+		t.Fatalf("expected concatenated content 'a.txtb.txt', got %q", got)
+	}
+}
+
+func TestObjectsComposeEmptySourceList(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+
+	nr = bucketParams()
+	nr.Params["bucket"] = "bkt"
+	nr.Params["object"] = "empty.txt"
+	nr.Params["body"] = map[string]any{"sourceObjects": []any{}}
+	if _, err := p.ObjectsCompose(ctx, nr); err == nil {
+		t.Fatal("expected InvalidRequest when sourceObjects is empty")
+	}
+}
+
+func TestMediaDownloadHeaders(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	insertTestObject(t, p, "bkt", "obj.txt", "text/plain", map[string]any{"foo": "bar"})
+
+	media, err := p.ObjectsGetMedia(ctx, bucketParamsWithObj("bkt", "obj.txt"))
+	if err != nil {
+		t.Fatalf("get media: %v", err)
+	}
+	hdr, _ := media.Data[wire.HeadersKey].(map[string]string)
+	if hdr == nil {
+		t.Fatal("expected media response headers")
+	}
+
+	if hdr["x-goog-generation"] == "" {
+		t.Error("expected x-goog-generation header")
+	}
+	if hdr["x-goog-metageneration"] != "1" {
+		t.Errorf("expected x-goog-metageneration 1, got %q", hdr["x-goog-metageneration"])
+	}
+	if hdr["x-goog-stored-content-length"] != "5" {
+		t.Errorf("expected x-goog-stored-content-length 5, got %q", hdr["x-goog-stored-content-length"])
+	}
+
+	hash := hdr["x-goog-hash"]
+	if !strings.Contains(hash, "crc32c=") || !strings.Contains(hash, "md5=") {
+		t.Errorf("expected x-goog-hash with crc32c and md5, got %q", hash)
+	}
+	if hdr["x-goog-meta-Foo"] != "bar" {
+		t.Errorf("expected x-goog-meta-Foo header, got %q", hdr["x-goog-meta-Foo"])
+	}
+}

--- a/internal/gcp/provider/storage/storage.go
+++ b/internal/gcp/provider/storage/storage.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"jaiscloud/internal/blobfs"
 	"jaiscloud/internal/clock"
@@ -77,11 +78,12 @@ type uploadSession struct {
 	Bucket      string
 	Object      string
 	ContentType string
-	buf         []byte    // in-memory bytes up to resumableSpillThreshold
-	tmpPath     string    // spill file path once threshold is exceeded
-	tmpFile     *os.File  // open handle for appending spilled bytes
-	length      int64     // total accumulated bytes across chunks
-	lastAccess  time.Time // last chunk/status-query time, for the TTL sweep
+	Metadata    map[string]string // custom object metadata captured at session start
+	buf         []byte            // in-memory bytes up to resumableSpillThreshold
+	tmpPath     string            // spill file path once threshold is exceeded
+	tmpFile     *os.File          // open handle for appending spilled bytes
+	length      int64             // total accumulated bytes across chunks
+	lastAccess  time.Time         // last chunk/status-query time, for the TTL sweep
 }
 
 // New returns a GCS provider backed by the dedicated object store (buckets +
@@ -198,6 +200,8 @@ func (p *Provider) Routes() map[string]provider.HandlerFunc {
 		"Storage.ObjectsGetIamPolicy":         p.ObjectsGetIamPolicy,
 		"Storage.ObjectsSetIamPolicy":         p.ObjectsSetIamPolicy,
 		"Storage.ObjectsDelete":               p.ObjectsDelete,
+		"Storage.ObjectsRewrite":              p.ObjectsRewrite,
+		"Storage.ObjectsCompose":              p.ObjectsCompose,
 		"Storage.ObjectACLList":               p.ObjectACLList,
 		"Storage.ObjectACLInsert":             p.ObjectACLInsert,
 		"Storage.ObjectsInsertStartResumable": p.ObjectsInsertStartResumable,
@@ -237,6 +241,9 @@ type objectMeta struct {
 	StorageClass   string            `json:"storageClass,omitempty"`
 	TimeCreated    string            `json:"timeCreated,omitempty"`
 	Updated        string            `json:"updated,omitempty"`
+	// ComponentCount is the number of source objects accumulated by compose
+	// operations (GCS Object.componentCount). Zero for non-composite objects.
+	ComponentCount int64 `json:"componentCount,omitempty"`
 	// Retention is the object-level retention policy (Object.retention).
 	Retention *objectRetention `json:"retention,omitempty"`
 	// RetentionExpirationTime is the server-determined expiry (RFC 3339).
@@ -277,6 +284,7 @@ func toStoreObject(o objectMeta) gcs.ObjectMeta {
 		CRC32C:         o.Crc32c,
 		StorageClass:   o.StorageClass,
 		Metadata:       o.Metadata,
+		ComponentCount: o.ComponentCount,
 		TimeCreated:    tc,
 		Updated:        up,
 		TemporaryHold:  o.TemporaryHold,
@@ -314,6 +322,7 @@ func fromStoreObject(m gcs.ObjectMeta) objectMeta {
 		Generation:     m.Generation,
 		Metageneration: m.Metageneration,
 		StorageClass:   m.StorageClass,
+		ComponentCount: m.ComponentCount,
 		TemporaryHold:  m.TemporaryHold,
 		EventBasedHold: m.EventBasedHold,
 	}
@@ -710,7 +719,6 @@ func (p *Provider) ObjectsInsert(ctx context.Context, nr *model.NormalizedReques
 
 	now := clock.Now()
 	generation := p.nextGen()
-	id := blobKey(bucket, object, generation)
 
 	// Versioning + retention + holds are all driven by bucket config and the
 	// request body (GCP-native: bucket versioning.enabled, bucket
@@ -749,15 +757,8 @@ func (p *Provider) ObjectsInsert(ctx context.Context, nr *model.NormalizedReques
 	if retention != nil {
 		o.RetentionExpirationTime = retention.RetainUntilTime
 	}
+	o.Metadata = uploadMetadata(nr.Params)
 	if body != nil {
-		if md, ok := body["metadata"].(map[string]any); ok {
-			o.Metadata = make(map[string]string, len(md))
-			for k, v := range md {
-				if s, ok := v.(string); ok {
-					o.Metadata[k] = s
-				}
-			}
-		}
 		if h, ok := body["temporaryHold"].(bool); ok {
 			o.TemporaryHold = h
 		}
@@ -779,32 +780,45 @@ func (p *Provider) ObjectsInsert(ctx context.Context, nr *model.NormalizedReques
 		}
 	}
 
-	// Resolve the object encryption key: CSEK (header) wins, then CMEK
-	// (per-object kmsKeyName query param, else the bucket's
-	// encryption.defaultKmsKeyName), else the server DEK via Wrap.
-	kmsKeyName, cseKey, cseKeySHA256, err := p.resolveWriteKey(nr, bucket, bmeta)
-	if err != nil {
-		return nil, err
-	}
-
 	// Read the raw object bytes. Envelope encryption is applied whole-object
 	// with AES-GCM, so the body is buffered; TODO(streaming-AEAD): stream very
 	// large objects through a streaming AEAD (e.g. Tink StreamingAead) rather
 	// than buffering the full ciphertext in memory.
 	var raw []byte
 	if stream, ok := nr.Params[wire.StreamKey].(io.Reader); ok {
-		raw, err = io.ReadAll(stream)
-		if err != nil {
-			return nil, err
+		b, rerr := io.ReadAll(stream)
+		if rerr != nil {
+			return nil, rerr
 		}
+		raw = b
 	} else {
 		raw = media
 	}
 
+	final, err := p.writeObjectRaw(ctx, nr, bucket, object, o, raw, versioned, priorBlobKey, true)
+	if err != nil {
+		return nil, err
+	}
+	return provider.OK(toMap(final)), nil
+}
+
+// writeObjectRaw computes checksums over the plaintext, envelope-encrypts it,
+// and persists a new object generation (metadata + blob). md5Enabled controls
+// whether an MD5 checksum is computed (compose leaves MD5 empty). It returns the
+// finalized objectMeta with checksums/size populated.
+func (p *Provider) writeObjectRaw(ctx context.Context, nr *model.NormalizedRequest, bucket, object string, o objectMeta, raw []byte, versioned bool, priorBlobKey string, md5Enabled bool) (objectMeta, error) {
+	bmeta, _ := p.objects.GetBucket(ctx, bucket)
+	kmsKeyName, cseKey, cseKeySHA256, err := p.resolveWriteKey(nr, bucket, bmeta)
+	if err != nil {
+		return o, err
+	}
+
 	// Plaintext checksums/size (GCS reports the logical object, not the
 	// ciphertext).
-	sum := md5.Sum(raw)
-	o.Md5Hash = base64.StdEncoding.EncodeToString(sum[:])
+	if md5Enabled {
+		sum := md5.Sum(raw)
+		o.Md5Hash = base64.StdEncoding.EncodeToString(sum[:])
+	}
 	crc := crc32.Checksum(raw, crc32.MakeTable(crc32.Castagnoli))
 	crcBytes := make([]byte, 4)
 	binary.BigEndian.PutUint32(crcBytes, crc)
@@ -812,28 +826,29 @@ func (p *Provider) ObjectsInsert(ctx context.Context, nr *model.NormalizedReques
 	o.Size = strconv.FormatInt(int64(len(raw)), 10)
 
 	// Encrypt and store the ciphertext blob.
+	id := blobKey(bucket, object, o.Generation)
 	var wrappedDEK []byte
 	if cseKey != nil {
 		ciphertext, err := kmsstore.EncryptData(cseKey, raw, nil)
 		if err != nil {
-			return nil, err
+			return o, err
 		}
 		if err := p.blobs.Put(ctx, blobsNamespace, id, ciphertext); err != nil {
-			return nil, err
+			return o, err
 		}
 		o.CustomerEncryption = &customerEncryption{EncryptionAlgorithm: "AES256", KeySha256: cseKeySHA256}
 	} else {
 		rawDEK, wd, err := p.encryptor.Wrap(ctx, nr.AccountID, kmsKeyName)
 		if err != nil {
-			return nil, err
+			return o, err
 		}
 		wrappedDEK = wd
 		ciphertext, err := kmsstore.EncryptData(rawDEK, raw, nil)
 		if err != nil {
-			return nil, err
+			return o, err
 		}
 		if err := p.blobs.Put(ctx, blobsNamespace, id, ciphertext); err != nil {
-			return nil, err
+			return o, err
 		}
 		o.KmsKeyName = kmsKeyName
 	}
@@ -849,12 +864,12 @@ func (p *Provider) ObjectsInsert(ctx context.Context, nr *model.NormalizedReques
 		// Roll back the just-written blob so a failed metadata write does not
 		// leave an orphaned object (metadata absent, blob present).
 		_ = p.blobs.Delete(ctx, blobsNamespace, id)
-		return nil, err
+		return o, err
 	}
 	if priorBlobKey != "" {
 		_ = p.blobs.Delete(ctx, blobsNamespace, priorBlobKey)
 	}
-	return provider.OK(toMap(o)), nil
+	return o, nil
 }
 
 func (p *Provider) ObjectsGet(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
@@ -890,8 +905,264 @@ func (p *Provider) ObjectsGetMedia(ctx context.Context, nr *model.NormalizedRequ
 		Data: map[string]any{
 			"_stream":           io.NopCloser(bytes.NewReader(plain)),
 			wire.ContentTypeKey: meta.ContentType,
+			wire.HeadersKey:     mediaHeaders(meta),
 		},
 	}, nil
+}
+
+// mediaHeaders builds the GCS media-download response headers for an object so
+// the Go SDK's Reader.Attrs (and reader.Metadata()) populate: x-goog-hash,
+// x-goog-generation, x-goog-metageneration, x-goog-stored-content-length, and
+// one x-goog-meta-<key> header per custom metadata entry.
+func mediaHeaders(m gcs.ObjectMeta) map[string]string {
+	h := map[string]string{
+		"x-goog-generation":            m.Generation,
+		"x-goog-metageneration":        m.Metageneration,
+		"x-goog-stored-content-length": strconv.FormatInt(m.Size, 10),
+	}
+	var hashes []string
+	if m.CRC32C != "" {
+		hashes = append(hashes, "crc32c="+m.CRC32C)
+	}
+	if m.MD5Hash != "" {
+		hashes = append(hashes, "md5="+m.MD5Hash)
+	}
+	if len(hashes) > 0 {
+		h["x-goog-hash"] = strings.Join(hashes, ",")
+	}
+	for k, v := range m.Metadata {
+		h["x-goog-meta-"+canonicalMetaKey(k)] = v
+	}
+	return h
+}
+
+// canonicalMetaKey canonicalises a metadata key the way net/http canonicalises
+// header names: lowercased key with the first rune title-cased
+// (e.g. "originalname" → "Originalname").
+func canonicalMetaKey(key string) string {
+	k := strings.ToLower(key)
+	if k == "" {
+		return k
+	}
+	r := []rune(k)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
+}
+
+// uploadMetadata merges custom object metadata from the request body's
+// "metadata" map and the x-goog-meta-* request headers (wire.MetaHeadersKey).
+func uploadMetadata(params map[string]any) map[string]string {
+	out := bodyMetadata(params)
+	hdr, _ := params[wire.MetaHeadersKey].(map[string]string)
+	if len(hdr) == 0 {
+		return out
+	}
+	if out == nil {
+		out = make(map[string]string, len(hdr))
+	}
+	for k, v := range hdr {
+		out[k] = v
+	}
+	return out
+}
+
+// bucketVersioned reports whether the bucket has versioning.enabled.
+func (p *Provider) bucketVersioned(ctx context.Context, bucket string) bool {
+	bmeta, _ := p.objects.GetBucket(ctx, bucket)
+	if v, ok := bmeta["versioning"].(map[string]any); ok {
+		if en, _ := v["enabled"].(bool); en {
+			return true
+		}
+	}
+	return false
+}
+
+// readSourceRaw reads and decrypts an object's plaintext bytes.
+func (p *Provider) readSourceRaw(ctx context.Context, nr *model.NormalizedRequest, bucket, object string, params map[string]any) (gcs.ObjectMeta, []byte, error) {
+	meta, err := p.getObjectForRead(ctx, bucket, object, params)
+	if err != nil {
+		return gcs.ObjectMeta{}, nil, err
+	}
+	id := blobKey(bucket, object, meta.Generation)
+	rc, err := p.blobs.GetStream(ctx, blobsNamespace, id, 0, -1)
+	if err != nil {
+		return gcs.ObjectMeta{}, nil, model.NewProviderError("InternalError", "object metadata present but blob missing: "+err.Error(), 500)
+	}
+	ciphertext, err := io.ReadAll(rc)
+	rc.Close()
+	if err != nil {
+		return gcs.ObjectMeta{}, nil, err
+	}
+	plain, err := p.decryptObject(ctx, nr, meta, ciphertext)
+	if err != nil {
+		return gcs.ObjectMeta{}, nil, err
+	}
+	return meta, plain, nil
+}
+
+// ObjectsRewrite implements objects.rewrite (the GCS JSON API copy action used
+// by the Go SDK's Object.CopierFrom). It copies the source object's bytes and
+// metadata to the destination under a new generation, returning the
+// storage#rewriteResponse envelope.
+func (p *Provider) ObjectsRewrite(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	srcBucket, _ := nr.Params["sourceBucket"].(string)
+	srcObject, _ := nr.Params["sourceObject"].(string)
+	dstBucket, _ := nr.Params["destinationBucket"].(string)
+	dstObject, _ := nr.Params["destinationObject"].(string)
+	body, _ := nr.Params["body"].(map[string]any)
+	if dstObject == "" && body != nil {
+		dstObject, _ = body["name"].(string)
+	}
+	if srcBucket == "" || srcObject == "" || dstBucket == "" || dstObject == "" {
+		return nil, model.NewProviderError("InvalidRequest", "rewrite requires source and destination object names", 400)
+	}
+	if err := p.scopeToBucket(ctx, nr, dstBucket); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, model.NewProviderError("NotFound", "destination bucket not found", 404)
+		}
+		return nil, err
+	}
+
+	srcParams := map[string]any{}
+	if g, _ := nr.Params["sourceGeneration"].(string); g != "" {
+		srcParams["generation"] = g
+	}
+	srcMeta, raw, err := p.readSourceRaw(ctx, nr, srcBucket, srcObject, srcParams)
+	if err != nil {
+		return nil, err
+	}
+
+	// Destination metadata starts as a copy of the source, overridden by the
+	// request body's writable fields, then stamped with a fresh generation.
+	now := clock.Now()
+	o := fromStoreObject(srcMeta)
+	o.Name = dstObject
+	o.Bucket = dstBucket
+	o.Generation = p.nextGen()
+	o.Metageneration = "1"
+	o.TimeCreated = now.Format(time.RFC3339Nano)
+	o.Updated = o.TimeCreated
+	o.Retention = nil
+	o.RetentionExpirationTime = ""
+	if body != nil {
+		if ct, _ := body["contentType"].(string); ct != "" {
+			o.ContentType = ct
+		}
+		if _, ok := body["metadata"]; ok {
+			o.Metadata = bodyMetadata(nr.Params)
+		}
+		if sc, _ := body["storageClass"].(string); sc != "" {
+			o.StorageClass = sc
+		}
+	}
+	o.ID = dstBucket + "/" + dstObject + "/" + o.Generation
+	o.Etag = "CAE="
+	o.SelfLink = "https://www.googleapis.com/storage/v1/b/" + dstBucket + "/o/" + url.PathEscape(dstObject)
+	o.MediaLink = "https://www.googleapis.com/download/storage/v1/b/" + dstBucket + "/o/" + url.PathEscape(dstObject) + "?alt=media"
+
+	final, err := p.writeObjectRaw(ctx, nr, dstBucket, dstObject, o, raw, p.bucketVersioned(ctx, dstBucket), "", true)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := map[string]any{
+		"kind":                "storage#rewriteResponse",
+		"totalBytesRewritten": final.Size,
+		"objectSize":          final.Size,
+		"done":                true,
+		"resource":            toMap(final),
+	}
+	return provider.OK(resp), nil
+}
+
+// ObjectsCompose implements objects.compose (the GCS JSON API compose action
+// used by the Go SDK's Object.ComposerFrom). It concatenates the source objects'
+// bytes in sourceObjects order, sets componentCount, computes CRC32C over the
+// concatenated bytes, and leaves MD5 empty.
+func (p *Provider) ObjectsCompose(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	bucket, _ := nr.Params["bucket"].(string)
+	object, _ := nr.Params["object"].(string)
+	body, _ := nr.Params["body"].(map[string]any)
+	if err := p.scopeToBucket(ctx, nr, bucket); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, model.NewProviderError("NotFound", "bucket not found", 404)
+		}
+		return nil, err
+	}
+
+	var dest map[string]any
+	if body != nil {
+		dest, _ = body["destination"].(map[string]any)
+	}
+	if object == "" && dest != nil {
+		object, _ = dest["name"].(string)
+	}
+	if bucket == "" || object == "" {
+		return nil, model.NewProviderError("InvalidRequest", "compose requires a destination object name", 400)
+	}
+
+	sources, _ := body["sourceObjects"].([]any)
+	if len(sources) == 0 {
+		return nil, model.NewProviderError("InvalidRequest", "compose requires source objects", 400)
+	}
+
+	var buf bytes.Buffer
+	for _, s := range sources {
+		sm, _ := s.(map[string]any)
+		name, _ := sm["name"].(string)
+		if name == "" {
+			return nil, model.NewProviderError("InvalidRequest", "compose source object missing name", 400)
+		}
+		srcParams := map[string]any{}
+		if g, _ := sm["generation"].(string); g != "" {
+			srcParams["generation"] = g
+		}
+		_, raw, err := p.readSourceRaw(ctx, nr, bucket, name, srcParams)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(raw)
+	}
+
+	now := clock.Now()
+	o := objectMeta{
+		Kind:           "storage#object",
+		Name:           object,
+		Bucket:         bucket,
+		ContentType:    "application/octet-stream",
+		Generation:     p.nextGen(),
+		Metageneration: "1",
+		StorageClass:   "STANDARD",
+		TimeCreated:    now.Format(time.RFC3339Nano),
+		Updated:        now.Format(time.RFC3339Nano),
+		ComponentCount: int64(len(sources)),
+	}
+	if dest != nil {
+		if ct, _ := dest["contentType"].(string); ct != "" {
+			o.ContentType = ct
+		}
+		if md, ok := dest["metadata"].(map[string]any); ok {
+			o.Metadata = make(map[string]string, len(md))
+			for k, v := range md {
+				if s, ok := v.(string); ok {
+					o.Metadata[k] = s
+				}
+			}
+		}
+		if sc, _ := dest["storageClass"].(string); sc != "" {
+			o.StorageClass = sc
+		}
+	}
+	o.ID = bucket + "/" + object + "/" + o.Generation
+	o.Etag = "CAE="
+	o.SelfLink = "https://www.googleapis.com/storage/v1/b/" + bucket + "/o/" + url.PathEscape(object)
+	o.MediaLink = "https://www.googleapis.com/download/storage/v1/b/" + bucket + "/o/" + url.PathEscape(object) + "?alt=media"
+
+	final, err := p.writeObjectRaw(ctx, nr, bucket, object, o, buf.Bytes(), p.bucketVersioned(ctx, bucket), "", false)
+	if err != nil {
+		return nil, err
+	}
+	return provider.OK(toMap(final)), nil
 }
 
 // resolveWriteKey determines the DEK for an object write: CSEK (header) wins,
@@ -1615,7 +1886,7 @@ func (p *Provider) ObjectsInsertStartResumable(ctx context.Context, nr *model.No
 		p.mu.Unlock()
 		return nil, model.NewProviderError("InvalidRequest", "too many active resumable uploads", 429)
 	}
-	p.uploads[id] = &uploadSession{Bucket: bucket, Object: object, ContentType: ct, lastAccess: now}
+	p.uploads[id] = &uploadSession{Bucket: bucket, Object: object, ContentType: ct, Metadata: uploadMetadata(nr.Params), lastAccess: now}
 	p.mu.Unlock()
 
 	// Sweep stale sessions from the durable store (may hold orphans from a
@@ -1692,6 +1963,7 @@ func (p *Provider) ObjectsInsertResumable(ctx context.Context, nr *model.Normali
 	bucket := sess.Bucket
 	object := sess.Object
 	contentType := sess.ContentType
+	metadata := sess.Metadata
 	length := sess.length
 	tmpPath := sess.tmpPath
 	var stream io.Reader
@@ -1751,6 +2023,9 @@ func (p *Provider) ObjectsInsertResumable(ctx context.Context, nr *model.Normali
 	nr.Params["object"] = object
 	nr.Params[wire.StreamKey] = stream
 	nr.Params[wire.ContentTypeKey] = contentType
+	if metadata != nil {
+		nr.Params[wire.MetaHeadersKey] = metadata
+	}
 	return p.ObjectsInsert(ctx, nr)
 }
 

--- a/internal/gcp/store/gcs/postgres.go
+++ b/internal/gcp/store/gcs/postgres.go
@@ -173,11 +173,11 @@ func insertObjectGeneration(ctx context.Context, tx pgx.Tx, meta ObjectMeta) err
 	timeDeleted := nullableTime(meta.TimeDeleted)
 	_, err := tx.Exec(ctx, `
 		INSERT INTO jc_gcs_objects
-		  (bucket, name, generation, metageneration, content_type, size, md5_hash, crc32c, storage_class, metadata, time_created, updated, retain_until, retention_mode, temporary_hold, event_based_hold, time_deleted, kms_key_name, wrapped_dek, cse_key_sha256)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)
+		  (bucket, name, generation, metageneration, content_type, size, md5_hash, crc32c, storage_class, metadata, time_created, updated, retain_until, retention_mode, temporary_hold, event_based_hold, time_deleted, kms_key_name, wrapped_dek, cse_key_sha256, component_count)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
 	`, meta.Bucket, meta.Name, meta.Generation, meta.Metageneration, meta.ContentType, meta.Size, meta.MD5Hash, meta.CRC32C,
 		meta.StorageClass, json.RawMessage(metaRaw), meta.TimeCreated, meta.Updated, retainUntil, retentionMode,
-		meta.TemporaryHold, meta.EventBasedHold, timeDeleted, meta.KmsKeyName, meta.WrappedDEK, meta.CSEKeySHA256)
+		meta.TemporaryHold, meta.EventBasedHold, timeDeleted, meta.KmsKeyName, meta.WrappedDEK, meta.CSEKeySHA256, meta.ComponentCount)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func insertObjectGeneration(ctx context.Context, tx pgx.Tx, meta ObjectMeta) err
 }
 
 // objectCols is the shared SELECT column list for object rows.
-const objectCols = "bucket, name, generation, metageneration, content_type, size, md5_hash, crc32c, storage_class, metadata, time_created, updated, retain_until, retention_mode, temporary_hold, event_based_hold, time_deleted, kms_key_name, wrapped_dek, cse_key_sha256"
+const objectCols = "bucket, name, generation, metageneration, content_type, size, md5_hash, crc32c, storage_class, metadata, time_created, updated, retain_until, retention_mode, temporary_hold, event_based_hold, time_deleted, kms_key_name, wrapped_dek, cse_key_sha256, component_count"
 
 // scanObject scans the objectCols columns into an ObjectMeta.
 func scanObject(scan func(...any) error) (ObjectMeta, error) {
@@ -195,7 +195,7 @@ func scanObject(scan func(...any) error) (ObjectMeta, error) {
 	var retainUntil pgtype.Timestamptz
 	var timeDeleted pgtype.Timestamptz
 	err := scan(&m.Bucket, &m.Name, &m.Generation, &m.Metageneration, &m.ContentType, &m.Size, &m.MD5Hash, &m.CRC32C,
-		&m.StorageClass, &metaRaw, &m.TimeCreated, &m.Updated, &retainUntil, &retentionMode, &m.TemporaryHold, &m.EventBasedHold, &timeDeleted, &m.KmsKeyName, &m.WrappedDEK, &m.CSEKeySHA256)
+		&m.StorageClass, &metaRaw, &m.TimeCreated, &m.Updated, &retainUntil, &retentionMode, &m.TemporaryHold, &m.EventBasedHold, &timeDeleted, &m.KmsKeyName, &m.WrappedDEK, &m.CSEKeySHA256, &m.ComponentCount)
 	if err != nil {
 		return ObjectMeta{}, err
 	}
@@ -259,8 +259,14 @@ func (s *PostgresObjectStore) GetObjectGeneration(ctx context.Context, bucket, n
 }
 
 func (s *PostgresObjectStore) DeleteObjectMeta(ctx context.Context, bucket, name string) error {
-	_, err := s.pool.Exec(ctx, `DELETE FROM jc_gcs_objects WHERE bucket=$1 AND name=$2`, bucket, name)
-	return err
+	res, err := s.pool.Exec(ctx, `DELETE FROM jc_gcs_objects WHERE bucket=$1 AND name=$2`, bucket, name)
+	if err != nil {
+		return err
+	}
+	if res.RowsAffected() == 0 {
+		return ErrNoSuchObject
+	}
+	return nil
 }
 
 func (s *PostgresObjectStore) ListObjects(ctx context.Context, bucket string) ([]ObjectMeta, error) {

--- a/internal/gcp/store/gcs/snapshot.go
+++ b/internal/gcp/store/gcs/snapshot.go
@@ -205,8 +205,8 @@ func (s *PostgresObjectStore) Restore(ctx context.Context, r io.Reader) error {
 		}
 		retainUntil, retentionMode := retentionArgs(&o)
 		timeDeleted := nullableTime(o.TimeDeleted)
-		if _, err := tx.Exec(ctx, `INSERT INTO jc_gcs_objects (bucket, name, generation, metageneration, content_type, size, md5_hash, crc32c, storage_class, metadata, time_created, updated, retain_until, retention_mode, temporary_hold, event_based_hold, time_deleted, kms_key_name, wrapped_dek, cse_key_sha256) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)`,
-			o.Bucket, o.Name, o.Generation, o.Metageneration, o.ContentType, o.Size, o.MD5Hash, o.CRC32C, o.StorageClass, json.RawMessage(mustJSON(metadata)), o.TimeCreated, o.Updated, retainUntil, retentionMode, o.TemporaryHold, o.EventBasedHold, timeDeleted, o.KmsKeyName, o.WrappedDEK, o.CSEKeySHA256); err != nil {
+		if _, err := tx.Exec(ctx, `INSERT INTO jc_gcs_objects (bucket, name, generation, metageneration, content_type, size, md5_hash, crc32c, storage_class, metadata, time_created, updated, retain_until, retention_mode, temporary_hold, event_based_hold, time_deleted, kms_key_name, wrapped_dek, cse_key_sha256, component_count) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)`,
+			o.Bucket, o.Name, o.Generation, o.Metageneration, o.ContentType, o.Size, o.MD5Hash, o.CRC32C, o.StorageClass, json.RawMessage(mustJSON(metadata)), o.TimeCreated, o.Updated, retainUntil, retentionMode, o.TemporaryHold, o.EventBasedHold, timeDeleted, o.KmsKeyName, o.WrappedDEK, o.CSEKeySHA256, o.ComponentCount); err != nil {
 			return err
 		}
 	}

--- a/internal/gcp/store/gcs/store.go
+++ b/internal/gcp/store/gcs/store.go
@@ -42,8 +42,11 @@ type ObjectMeta struct {
 	CRC32C         string            `json:"crc32c,omitempty"`
 	StorageClass   string            `json:"storageClass"`
 	Metadata       map[string]string `json:"metadata,omitempty"`
-	TimeCreated    time.Time         `json:"timeCreated"`
-	Updated        time.Time         `json:"updated"`
+	// ComponentCount is the number of source objects accumulated by compose
+	// operations (GCS Object.componentCount). Zero for non-composite objects.
+	ComponentCount int64     `json:"componentCount,omitempty"`
+	TimeCreated    time.Time `json:"timeCreated"`
+	Updated        time.Time `json:"updated"`
 	// Retention is the object-level retention policy (GCS Object.retention).
 	Retention *ObjectRetention `json:"retention,omitempty"`
 	// TemporaryHold / EventBasedHold mirror GCS Object.temporaryHold /

--- a/internal/gcp/store/migrations/018_kms_key_material_nullable.sql
+++ b/internal/gcp/store/migrations/018_kms_key_material_nullable.sql
@@ -1,0 +1,5 @@
+-- Asymmetric KMS keys have no symmetric key material; only private_key /
+-- public_key are populated. key_material was declared NOT NULL in
+-- 008_kms_versions.sql, which broke CreateCryptoKey (and its implicit primary
+-- version) for ASYMMETRIC_SIGN / ASYMMETRIC_DECRYPT purposes on Postgres.
+ALTER TABLE jc_kms_cryptokey_versions ALTER COLUMN key_material DROP NOT NULL;

--- a/internal/gcp/store/migrations/019_gcs_component_count.sql
+++ b/internal/gcp/store/migrations/019_gcs_component_count.sql
@@ -1,0 +1,4 @@
+-- 019_gcs_component_count: GCS composite objects (objects.compose). The number
+-- of source objects concatenated into a composite object is persisted as
+-- Object.componentCount.
+ALTER TABLE jc_gcs_objects ADD COLUMN IF NOT EXISTS component_count BIGINT NOT NULL DEFAULT 0;

--- a/internal/gcp/store/pubsub/postgres.go
+++ b/internal/gcp/store/pubsub/postgres.go
@@ -76,13 +76,38 @@ func (s *PostgresMessages) List(ctx context.Context, topic string) ([]Message, e
 }
 
 // Pull atomically claims eligible messages using FOR UPDATE SKIP LOCKED
-// (mirrors SQS Receive).
+// (mirrors SQS Receive), applying the same orderingKey FIFO gating as the
+// memory store: only the earliest eligible message in each ordering-key group
+// is claimed in a single pull.
 func (s *PostgresMessages) Pull(ctx context.Context, topic string, maxMessages, ackDeadlineSec, retentionSec int, now time.Time) ([]Message, error) {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Rollback(ctx)
+
+	// Ordering-key groups that currently have an earlier in-flight message
+	// (claimed but within its ack deadline) gate delivery of later messages.
+	inFlightGroups := map[string]bool{}
+	krows, err := tx.Query(ctx, `
+		SELECT DISTINCT ordering_key FROM jc_pubsub_messages
+		WHERE topic = $1 AND ordering_key <> '' AND visible_at > $2
+	`, topic, now)
+	if err != nil {
+		return nil, err
+	}
+	for krows.Next() {
+		var k string
+		if err := krows.Scan(&k); err != nil {
+			krows.Close()
+			return nil, err
+		}
+		inFlightGroups[k] = true
+	}
+	krows.Close()
+	if err := krows.Err(); err != nil {
+		return nil, err
+	}
 
 	rows, err := tx.Query(ctx, `
 		SELECT message_id, data, attributes, publish_time, delivery_attempt, ordering_key, kms_key_name, wrapped_dek
@@ -91,13 +116,12 @@ func (s *PostgresMessages) Pull(ctx context.Context, topic string, maxMessages, 
 		  AND (visible_at IS NULL OR visible_at <= $2)
 		  AND publish_time > $2 - make_interval(secs => $3)
 		ORDER BY publish_time
-		LIMIT $4
 		FOR UPDATE SKIP LOCKED
-	`, topic, now, retentionSec, maxMessages)
+	`, topic, now, retentionSec)
 	if err != nil {
 		return nil, err
 	}
-	var out []Message
+	var candidates []Message
 	for rows.Next() {
 		var m Message
 		var attrs []byte
@@ -107,13 +131,28 @@ func (s *PostgresMessages) Pull(ctx context.Context, topic string, maxMessages, 
 		}
 		json.Unmarshal(attrs, &m.Attributes)
 		m.Topic = topic
-		m.VisibleAt = now.Add(time.Duration(ackDeadlineSec) * time.Second)
-		m.DeliveryAttempt++
-		out = append(out, m)
+		candidates = append(candidates, m)
 	}
 	rows.Close()
 	if err := rows.Err(); err != nil {
 		return nil, err
+	}
+
+	var out []Message
+	for _, m := range candidates {
+		if len(out) >= maxMessages {
+			break
+		}
+		// FIFO: skip if an earlier message in the same ordering-key group is in-flight.
+		if m.OrderingKey != "" && inFlightGroups[m.OrderingKey] {
+			continue
+		}
+		m.VisibleAt = now.Add(time.Duration(ackDeadlineSec) * time.Second)
+		m.DeliveryAttempt++
+		if m.OrderingKey != "" {
+			inFlightGroups[m.OrderingKey] = true
+		}
+		out = append(out, m)
 	}
 
 	for _, m := range out {

--- a/internal/gcp/wire/wire.go
+++ b/internal/gcp/wire/wire.go
@@ -46,4 +46,13 @@ const (
 	// and batchGet — whose response body is newline-delimited JSON, one JSON
 	// object per line, not a JSON array or a single object).
 	RawJSONKey = "jaiscloud:rawJSON"
+	// MetaHeadersKey carries custom object metadata extracted from x-goog-meta-*
+	// request headers (codec → provider), as map[string]string keyed by the
+	// canonicalised metadata key.
+	MetaHeadersKey = "jaiscloud:metaHeaders"
+	// HeadersKey carries extra response headers (provider → codec) as
+	// map[string]string. The codec merges them into the response header set, so
+	// media downloads can surface x-goog-hash / x-goog-generation /
+	// x-goog-meta-* etc. alongside the streamed bytes.
+	HeadersKey = "jaiscloud:headers"
 )

--- a/tests/integration/gcp/sdk-firestore/firestore_test.go
+++ b/tests/integration/gcp/sdk-firestore/firestore_test.go
@@ -167,3 +167,34 @@ func TestSDKFirestoreReadsQueriesTxn(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, snap.Exists())
 }
+
+// TestSDKFirestoreSnapshots exercises the high-level Snapshots listener. It
+// verifies the emulator emits a TargetChange NO_CHANGE frame after CURRENT so
+// the SDK concludes a snapshot instead of hanging, and that subsequent writes
+// surface as real-time snapshot updates.
+func TestSDKFirestoreSnapshots(t *testing.T) {
+	ctx := context.Background()
+	client := newClient(t)
+	col := client.Collection(unique("snap"))
+
+	_, _, err := col.Add(ctx, map[string]any{"n": int64(1)})
+	require.NoError(t, err)
+
+	sctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	it := col.Snapshots(sctx)
+	defer it.Stop()
+
+	// Initial snapshot must be delivered promptly (without NO_CHANGE the SDK
+	// never concludes a snapshot and Next() blocks until the context deadline).
+	snap, err := it.Next()
+	require.NoError(t, err)
+	require.Equal(t, 1, snap.Size)
+
+	// A subsequent write must surface as a real-time snapshot update.
+	_, _, err = col.Add(ctx, map[string]any{"n": int64(2)})
+	require.NoError(t, err)
+	snap, err = it.Next()
+	require.NoError(t, err)
+	require.Equal(t, 2, snap.Size)
+}


### PR DESCRIPTION
## Summary

Makes the official GCP client SDKs work against the emulator, driven by the floci-gcp and localgcp compatibility test suites. Adds gRPC transports for Pub/Sub, Secret Manager, and Cloud KMS (previously REST-only, so the official gRPC-only SDKs were unreachable), completes Firestore `Listen`, and closes GCS + Postgres parity gaps.

## gRPC transports (new)

- **Pub/Sub** (`internal/gcp/grpc/pubsub/`) — `Publisher` + `Subscriber` + IAM, including `StreamingPull` (the official SDK's `Receive` uses this, not unary `Pull`), ack/modify-deadline on the request stream, ordering-key FIFO, and topic/subscription IAM.
- **Secret Manager** (`internal/gcp/grpc/secretmanager/`) — secrets + versions, `AccessSecretVersion` with the `latest` alias resolved, `dataCrc32c`, CMEK, and IAM.
- **Cloud KMS** (`internal/gcp/grpc/kms/`) — keyring/key/version CRUD, symmetric encrypt/decrypt, asymmetric sign/decrypt, `GetPublicKey`, `MacSign`/`MacVerify`, `GenerateRandomBytes`, and IAM.
- Shared helpers: `internal/gcp/grpc/{status.go,identity.go,iam.go}` (error→gRPC-code mapping, project-from-metadata, single `google.iam.v1.IAMPolicy` router).

## Firestore

- **`Listen`** (bidirectional streaming) — collection/document targets, initial snapshot + real-time deltas, `DocumentChange`/`DocumentDelete`/`TargetChange` `ADD`/`CURRENT`/`NO_CHANGE`/`REMOVE`, monotonic read-time, and resume tokens, backed by a change-feed in the shared service layer so REST and gRPC writes both emit deltas.
- Reject `Commit` on a rolled-back/unknown transaction instead of silently committing non-transactionally.

## GCS (REST)

- Custom object metadata round-trip (`x-goog-meta-*` headers + `metadata`), `objects.rewrite` (copy), `objects.compose` (with `componentCount`/no-MD5/crc32c), and media-download `x-goog-hash`/`x-goog-generation`/`x-goog-metageneration`/`x-goog-stored-content-length` headers.

## Postgres parity

- GCS delete-missing → `404 Not Found`; Pub/Sub ordering-key FIFO gating; KMS `key_material` nullable (migration `018`); GCS `component_count` column (migration `019`).

## Verification

- `go build` / `go vet` / `gofmt -l` clean; `go test -race ./internal/gcp/...` green.
- REST regression (`tests/integration/gcp/sdkv1`) and gRPC regression (`tests/integration/gcp/sdk-firestore`, now incl. a `Snapshots` listen test) green.
- floci-gcp Go SDK suite: all 6 implemented services (`GCS`, `Firestore`, `IAM`, `PubSub`, `SecretManager`, `KMS`) pass.

## Deferred (non-blocking follow-ups, from architect review)

Per-target resume tokens, `DocumentDelete.removed_target_ids`, KMS CRC32C mismatch rejection, `StreamingPull` mid-stream ack-deadline updates + flow-control, and unbounded change-log bounding.
