### PR TITLE
fix gcp: GCS delete parity and versioned tombstone semantics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ vendor/
 
 # Local SEO / personal notes (not for repo)
 SEO_NEXT_STEPS.md
+
+.astra/
+.astraignore

--- a/internal/gcp/provider/storage/storage.go
+++ b/internal/gcp/provider/storage/storage.go
@@ -1059,14 +1059,32 @@ func (p *Provider) ObjectsDelete(ctx context.Context, nr *model.NormalizedReques
 
 	// Retention check first: a held or retention-active object cannot be
 	// deleted (GCS returns PERMISSION_DENIED).
-	if meta, err := p.objects.GetObjectMeta(ctx, bucket, object); err == nil {
-		if objectProtected(meta) {
-			return nil, model.NewProviderError("PermissionDenied", "Object is under hold or retention and cannot be deleted", 403)
+	meta, err := p.objects.GetObjectMeta(ctx, bucket, object)
+	if err != nil {
+		if errors.Is(err, gcs.ErrNoSuchObject) {
+			return nil, model.NewProviderError("NotFound", "object not found", 404)
 		}
+		return nil, err
+	}
+	if objectProtected(meta) {
+		return nil, model.NewProviderError("PermissionDenied", "Object is under hold or retention and cannot be deleted", 403)
 	}
 
-	// Collect every generation's blob key before deleting metadata, so the
-	// bytes can be removed too.
+	if p.bucketVersioned(ctx, bucket) {
+		// Versioned bucket: delete only the live generation, leaving a
+		// non-live tombstone that appears in ?versions=true listings.
+		if _, err := p.objects.TombstoneObjectMeta(ctx, bucket, object); err != nil {
+			if errors.Is(err, gcs.ErrNoSuchObject) {
+				return nil, model.NewProviderError("NotFound", "object not found", 404)
+			}
+			return nil, err
+		}
+		_ = p.blobs.Delete(ctx, blobsNamespace, blobKey(bucket, object, meta.Generation))
+		return &model.ProviderResponse{HTTPStatus: 204, Data: map[string]any{}}, nil
+	}
+
+	// Non-versioned bucket: hard-delete every generation (there should only
+	// be one) and its bytes.
 	var blobKeys []string
 	if gens, err := p.objects.ListObjectVersions(ctx, bucket); err == nil {
 		for _, m := range gens {
@@ -1075,7 +1093,6 @@ func (p *Provider) ObjectsDelete(ctx context.Context, nr *model.NormalizedReques
 			}
 		}
 	}
-
 	if err := p.objects.DeleteObjectMeta(ctx, bucket, object); err != nil {
 		if errors.Is(err, gcs.ErrNoSuchObject) {
 			return nil, model.NewProviderError("NotFound", "object not found", 404)
@@ -1086,6 +1103,20 @@ func (p *Provider) ObjectsDelete(ctx context.Context, nr *model.NormalizedReques
 		_ = p.blobs.Delete(ctx, blobsNamespace, id)
 	}
 	return &model.ProviderResponse{HTTPStatus: 204, Data: map[string]any{}}, nil
+}
+
+// bucketVersioned reports whether versioning is enabled on the bucket.
+func (p *Provider) bucketVersioned(ctx context.Context, bucket string) bool {
+	bmeta, err := p.objects.GetBucket(ctx, bucket)
+	if err != nil {
+		return false
+	}
+	if v, ok := bmeta["versioning"].(map[string]any); ok {
+		if en, _ := v["enabled"].(bool); en {
+			return true
+		}
+	}
+	return false
 }
 
 // objectProtected reports whether an object's holds or active retention block

--- a/internal/gcp/store/gcs/memory.go
+++ b/internal/gcp/store/gcs/memory.go
@@ -200,6 +200,29 @@ func (s *MemoryObjectStore) DeleteObjectMeta(_ context.Context, bucket, name str
 	return nil
 }
 
+func (s *MemoryObjectStore) TombstoneObjectMeta(_ context.Context, bucket, name string) (ObjectMeta, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	objs, ok := s.objects[bucket]
+	if !ok {
+		return ObjectMeta{}, ErrNoSuchObject
+	}
+	gens, ok := objs[name]
+	if !ok {
+		return ObjectMeta{}, ErrNoSuchObject
+	}
+	// The live generation is the last appended one without a TimeDeleted mark.
+	for i := len(gens) - 1; i >= 0; i-- {
+		if gens[i].TimeDeleted == nil {
+			now := clock.Now()
+			gens[i].TimeDeleted = &now
+			objs[name] = gens
+			return gens[i], nil
+		}
+	}
+	return ObjectMeta{}, ErrNoSuchObject
+}
+
 func (s *MemoryObjectStore) ListObjects(_ context.Context, bucket string) ([]ObjectMeta, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/gcp/store/gcs/postgres.go
+++ b/internal/gcp/store/gcs/postgres.go
@@ -97,6 +97,17 @@ func (s *PostgresObjectStore) DeleteBucket(ctx context.Context, name string) err
 	return nil
 }
 
+// ensureBucketExists returns ErrNoSuchBucket when the named bucket is absent,
+// guarding PutObjectMeta/PutObjectGeneration against orphan object rows.
+func ensureBucketExists(ctx context.Context, tx pgx.Tx, name string) error {
+	var one int
+	err := tx.QueryRow(ctx, `SELECT 1 FROM jc_gcs_buckets WHERE name=$1`, name).Scan(&one)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNoSuchBucket
+	}
+	return err
+}
+
 func (s *PostgresObjectStore) ListBuckets(ctx context.Context, projectID string) ([]map[string]any, error) {
 	var rows pgx.Rows
 	var err error
@@ -133,6 +144,9 @@ func (s *PostgresObjectStore) PutObjectMeta(ctx context.Context, bucket, name st
 		return err
 	}
 	defer tx.Rollback(ctx)
+	if err := ensureBucketExists(ctx, tx, bucket); err != nil {
+		return err
+	}
 	if _, err := tx.Exec(ctx, `DELETE FROM jc_gcs_objects WHERE bucket=$1 AND name=$2`, bucket, name); err != nil {
 		return err
 	}
@@ -153,6 +167,9 @@ func (s *PostgresObjectStore) PutObjectGeneration(ctx context.Context, bucket, n
 		return err
 	}
 	defer tx.Rollback(ctx)
+	if err := ensureBucketExists(ctx, tx, bucket); err != nil {
+		return err
+	}
 	now := clock.Now()
 	if _, err := tx.Exec(ctx, `
 		UPDATE jc_gcs_objects SET time_deleted=$3 WHERE bucket=$1 AND name=$2 AND time_deleted IS NULL
@@ -259,8 +276,49 @@ func (s *PostgresObjectStore) GetObjectGeneration(ctx context.Context, bucket, n
 }
 
 func (s *PostgresObjectStore) DeleteObjectMeta(ctx context.Context, bucket, name string) error {
-	_, err := s.pool.Exec(ctx, `DELETE FROM jc_gcs_objects WHERE bucket=$1 AND name=$2`, bucket, name)
-	return err
+	tag, err := s.pool.Exec(ctx, `DELETE FROM jc_gcs_objects WHERE bucket=$1 AND name=$2`, bucket, name)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNoSuchObject
+	}
+	return nil
+}
+
+func (s *PostgresObjectStore) TombstoneObjectMeta(ctx context.Context, bucket, name string) (ObjectMeta, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return ObjectMeta{}, err
+	}
+	defer tx.Rollback(ctx)
+	row := tx.QueryRow(ctx, `
+		SELECT `+objectCols+`
+		FROM jc_gcs_objects WHERE bucket=$1 AND name=$2 AND time_deleted IS NULL
+		ORDER BY generation::bigint DESC LIMIT 1
+	`, bucket, name)
+	m, err := scanObject(row.Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ObjectMeta{}, ErrNoSuchObject
+	}
+	if err != nil {
+		return ObjectMeta{}, err
+	}
+	now := clock.Now()
+	tag, err := tx.Exec(ctx, `
+		UPDATE jc_gcs_objects SET time_deleted=$3 WHERE bucket=$1 AND name=$2 AND generation=$4
+	`, bucket, name, now, m.Generation)
+	if err != nil {
+		return ObjectMeta{}, err
+	}
+	if tag.RowsAffected() == 0 {
+		return ObjectMeta{}, ErrNoSuchObject
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ObjectMeta{}, err
+	}
+	m.TimeDeleted = &now
+	return m, nil
 }
 
 func (s *PostgresObjectStore) ListObjects(ctx context.Context, bucket string) ([]ObjectMeta, error) {

--- a/internal/gcp/store/gcs/store.go
+++ b/internal/gcp/store/gcs/store.go
@@ -103,6 +103,10 @@ type ObjectStore interface {
 	GetObjectGeneration(ctx context.Context, bucket, name, generation string) (ObjectMeta, error)
 	// DeleteObjectMeta removes every generation of the object.
 	DeleteObjectMeta(ctx context.Context, bucket, name string) error
+	// TombstoneObjectMeta marks the live generation non-live (timeDeleted set)
+	// and returns it, leaving any prior non-live generations untouched. Used
+	// for versioned-object deletion so a non-live tombstone is retained.
+	TombstoneObjectMeta(ctx context.Context, bucket, name string) (ObjectMeta, error)
 	// ListObjects returns the live generation of every object in the bucket,
 	// sorted by name. Prefix, delimiter, and pageToken pagination are applied
 	// by the provider.


### PR DESCRIPTION
Postgres DeleteObjectMeta now returns ErrNoSuchObject on zero rows, and ObjectsDelete returns 404 NotFound for a missing object. Versioned buckets tombstone the live generation instead of hard-deleting all generations, so a non-live tombstone remains for the versions query flag. ensureBucketExists guards PutObjectMeta and PutObjectGeneration transactions against orphan object rows.