### PR TITLE
ci: fix test job on main (build path + integration timeout)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: go mod download
 
       - name: Build server
-        run: go build -o jaiscloud ./cmd/jaiscloud/
+        run: go build -o jaiscloud ./cmd/jaiscloud-aws/
 
       - name: Start jaiscloud server (background)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           AWS_ACCESS_KEY_ID: test
           AWS_SECRET_ACCESS_KEY: test
           AWS_REGION: us-east-1
-        run: go test ./tests/integration/ -v -count=1 -timeout 120s
+        run: go test ./tests/integration/ -v -count=1 -timeout 300s
 
       - name: Upload server log (on failure)
         if: failure()


### PR DESCRIPTION
Two fixes for the `test` job on `main`:

1. **Correct the build path** — the `Build server` step used `go build -o jaiscloud ./cmd/jaiscloud/`, but the directory is `cmd/jaiscloud-aws/` (the `gcp` branch already has this fix; `main` did not), so the job failed at build with `stat .../cmd/jaiscloud: directory not found`.
2. **Raise the integration timeout** — `-timeout 120s` → `-timeout 300s`. The AWS integration suite takes ~3.3min (dominated by `TestSQS_QueueDeletedRecentlyExpires`'s 61s sleep), so 120s caused intermittent `test timed out after 2m0s` failures. Verified locally: passes in ~197s with 300s.