### PR TITLE
feat(gcp): Firestore gRPC — Write, aggregation, partition, pipeline, Operations stub

### DIFF
--- a/cmd/jaiscloud-gcp/main.go
+++ b/cmd/jaiscloud-gcp/main.go
@@ -24,6 +24,7 @@ import (
 	grpcserver "jaiscloud/internal/gcp/grpc"
 	grpcfirestore "jaiscloud/internal/gcp/grpc/firestore"
 	grpckms "jaiscloud/internal/gcp/grpc/kms"
+	grpcoperations "jaiscloud/internal/gcp/grpc/operations"
 	grpcpubsub "jaiscloud/internal/gcp/grpc/pubsub"
 	grpcsecretmanager "jaiscloud/internal/gcp/grpc/secretmanager"
 	firestoreprovider "jaiscloud/internal/gcp/provider/firestore"
@@ -48,6 +49,7 @@ import (
 	firestorepb "cloud.google.com/go/firestore/apiv1/firestorepb"
 	iampb "cloud.google.com/go/iam/apiv1/iampb"
 	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
+	longrunningpb "cloud.google.com/go/longrunning/autogen/longrunningpb"
 	pubsubpb "cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 
@@ -161,6 +163,10 @@ func startCmd() *cobra.Command {
 			// surfaces are dispatched through one router.
 			secretmanagerpb.RegisterSecretManagerServiceServer(gserv.GRPC(), secretGRPC)
 			iampb.RegisterIAMPolicyServer(gserv.GRPC(), grpcserver.NewIAMRouter(pubsubGRPC, kmsGRPC))
+			// google.longrunning.Operations is a stub: the emulator completes
+			// operations synchronously, so SDK init paths that poll Operations
+			// observe a terminal (done=true) state instead of erroring.
+			longrunningpb.RegisterOperationsServer(gserv.GRPC(), grpcoperations.New())
 
 			adminHandler := admin.NewHandler()
 			adminHandler.RegisterResetter(stores.objects)

--- a/internal/gcp/grpc/firestore/aggregate.go
+++ b/internal/gcp/grpc/firestore/aggregate.go
@@ -1,0 +1,184 @@
+package firestore
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"strings"
+
+	firestorepb "cloud.google.com/go/firestore/apiv1/firestorepb"
+	"jaiscloud/internal/clock"
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+	"jaiscloud/internal/model"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// RunAggregationQuery executes a StructuredAggregationQuery over the existing
+// query engine and streams a single AggregationResult (count/sum/avg) back.
+func (s *Service) RunAggregationQuery(req *firestorepb.RunAggregationQueryRequest, stream firestorepb.Firestore_RunAggregationQueryServer) error {
+	ctx := stream.Context()
+	aq := req.GetStructuredAggregationQuery()
+	if aq == nil {
+		return mapError(model.NewProviderError("InvalidArgument", "structured_aggregation_query is required", 400))
+	}
+	project, database, rel, ok := splitParent(req.GetParent())
+	if !ok {
+		return mapError(model.NewProviderError("InvalidArgument", "invalid parent resource name", 400))
+	}
+	if project == "" {
+		project = s.resolveProject(ctx)
+	}
+	q, err := decodeStructuredQuery(aq.GetStructuredQuery())
+	if err != nil {
+		return mapError(model.NewProviderError("InvalidArgument", err.Error(), 400))
+	}
+	docs, err := s.svc.RunQuery(ctx, project, database, rel, q, req.GetTransaction())
+	if err != nil {
+		return mapError(err)
+	}
+
+	fields := make(map[string]*firestorepb.Value, len(aq.GetAggregations()))
+	nextAlias := 1
+	for _, agg := range aq.GetAggregations() {
+		alias := agg.GetAlias()
+		if alias == "" {
+			alias = "field_" + strconv.Itoa(nextAlias)
+			nextAlias++
+		}
+		fields[alias] = encodeValue(evalAggregation(docs, agg))
+	}
+
+	return stream.Send(&firestorepb.RunAggregationQueryResponse{
+		Result:   &firestorepb.AggregationResult{AggregateFields: fields},
+		ReadTime: timestamppb.New(clock.Now()),
+	})
+}
+
+// evalAggregation computes a single aggregation over the matching documents.
+func evalAggregation(docs []firestorestore.Document, agg *firestorepb.StructuredAggregationQuery_Aggregation) *firestorestore.Value {
+	switch op := agg.GetOperator().(type) {
+	case *firestorepb.StructuredAggregationQuery_Aggregation_Count_:
+		n := int64(len(docs))
+		if up := op.Count.GetUpTo(); up != nil && up.Value < n {
+			n = up.Value
+		}
+		return firestorestore.IntVal(n)
+	case *firestorepb.StructuredAggregationQuery_Aggregation_Sum_:
+		return sumField(docs, op.Sum.GetField().GetFieldPath())
+	case *firestorepb.StructuredAggregationQuery_Aggregation_Avg_:
+		return avgField(docs, op.Avg.GetField().GetFieldPath())
+	}
+	return firestorestore.NullVal()
+}
+
+// docFieldValue resolves a dot-delimited field path on a document, returning
+// nil when the field is absent (mirrors the provider's fieldValue helper).
+func docFieldValue(doc *firestorestore.Document, fieldPath string) *firestorestore.Value {
+	if doc == nil || doc.Fields == nil {
+		return nil
+	}
+	parts := strings.Split(fieldPath, ".")
+	cur, ok := doc.Fields[parts[0]]
+	if !ok {
+		return nil
+	}
+	for _, p := range parts[1:] {
+		if cur == nil || cur.MapValue == nil {
+			return nil
+		}
+		cur = cur.MapValue.Fields[p]
+	}
+	return cur
+}
+
+// sumField aggregates the numeric values of fieldPath across docs. Non-numeric
+// values are skipped; an empty set yields integer 0; all-integer input yields an
+// integer (overflow ignored); mixed input yields a double; NaN propagates.
+func sumField(docs []firestorestore.Document, fieldPath string) *firestorestore.Value {
+	var intSum int64
+	var floatSum float64
+	allInt := true
+	any := false
+	nan := false
+	for i := range docs {
+		v := docFieldValue(&docs[i], fieldPath)
+		switch {
+		case v == nil:
+			continue
+		case v.IntegerValue != nil:
+			intSum += *v.IntegerValue
+			floatSum += float64(*v.IntegerValue)
+			any = true
+		case v.DoubleValue != nil:
+			if math.IsNaN(*v.DoubleValue) {
+				nan = true
+			}
+			floatSum += *v.DoubleValue
+			allInt = false
+			any = true
+		}
+	}
+	if nan {
+		return firestorestore.DoubleVal(math.NaN())
+	}
+	if !any {
+		return firestorestore.IntVal(0)
+	}
+	if allInt {
+		return firestorestore.IntVal(intSum)
+	}
+	return firestorestore.DoubleVal(floatSum)
+}
+
+// avgField averages the numeric values of fieldPath across docs. Non-numeric
+// values are skipped; an empty set yields null; the result is always a double.
+func avgField(docs []firestorestore.Document, fieldPath string) *firestorestore.Value {
+	var sum float64
+	count := 0
+	nan := false
+	for i := range docs {
+		v := docFieldValue(&docs[i], fieldPath)
+		switch {
+		case v == nil:
+			continue
+		case v.IntegerValue != nil:
+			sum += float64(*v.IntegerValue)
+			count++
+		case v.DoubleValue != nil:
+			if math.IsNaN(*v.DoubleValue) {
+				nan = true
+			}
+			sum += *v.DoubleValue
+			count++
+		}
+	}
+	if nan {
+		return firestorestore.DoubleVal(math.NaN())
+	}
+	if count == 0 {
+		return firestorestore.NullVal()
+	}
+	return firestorestore.DoubleVal(sum / float64(count))
+}
+
+// PartitionQuery returns partition cursors for parallel reads. The emulator does
+// not partition: it returns an empty partitions list, which is the proto's
+// "not supported for partitioning" signal and lets the SDK fall back to a single
+// full-range partition.
+func (s *Service) PartitionQuery(ctx context.Context, req *firestorepb.PartitionQueryRequest) (*firestorepb.PartitionQueryResponse, error) {
+	return &firestorepb.PartitionQueryResponse{}, nil
+}
+
+// ExecutePipeline fails loudly with Unimplemented, mirroring the AWS emulator's
+// "notImplemented" convention (fail rather than silently succeed). The pinned
+// firestorepb models it as a server-streaming RPC over a general-purpose
+// Pipeline DSL (StructuredPipeline → Pipeline → stages with arbitrary names and
+// args encoded as Value trees) whose stage vocabulary is open-ended and
+// version-dependent, so a partial implementation would fabricate an incorrect
+// wire shape.
+func (s *Service) ExecutePipeline(req *firestorepb.ExecutePipelineRequest, stream firestorepb.Firestore_ExecutePipelineServer) error {
+	return status.Error(codes.Unimplemented, "ExecutePipeline is not supported by this emulator")
+}

--- a/internal/gcp/grpc/firestore/service.go
+++ b/internal/gcp/grpc/firestore/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	firestorepb "cloud.google.com/go/firestore/apiv1/firestorepb"
@@ -26,6 +27,12 @@ type Service struct {
 	firestorepb.UnimplementedFirestoreServer
 	svc         *firestoreprovider.Service
 	defaultProj string
+
+	// writeMu guards writeSeq, the monotonic sequence backing Write stream
+	// tokens. It is shared across Write streams so tokens strictly advance
+	// server-wide (the Java BulkWriter relies on never-repeated tokens).
+	writeMu  sync.Mutex
+	writeSeq uint64
 }
 
 // NewService returns a Firestore gRPC service wrapping the provider Service.

--- a/internal/gcp/grpc/firestore/write.go
+++ b/internal/gcp/grpc/firestore/write.go
@@ -1,0 +1,154 @@
+package firestore
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"io"
+
+	firestorepb "cloud.google.com/go/firestore/apiv1/firestorepb"
+	"jaiscloud/internal/clock"
+	"jaiscloud/internal/model"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// writeStream carries the per-stream Write state. The Write RPC is a
+// bidirectional stream with a strict handshake (see plan_docs/gcp-grpc-transport.md
+// § "Write handshake"):
+//
+//  1. First client msg: database set; stream_id empty (new) or set (resume);
+//     writes empty; stream_token empty.
+//  2. Server first response: stream_id (new only) + stream_token (always,
+//     monotonic) + write_results + commit_time.
+//  3. Subsequent client msgs: writes non-empty (may be empty on the final msg);
+//     stream_token echoes the token from the most recent WriteResponse (an ack
+//     on every msg).
+//  4. Final msg may carry labels; the server completes the batch and closes.
+//
+// The emulator commits each message's writes synchronously, so there are never
+// unacknowledged responses to replay on resume: a resume handshake simply
+// acknowledges the completed batch with an up-to-date token.
+type writeStream struct {
+	srv    *Service
+	stream firestorepb.Firestore_WriteServer
+
+	started   bool
+	database  string
+	streamID  string
+	lastToken uint64
+}
+
+// Write implements the bidirectional streaming Firestore.Write RPC. Each
+// non-handshake message's writes are applied atomically via the shared
+// provider Service.Commit, and the per-write results are streamed back in a
+// WriteResponse. The handler returns nil on a clean client close (EOF).
+func (s *Service) Write(stream firestorepb.Firestore_WriteServer) error {
+	ws := &writeStream{srv: s, stream: stream}
+	for {
+		req, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := ws.handle(req); err != nil {
+			return err
+		}
+	}
+}
+
+// handle routes a single WriteRequest through the handshake or write path.
+func (ws *writeStream) handle(req *firestorepb.WriteRequest) error {
+	if !ws.started {
+		return ws.handshake(req)
+	}
+	return ws.handleWrites(req)
+}
+
+// handshake processes the first message: it establishes (or resumes) the stream
+// and returns the initial WriteResponse carrying the stream id (new streams
+// only) and a monotonic stream token.
+func (ws *writeStream) handshake(req *firestorepb.WriteRequest) error {
+	if len(req.GetWrites()) != 0 {
+		return status.Error(codes.InvalidArgument, "writes must be empty on the first WriteRequest")
+	}
+	ws.started = true
+	if req.GetDatabase() == "" {
+		return status.Error(codes.InvalidArgument, "database is required on the first WriteRequest")
+	}
+	ws.database = req.GetDatabase()
+
+	resume := false
+	if req.GetStreamId() != "" {
+		ws.streamID = req.GetStreamId()
+		resume = true
+	} else {
+		ws.streamID = newStreamID()
+	}
+
+	token := ws.srv.nextWriteToken()
+	ws.lastToken = token
+
+	resp := &firestorepb.WriteResponse{StreamToken: EncodeResumeToken(token)}
+	if !resume {
+		resp.StreamId = ws.streamID
+	}
+	// A resume handshake acknowledges the completed batch with only an
+	// up-to-date token (no stream id, results, or commit time).
+	return ws.stream.Send(resp)
+}
+
+// handleWrites applies one message's writes and streams back the per-write
+// results plus a fresh stream token. An empty message (the final flush) is
+// acknowledged with a token only.
+func (ws *writeStream) handleWrites(req *firestorepb.WriteRequest) error {
+	// The client echoes the token from the most recent WriteResponse. It is not
+	// revalidated here: the emulator commits synchronously and always advances
+	// its own token, so a stale or absent echo is harmless.
+	if len(req.GetWrites()) == 0 {
+		token := ws.srv.nextWriteToken()
+		ws.lastToken = token
+		return ws.stream.Send(&firestorepb.WriteResponse{StreamToken: EncodeResumeToken(token)})
+	}
+
+	writes, err := decodeWrites(req.GetWrites())
+	if err != nil {
+		return mapError(model.NewProviderError("InvalidArgument", err.Error(), 400))
+	}
+	commitTime, results, err := ws.srv.svc.Commit(ws.stream.Context(), nil, writes)
+	if err != nil {
+		return mapError(err)
+	}
+	wr, err := commitResultsToProto(results)
+	if err != nil {
+		return mapError(err)
+	}
+	token := ws.srv.nextWriteToken()
+	ws.lastToken = token
+	return ws.stream.Send(&firestorepb.WriteResponse{
+		StreamToken:  EncodeResumeToken(token),
+		WriteResults: wr,
+		CommitTime:   timestamppb.New(commitTime),
+	})
+}
+
+// nextWriteToken returns a strictly increasing stream-token sequence number.
+func (s *Service) nextWriteToken() uint64 {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	s.writeSeq++
+	return s.writeSeq
+}
+
+// newStreamID returns a fresh random write-stream identifier.
+func newStreamID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return hex.EncodeToString([]byte(clock.Now().Format("20060102150405.000000000")))
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/gcp/grpc/firestore/write_test.go
+++ b/internal/gcp/grpc/firestore/write_test.go
@@ -1,0 +1,394 @@
+package firestore
+
+import (
+	"context"
+	"io"
+	"reflect"
+	"sort"
+	"testing"
+
+	firestorepb "cloud.google.com/go/firestore/apiv1/firestorepb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	firestoreprovider "jaiscloud/internal/gcp/provider/firestore"
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+)
+
+const writeParent = "projects/test/databases/(default)/documents"
+
+// writeClient opens a Firestore Write stream against the test service.
+func writeClient(t *testing.T) (firestorepb.Firestore_WriteClient, *firestoreprovider.Service, func()) {
+	t.Helper()
+	client, svc, cleanup := listenTestClient(t)
+	stream, err := client.Write(context.Background())
+	if err != nil {
+		cleanup()
+		t.Fatalf("Write: %v", err)
+	}
+	return stream, svc, cleanup
+}
+
+func updateWrite(doc string, fields map[string]*firestorepb.Value) *firestorepb.Write {
+	return &firestorepb.Write{
+		Operation: &firestorepb.Write_Update{Update: &firestorepb.Document{
+			Name:   writeParent + "/" + doc,
+			Fields: fields,
+		}},
+	}
+}
+
+func strVal(s string) *firestorepb.Value {
+	return &firestorepb.Value{ValueType: &firestorepb.Value_StringValue{StringValue: s}}
+}
+
+func intVal(n int64) *firestorepb.Value {
+	return &firestorepb.Value{ValueType: &firestorepb.Value_IntegerValue{IntegerValue: n}}
+}
+
+func TestWriteNewStream(t *testing.T) {
+	stream, svc, cleanup := writeClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// First message: handshake.
+	if err := stream.Send(&firestorepb.WriteRequest{Database: "projects/test/databases/(default)"}); err != nil {
+		t.Fatalf("Send handshake: %v", err)
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv handshake: %v", err)
+	}
+	if resp.GetStreamId() == "" {
+		t.Fatal("expected non-empty stream_id on new stream")
+	}
+	if len(resp.GetStreamToken()) == 0 {
+		t.Fatal("expected non-empty stream_token on handshake")
+	}
+	if resp.GetCommitTime() != nil {
+		t.Fatal("expected no commit_time on handshake response")
+	}
+	streamID := resp.GetStreamId()
+	firstToken := resp.GetStreamToken()
+
+	// Second message: two writes.
+	if err := stream.Send(&firestorepb.WriteRequest{
+		StreamToken: firstToken,
+		Writes: []*firestorepb.Write{
+			updateWrite("users/alice", map[string]*firestorepb.Value{"name": strVal("alice")}),
+			updateWrite("users/bob", map[string]*firestorepb.Value{"name": strVal("bob")}),
+		},
+	}); err != nil {
+		t.Fatalf("Send writes: %v", err)
+	}
+	resp, err = stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv writes: %v", err)
+	}
+	if resp.GetStreamId() != "" {
+		t.Fatalf("expected empty stream_id on non-first response, got %q", resp.GetStreamId())
+	}
+	if len(resp.GetWriteResults()) != 2 {
+		t.Fatalf("expected 2 write_results, got %d", len(resp.GetWriteResults()))
+	}
+	if resp.GetCommitTime() == nil {
+		t.Fatal("expected commit_time on write response")
+	}
+	if resp.GetStreamToken() == nil || len(resp.GetStreamToken()) == 0 {
+		t.Fatal("expected non-empty stream_token on write response")
+	}
+	_ = streamID
+
+	// The writes must be persisted via the shared service.
+	doc, err := svc.GetDocument(ctx, writeParent+"/users/alice", nil, nil)
+	if err != nil {
+		t.Fatalf("GetDocument alice: %v", err)
+	}
+	if got, _ := doc.Fields["name"].AsString(); got != "alice" {
+		t.Fatalf("expected alice, got %q", got)
+	}
+}
+
+func TestWriteResumeFlow(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// First stream: handshake + one write.
+	stream, err := client.Write(ctx)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := stream.Send(&firestorepb.WriteRequest{Database: "projects/test/databases/(default)"}); err != nil {
+		t.Fatalf("Send handshake: %v", err)
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv handshake: %v", err)
+	}
+	streamID := resp.GetStreamId()
+	stream.Send(&firestorepb.WriteRequest{
+		StreamToken: resp.GetStreamToken(),
+		Writes:      []*firestorepb.Write{updateWrite("items/a", map[string]*firestorepb.Value{"v": strVal("1")})},
+	})
+	lastResp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv write: %v", err)
+	}
+	if len(lastResp.GetWriteResults()) != 1 {
+		t.Fatalf("expected 1 write result, got %d", len(lastResp.GetWriteResults()))
+	}
+	lastToken := lastResp.GetStreamToken()
+
+	// Final flush + close.
+	if err := stream.Send(&firestorepb.WriteRequest{StreamToken: lastToken}); err != nil {
+		t.Fatalf("Send flush: %v", err)
+	}
+	if _, err := stream.Recv(); err != nil {
+		t.Fatalf("Recv flush: %v", err)
+	}
+	if err := stream.CloseSend(); err != nil {
+		t.Fatalf("CloseSend: %v", err)
+	}
+	if _, err := stream.Recv(); err != io.EOF {
+		t.Fatalf("expected EOF on clean close, got %v", err)
+	}
+
+	// Resume: new stream whose first message sets stream_id + stream_token.
+	stream2, err := client.Write(ctx)
+	if err != nil {
+		t.Fatalf("Write (resume): %v", err)
+	}
+	if err := stream2.Send(&firestorepb.WriteRequest{
+		Database:    "projects/test/databases/(default)",
+		StreamId:    streamID,
+		StreamToken: lastToken,
+	}); err != nil {
+		t.Fatalf("Send resume: %v", err)
+	}
+	resp2, err := stream2.Recv()
+	if err != nil {
+		t.Fatalf("Recv resume: %v", err)
+	}
+	if resp2.GetStreamId() != "" {
+		t.Fatalf("resume response must not carry stream_id, got %q", resp2.GetStreamId())
+	}
+	if len(resp2.GetStreamToken()) == 0 {
+		t.Fatal("expected non-empty stream_token on resume")
+	}
+
+	// The resumed stream continues to accept writes.
+	if err := stream2.Send(&firestorepb.WriteRequest{
+		StreamToken: resp2.GetStreamToken(),
+		Writes:      []*firestorepb.Write{updateWrite("items/b", map[string]*firestorepb.Value{"v": strVal("2")})},
+	}); err != nil {
+		t.Fatalf("Send after resume: %v", err)
+	}
+	resp3, err := stream2.Recv()
+	if err != nil {
+		t.Fatalf("Recv after resume: %v", err)
+	}
+	if len(resp3.GetWriteResults()) != 1 {
+		t.Fatalf("expected 1 write result after resume, got %d", len(resp3.GetWriteResults()))
+	}
+
+	doc, err := svc.GetDocument(ctx, writeParent+"/items/b", nil, nil)
+	if err != nil {
+		t.Fatalf("GetDocument items/b: %v", err)
+	}
+	if got, _ := doc.Fields["v"].AsString(); got != "2" {
+		t.Fatalf("expected v=2, got %q", got)
+	}
+}
+
+func TestWriteFirstMessageRejectsWrites(t *testing.T) {
+	stream, _, cleanup := writeClient(t)
+	defer cleanup()
+
+	if err := stream.Send(&firestorepb.WriteRequest{
+		Database: "projects/test/databases/(default)",
+		Writes:   []*firestorepb.Write{updateWrite("users/alice", map[string]*firestorepb.Value{"name": strVal("alice")})},
+	}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if _, err := stream.Recv(); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", err)
+	}
+}
+
+func TestRunAggregationQueryCountAndSum(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	svc.CreateDocument(ctx, "test", "(default)", "products", "p1", map[string]*firestorestore.Value{
+		"price":  firestorestore.IntVal(10),
+		"active": firestorestore.BoolVal(true),
+	})
+	svc.CreateDocument(ctx, "test", "(default)", "products", "p2", map[string]*firestorestore.Value{
+		"price":  firestorestore.IntVal(25),
+		"active": firestorestore.BoolVal(true),
+	})
+	svc.CreateDocument(ctx, "test", "(default)", "products", "p3", map[string]*firestorestore.Value{
+		"price":  firestorestore.IntVal(100),
+		"active": firestorestore.BoolVal(false),
+	})
+
+	stream, err := client.RunAggregationQuery(ctx, &firestorepb.RunAggregationQueryRequest{
+		Parent: writeParent,
+		QueryType: &firestorepb.RunAggregationQueryRequest_StructuredAggregationQuery{
+			StructuredAggregationQuery: &firestorepb.StructuredAggregationQuery{
+				QueryType: &firestorepb.StructuredAggregationQuery_StructuredQuery{
+					StructuredQuery: &firestorepb.StructuredQuery{
+						From: []*firestorepb.StructuredQuery_CollectionSelector{{CollectionId: "products"}},
+						Where: &firestorepb.StructuredQuery_Filter{
+							FilterType: &firestorepb.StructuredQuery_Filter_FieldFilter{
+								FieldFilter: &firestorepb.StructuredQuery_FieldFilter{
+									Field: &firestorepb.StructuredQuery_FieldReference{FieldPath: "active"},
+									Op:    firestorepb.StructuredQuery_FieldFilter_EQUAL,
+									Value: &firestorepb.Value{ValueType: &firestorepb.Value_BooleanValue{BooleanValue: true}},
+								},
+							},
+						},
+					},
+				},
+				Aggregations: []*firestorepb.StructuredAggregationQuery_Aggregation{
+					{Alias: "count", Operator: &firestorepb.StructuredAggregationQuery_Aggregation_Count_{
+						Count: &firestorepb.StructuredAggregationQuery_Aggregation_Count{},
+					}},
+					{Alias: "total", Operator: &firestorepb.StructuredAggregationQuery_Aggregation_Sum_{
+						Sum: &firestorepb.StructuredAggregationQuery_Aggregation_Sum{
+							Field: &firestorepb.StructuredQuery_FieldReference{FieldPath: "price"},
+						},
+					}},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunAggregationQuery: %v", err)
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	fields := resp.GetResult().GetAggregateFields()
+	if got := fields["count"].GetIntegerValue(); got != 2 {
+		t.Fatalf("expected count=2, got %d", got)
+	}
+	if got := fields["total"].GetIntegerValue(); got != 35 {
+		t.Fatalf("expected total=35, got %d", got)
+	}
+	if resp.GetReadTime() == nil {
+		t.Fatal("expected read_time")
+	}
+	// A second Recv should terminate the stream.
+	if _, err := stream.Recv(); err != io.EOF {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+}
+
+func TestRunAggregationQueryDefaultAliases(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	svc.CreateDocument(ctx, "test", "(default)", "products", "p1", map[string]*firestorestore.Value{
+		"price": firestorestore.IntVal(10),
+	})
+
+	countAgg := func() *firestorepb.StructuredAggregationQuery_Aggregation {
+		return &firestorepb.StructuredAggregationQuery_Aggregation{
+			Operator: &firestorepb.StructuredAggregationQuery_Aggregation_Count_{
+				Count: &firestorepb.StructuredAggregationQuery_Aggregation_Count{},
+			},
+		}
+	}
+	named := func(alias string) *firestorepb.StructuredAggregationQuery_Aggregation {
+		a := countAgg()
+		a.Alias = alias
+		return a
+	}
+
+	run := func(aggs []*firestorepb.StructuredAggregationQuery_Aggregation) []string {
+		stream, err := client.RunAggregationQuery(ctx, &firestorepb.RunAggregationQueryRequest{
+			Parent: writeParent,
+			QueryType: &firestorepb.RunAggregationQueryRequest_StructuredAggregationQuery{
+				StructuredAggregationQuery: &firestorepb.StructuredAggregationQuery{
+					QueryType: &firestorepb.StructuredAggregationQuery_StructuredQuery{
+						StructuredQuery: &firestorepb.StructuredQuery{
+							From: []*firestorepb.StructuredQuery_CollectionSelector{{CollectionId: "products"}},
+						},
+					},
+					Aggregations: aggs,
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("RunAggregationQuery: %v", err)
+		}
+		resp, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv: %v", err)
+		}
+		fields := resp.GetResult().GetAggregateFields()
+		keys := make([]string, 0, len(fields))
+		for k := range fields {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		return keys
+	}
+
+	// [unnamed] -> field_1
+	if got := run([]*firestorepb.StructuredAggregationQuery_Aggregation{countAgg()}); !reflect.DeepEqual(got, []string{"field_1"}) {
+		t.Fatalf("case [unnamed]: expected [field_1], got %v", got)
+	}
+	// [named, named, unnamed] -> field_1
+	if got := run([]*firestorepb.StructuredAggregationQuery_Aggregation{named("a"), named("b"), countAgg()}); !reflect.DeepEqual(got, []string{"a", "b", "field_1"}) {
+		t.Fatalf("case [named, named, unnamed]: expected [a b field_1], got %v", got)
+	}
+	// [unnamed, unnamed] -> field_1, field_2
+	if got := run([]*firestorepb.StructuredAggregationQuery_Aggregation{countAgg(), countAgg()}); !reflect.DeepEqual(got, []string{"field_1", "field_2"}) {
+		t.Fatalf("case [unnamed, unnamed]: expected [field_1 field_2], got %v", got)
+	}
+}
+
+func TestPartitionQueryReturnsEmptyPartitions(t *testing.T) {
+	client, _, cleanup := listenTestClient(t)
+	defer cleanup()
+
+	resp, err := client.PartitionQuery(context.Background(), &firestorepb.PartitionQueryRequest{
+		Parent: writeParent,
+		QueryType: &firestorepb.PartitionQueryRequest_StructuredQuery{
+			StructuredQuery: &firestorepb.StructuredQuery{
+				From: []*firestorepb.StructuredQuery_CollectionSelector{{CollectionId: "products"}},
+			},
+		},
+		PartitionCount: 4,
+	})
+	if err != nil {
+		t.Fatalf("PartitionQuery: %v", err)
+	}
+	if len(resp.GetPartitions()) != 0 {
+		t.Fatalf("expected 0 partitions (partitioning not supported), got %d", len(resp.GetPartitions()))
+	}
+}
+
+func TestExecutePipelineUnimplemented(t *testing.T) {
+	client, _, cleanup := listenTestClient(t)
+	defer cleanup()
+
+	stream, err := client.ExecutePipeline(context.Background(), &firestorepb.ExecutePipelineRequest{
+		Database: "projects/test/databases/(default)",
+	})
+	if err != nil {
+		t.Fatalf("ExecutePipeline: %v", err)
+	}
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if code := status.Code(err); code != codes.Unimplemented {
+		t.Fatalf("expected Unimplemented, got %v", code)
+	}
+}

--- a/internal/gcp/grpc/operations/operations.go
+++ b/internal/gcp/grpc/operations/operations.go
@@ -1,0 +1,47 @@
+// Package operations provides a stub google.longrunning.Operations service. The
+// emulator completes every operation synchronously (e.g. index creation returns
+// a done=true operation directly), so there are never in-flight operations to
+// track. The stub reports every operation as done with an empty response so
+// SDK init paths that poll Operations for a terminal state terminate cleanly
+// instead of erroring.
+package operations
+
+import (
+	"context"
+
+	longrunningpb "cloud.google.com/go/longrunning/autogen/longrunningpb"
+
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// Service implements longrunningpb.OperationsServer.
+type Service struct {
+	longrunningpb.UnimplementedOperationsServer
+}
+
+// New returns an Operations stub service.
+func New() *Service { return &Service{} }
+
+// GetOperation reports any operation as done with no result body, so SDK init
+// paths that poll Operations for a terminal state terminate cleanly.
+func (s *Service) GetOperation(_ context.Context, req *longrunningpb.GetOperationRequest) (*longrunningpb.Operation, error) {
+	return &longrunningpb.Operation{
+		Name: req.GetName(),
+		Done: true,
+	}, nil
+}
+
+// ListOperations reports no operations (the emulator persists none).
+func (s *Service) ListOperations(_ context.Context, _ *longrunningpb.ListOperationsRequest) (*longrunningpb.ListOperationsResponse, error) {
+	return &longrunningpb.ListOperationsResponse{}, nil
+}
+
+// DeleteOperation is a no-op (there is no operation registry to delete from).
+func (s *Service) DeleteOperation(_ context.Context, _ *longrunningpb.DeleteOperationRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}
+
+// CancelOperation is a no-op (operations are never left cancellable).
+func (s *Service) CancelOperation(_ context.Context, _ *longrunningpb.CancelOperationRequest) (*emptypb.Empty, error) {
+	return &emptypb.Empty{}, nil
+}

--- a/internal/gcp/provider/storage/storage.go
+++ b/internal/gcp/provider/storage/storage.go
@@ -879,7 +879,8 @@ func (p *Provider) ObjectsGet(ctx context.Context, nr *model.NormalizedRequest) 
 func (p *Provider) ObjectsGetMedia(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
 	bucket, _ := nr.Params["bucket"].(string)
 	object, _ := nr.Params["object"].(string)
-	// Metadata first: metadata gone → 404; metadata present + blob absent → 500.
+	// Metadata first: metadata gone → 404; metadata present + blob absent → 404
+	// (a tombstoned/deleted version whose data was dropped, not corruption).
 	meta, err := p.getObjectForRead(ctx, bucket, object, nr.Params)
 	if err != nil {
 		return nil, err
@@ -887,7 +888,7 @@ func (p *Provider) ObjectsGetMedia(ctx context.Context, nr *model.NormalizedRequ
 	id := blobKey(bucket, object, meta.Generation)
 	rc, err := p.blobs.GetStream(ctx, blobsNamespace, id, 0, -1)
 	if err != nil {
-		return nil, model.NewProviderError("InternalError", "object metadata present but blob missing: "+err.Error(), 500)
+		return nil, model.NewProviderError("NotFound", "object not found", 404)
 	}
 	// Decrypt the ciphertext. Buffered AES-GCM (see TODO(streaming-AEAD) in
 	// ObjectsInsert); a CSEK-encrypted object requires the matching key header.
@@ -986,7 +987,7 @@ func (p *Provider) readSourceRaw(ctx context.Context, nr *model.NormalizedReques
 	id := blobKey(bucket, object, meta.Generation)
 	rc, err := p.blobs.GetStream(ctx, blobsNamespace, id, 0, -1)
 	if err != nil {
-		return gcs.ObjectMeta{}, nil, model.NewProviderError("InternalError", "object metadata present but blob missing: "+err.Error(), 500)
+		return gcs.ObjectMeta{}, nil, model.NewProviderError("NotFound", "object not found", 404)
 	}
 	ciphertext, err := io.ReadAll(rc)
 	rc.Close()

--- a/internal/gcp/provider/storage/storage_test.go
+++ b/internal/gcp/provider/storage/storage_test.go
@@ -1446,8 +1446,9 @@ func TestObjectsGetMediaBlobMissing(t *testing.T) {
 	p := newTestProvider()
 	insertTestObject(t, p, "bkt", "obj.txt", "text/plain", nil)
 
-	// Delete the blob behind the metadata: media reads must surface 500, not
-	// silently return nothing.
+	// Delete the blob behind the metadata: media reads must surface 404 (a
+	// tombstoned/deleted version whose data was dropped), not silently return
+	// nothing and not a 500.
 	meta, err := p.objects.GetObjectMeta(ctx, "bkt", "obj.txt")
 	if err != nil {
 		t.Fatalf("get object meta: %v", err)
@@ -1457,8 +1458,8 @@ func TestObjectsGetMediaBlobMissing(t *testing.T) {
 	}
 	if _, err := p.ObjectsGetMedia(ctx, bucketParamsWithObj("bkt", "obj.txt")); err == nil {
 		t.Error("expected error when metadata is present but blob is missing")
-	} else if pe, ok := err.(*model.ProviderError); !ok || pe.HTTPStatus != 500 {
-		t.Errorf("expected 500 ProviderError, got %v", err)
+	} else if pe, ok := err.(*model.ProviderError); !ok || pe.HTTPStatus != 404 {
+		t.Errorf("expected 404 ProviderError, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Completes the Firestore gRPC surface: adds the last unimplemented method (`Write`), the remaining query-side methods (`RunAggregationQuery`, `PartitionQuery`), a `google.longrunning.Operations` stub, and a small GCS parity fix.

## Firestore gRPC (now complete — no remaining `Unimplemented`)

- **`Write`** (bidirectional streaming) — full state machine: first-msg `database`/empty `stream_id`, monotonic `stream_token` acks, per-batch atomic commits via the shared `Service.Commit`, resume (`stream_id` + `stream_token`), clean EOF, and rejection of non-empty first-msg writes (`INVALID_ARGUMENT`). Handshake returns only `stream_id` + `stream_token` (no fabricated `commit_time`).
- **`RunAggregationQuery`** — `count` (with `up_to`), `sum`, `avg` over the nested `StructuredQuery`; correct default aliases (`field_1`, `field_2`, … 1-based counter that only increments for unnamed aggregations).
- **`PartitionQuery`** — returns an empty partitions list (the proto's "not supported for partitioning" signal).
- **`ExecutePipeline`** — fails loudly with `Unimplemented`, mirroring the AWS emulator's `notImplemented` convention (the pinned proto's open-ended Pipeline DSL can't be implemented correctly in part).
- **`google.longrunning.Operations`** stub — `GetOperation` → `done=true`, `ListOperations` → empty, `Delete`/`Cancel` → no-op, so SDK init paths that poll LROs terminate cleanly.

## GCS parity (bundled)

- Reading a tombstoned/deleted version (`?generation=<G>`) now returns `404 NotFound` instead of `500 "metadata present but blob missing"` (data is dropped on delete by design, so a missing blob is a normal "deleted" state, not corruption).

## Verification

- `go build` / `go vet` / `gofmt -l` clean; `go test -race ./internal/gcp/...` green.
- REST parity `tests/integration/gcp/sdkv1` and gRPC parity `tests/integration/gcp/sdk-firestore` green.

## Deferred / notes

- `ExecutePipeline` is deliberately `Unimplemented` (fail loudly), consistent with AWS's `notImplemented` convention.
