### PR TITLE
feat(gcp): Cloud Functions v1 emulator (Lambda analogue)

### DIFF
--- a/cmd/jaiscloud-gcp/main.go
+++ b/cmd/jaiscloud-gcp/main.go
@@ -18,6 +18,7 @@ import (
 	"jaiscloud/internal/certstore"
 	"jaiscloud/internal/clock"
 	"jaiscloud/internal/config"
+	lambdaexec "jaiscloud/internal/executor/lambda"
 	"jaiscloud/internal/gateway"
 	gcpadapter "jaiscloud/internal/gcp/adapter"
 	"jaiscloud/internal/gcp/crypto"
@@ -28,6 +29,7 @@ import (
 	grpcpubsub "jaiscloud/internal/gcp/grpc/pubsub"
 	grpcsecretmanager "jaiscloud/internal/gcp/grpc/secretmanager"
 	firestoreprovider "jaiscloud/internal/gcp/provider/firestore"
+	functionsprovider "jaiscloud/internal/gcp/provider/functions"
 	iamprovider "jaiscloud/internal/gcp/provider/iam"
 	kmsprovider "jaiscloud/internal/gcp/provider/kms"
 	pubsubprovider "jaiscloud/internal/gcp/provider/pubsub"
@@ -35,6 +37,7 @@ import (
 	storageprovider "jaiscloud/internal/gcp/provider/storage"
 	gcpstore "jaiscloud/internal/gcp/store"
 	firestorestore "jaiscloud/internal/gcp/store/firestore"
+	functionsstore "jaiscloud/internal/gcp/store/functions"
 	"jaiscloud/internal/gcp/store/gcs"
 	kmsstore "jaiscloud/internal/gcp/store/kms"
 	pubsubstore "jaiscloud/internal/gcp/store/pubsub"
@@ -134,13 +137,27 @@ func startCmd() *cobra.Command {
 			pubsubP := pubsubprovider.New(stores.resources, stores.messages, crypto.NewEnvelopeEncryptor(stores.keys))
 			firestoreP := firestoreprovider.New(stores.documents, stores.resources)
 
+			// Cloud Functions reuses the Lambda executor: mock echo by default,
+			// Docker/K8s under JAISCLOUD_EXECUTOR_MODE.
+			lambdaMode, lambdaModeSrc := config.ExecutorMode("lambda", "mock")
+			lambdaCfg := lambdaexec.DefaultLambdaConfig()
+			lambdaCfg.Mode = lambdaMode
+			lambdaCfg.Region = cfg.Region
+			lambdaCfg.InstanceID = instanceID
+			lambdaCfg = lambdaexec.LambdaConfigFrom(lambdaCfg)
+			lambdaExec := lambdaexec.NewExecutor(lambdaCfg)
+			defer lambdaExec.Close()
+			slog.Info("lambda executor", "mode", lambdaMode, "source", lambdaModeSrc)
+			functionsP := functionsprovider.New(stores.functions, stores.resources, lambdaExec)
+
 			reg := provider.NewRegistry().
 				Register(storageP).
 				Register(secretP).
 				Register(kmsP).
 				Register(iamP).
 				Register(pubsubP).
-				Register(firestoreP)
+				Register(firestoreP).
+				Register(functionsP)
 
 			// gRPC transport shares the SAME Firestore provider Service as the
 			// REST adapter, so both transports use one transaction read-set
@@ -174,6 +191,7 @@ func startCmd() *cobra.Command {
 			adminHandler.RegisterResetter(stores.secrets)
 			adminHandler.RegisterResetter(stores.keys)
 			adminHandler.RegisterResetter(stores.documents)
+			adminHandler.RegisterResetter(stores.functions)
 			adminHandler.RegisterResetter(stores.resources)
 			adminHandler.RegisterResetter(stores.blobs)
 			adminHandler.RegisterResetter(storageP)
@@ -196,6 +214,9 @@ func startCmd() *cobra.Command {
 			}
 			if snap, ok := stores.documents.(admin.Snapshotter); ok {
 				adminHandler.RegisterSnapshotter("firestore_documents", snap)
+			}
+			if snap, ok := stores.functions.(admin.Snapshotter); ok {
+				adminHandler.RegisterSnapshotter("functions", snap)
 			}
 			if sb, ok := stores.blobs.(admin.SnapshotBlobStore); ok {
 				adminHandler.RegisterBlobStore(sb)
@@ -357,6 +378,7 @@ type stores struct {
 	secrets   secretmanagerstore.Store
 	keys      kmsstore.Store
 	documents firestorestore.FirestoreStore
+	functions functionsstore.Store
 	resources store.ResourceStore
 	blobs     blobfs.BlobStore
 	close     func()
@@ -383,6 +405,7 @@ func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*st
 			secrets:   secretmanagerstore.NewPostgresStore(pg.Pool()),
 			keys:      kmsstore.NewPostgresStore(pg.Pool()),
 			documents: firestorestore.NewPostgresStore(pg.Pool()),
+			functions: functionsstore.NewPostgresStore(pg.Pool()),
 			resources: pg,
 			blobs:     blobs,
 			close:     func() { pg.Close() },
@@ -395,6 +418,7 @@ func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*st
 			secrets:   secretmanagerstore.NewMemoryStore(),
 			keys:      kmsstore.NewMemoryStore(),
 			documents: firestorestore.NewMemoryStore(),
+			functions: functionsstore.NewMemoryStore(),
 			resources: store.NewMemoryResourceStore(),
 			blobs:     blobfs.NewMemoryBlobStore(),
 			close:     func() {},
@@ -410,6 +434,7 @@ func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*st
 		secrets:   secretmanagerstore.NewMemoryStore(),
 		keys:      kmsstore.NewMemoryStore(),
 		documents: firestorestore.NewMemoryStore(),
+		functions: functionsstore.NewMemoryStore(),
 		resources: store.NewMemoryResourceStore(),
 		blobs:     blobs,
 		close:     func() {},

--- a/internal/gcp/adapter/jsoncodec.go
+++ b/internal/gcp/adapter/jsoncodec.go
@@ -74,6 +74,16 @@ func (c *JSONCodec) Decode(r *http.Request, body []byte) (*model.NormalizedReque
 		}
 	}
 
+	// Cloud Functions: surface the location segment for store scoping.
+	if resourceType == "functions" {
+		for i, s := range rest {
+			if s == "locations" && i+1 < len(rest) {
+				nr.Params["location"] = rest[i+1]
+				break
+			}
+		}
+	}
+
 	isCollection := len(rest) > 0 && rest[len(rest)-1] == resourceType
 
 	nr.Action = deriveAction(resourceType, isCollection, name, r.Method, custom)
@@ -158,6 +168,8 @@ func detectResourceType(segs []string) string {
 			hasKeyRings = true
 		case "serviceAccounts":
 			hasServiceAccounts = true
+		case "functions":
+			return "functions"
 		}
 	}
 	if hasVersions {
@@ -285,6 +297,19 @@ func deriveAction(resourceType string, isCollection bool, name, method, custom s
 			case "listCollectionIds":
 				return "ListCollectionIds"
 			}
+		case "functions":
+			switch custom {
+			case "call":
+				return "CallFunction"
+			case "generateUploadUrl":
+				return "GenerateUploadUrl"
+			case "getIamPolicy":
+				return "FunctionGetIamPolicy"
+			case "setIamPolicy":
+				return "FunctionSetIamPolicy"
+			case "testIamPermissions":
+				return "FunctionTestIamPermissions"
+			}
 		}
 	}
 
@@ -410,6 +435,19 @@ func deriveAction(resourceType string, isCollection bool, name, method, custom s
 			return "GetIndex"
 		case method == http.MethodDelete:
 			return "DeleteIndex"
+		}
+	case "functions":
+		switch {
+		case isCollection && method == http.MethodPost:
+			return "CreateFunction"
+		case isCollection && method == http.MethodGet:
+			return "ListFunctions"
+		case method == http.MethodPatch:
+			return "UpdateFunction"
+		case method == http.MethodDelete:
+			return "DeleteFunction"
+		case method == http.MethodGet:
+			return "GetFunction"
 		}
 	}
 	return ""

--- a/internal/gcp/adapter/jsoncodec_test.go
+++ b/internal/gcp/adapter/jsoncodec_test.go
@@ -71,6 +71,17 @@ func TestJSONCodecDecode(t *testing.T) {
 		{"GET", "/v1/projects/p/serviceAccounts/sa@example.com/keys", "ServiceAccountKeyList"},
 		{"GET", "/v1/projects/p/serviceAccounts/sa@example.com/keys/kid1", "ServiceAccountKeyGet"},
 		{"DELETE", "/v1/projects/p/serviceAccounts/sa@example.com/keys/kid1", "ServiceAccountKeyDelete"},
+		// Cloud Functions
+		{"POST", "/v1/projects/p/locations/us-central1/functions", "CreateFunction"},
+		{"GET", "/v1/projects/p/locations/us-central1/functions", "ListFunctions"},
+		{"GET", "/v1/projects/p/locations/us-central1/functions/f", "GetFunction"},
+		{"PATCH", "/v1/projects/p/locations/us-central1/functions/f", "UpdateFunction"},
+		{"DELETE", "/v1/projects/p/locations/us-central1/functions/f", "DeleteFunction"},
+		{"POST", "/v1/projects/p/locations/us-central1/functions/f:call", "CallFunction"},
+		{"POST", "/v1/projects/p/locations/us-central1/functions:generateUploadUrl", "GenerateUploadUrl"},
+		{"GET", "/v1/projects/p/locations/us-central1/functions/f:getIamPolicy", "FunctionGetIamPolicy"},
+		{"POST", "/v1/projects/p/locations/us-central1/functions/f:setIamPolicy", "FunctionSetIamPolicy"},
+		{"POST", "/v1/projects/p/locations/us-central1/functions/f:testIamPermissions", "FunctionTestIamPermissions"},
 	}
 	for _, tc := range cases {
 		codec := &JSONCodec{Service: "test"}
@@ -94,6 +105,7 @@ func TestDetectV1Service(t *testing.T) {
 		"/v1/projects/p/locations/us/keyRings/kr":                                  "kms",
 		"/v1/projects/p/locations/us/keyRings/kr/cryptoKeys/k/cryptoKeyVersions/3": "kms",
 		"/v1/projects/p/serviceAccounts/sa@x.com":                                  "iam",
+		"/v1/projects/p/locations/us-central1/functions/f":                         "functions",
 		"/storage/v1/b/bkt/o":                                                      "",
 	}
 	for path, want := range cases {

--- a/internal/gcp/adapter/router.go
+++ b/internal/gcp/adapter/router.go
@@ -92,6 +92,8 @@ func detectV1Service(path string) string {
 		return "iam"
 	case "documents", "indexes":
 		return "firestore"
+	case "functions":
+		return "functions"
 	}
 	return ""
 }

--- a/internal/gcp/adapter/services.go
+++ b/internal/gcp/adapter/services.go
@@ -59,6 +59,11 @@ var gcpServices = []ServiceDescriptor{
 		ProviderPrefix: "Firestore",
 		Codec:          func() adapter.Codec { return &JSONCodec{Service: "firestore"} },
 	},
+	{
+		ServiceName:    "functions",
+		ProviderPrefix: "Function",
+		Codec:          func() adapter.Codec { return &JSONCodec{Service: "functions"} },
+	},
 }
 
 // serviceProviderMap maps wire service name → provider registry prefix.

--- a/internal/gcp/provider/functions/function.go
+++ b/internal/gcp/provider/functions/function.go
@@ -1,0 +1,449 @@
+// Package functions implements the Google Cloud Functions v1 provider.
+package functions
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"jaiscloud/internal/clock"
+	lambdaexec "jaiscloud/internal/executor/lambda"
+	"jaiscloud/internal/gcp/paging"
+	"jaiscloud/internal/gcp/policy"
+	functionsstore "jaiscloud/internal/gcp/store/functions"
+	"jaiscloud/internal/model"
+	"jaiscloud/internal/provider"
+	"jaiscloud/internal/store"
+
+	"github.com/google/uuid"
+)
+
+// rtFunctionPolicy is the generic ResourceStore type for function IAM policies.
+const rtFunctionPolicy = "gcp_function_policy"
+
+// Provider handles Cloud Functions v1 functions.
+type Provider struct {
+	functions functionsstore.Store
+	resources store.ResourceStore // IAM policies (control-plane)
+	executor  lambdaexec.LambdaExecutor
+}
+
+// New returns a Provider backed by the given store. executor defaults to a
+// MockExecutor (echo) when nil so CallFunction works out of the box.
+func New(functions functionsstore.Store, resources store.ResourceStore, executor lambdaexec.LambdaExecutor) *Provider {
+	if executor == nil {
+		executor = &lambdaexec.MockExecutor{}
+	}
+	return &Provider{functions: functions, resources: resources, executor: executor}
+}
+
+func (p *Provider) Routes() map[string]provider.HandlerFunc {
+	return map[string]provider.HandlerFunc{
+		"Function.CreateFunction":             p.CreateFunction,
+		"Function.GetFunction":                p.GetFunction,
+		"Function.ListFunctions":              p.ListFunctions,
+		"Function.UpdateFunction":             p.UpdateFunction,
+		"Function.DeleteFunction":             p.DeleteFunction,
+		"Function.CallFunction":               p.CallFunction,
+		"Function.GenerateUploadUrl":          p.GenerateUploadUrl,
+		"Function.FunctionGetIamPolicy":       p.FunctionGetIamPolicy,
+		"Function.FunctionSetIamPolicy":       p.FunctionSetIamPolicy,
+		"Function.FunctionTestIamPermissions": p.FunctionTestIamPermissions,
+	}
+}
+
+// defaultHttpsTriggerURL derives the deployed HTTPS URL for an HTTP-triggered
+// function (region-project.cloudfunctions.net/{name}).
+func defaultHttpsTriggerURL(project, location, id string) string {
+	return fmt.Sprintf("https://%s-%s.cloudfunctions.net/%s", location, project, id)
+}
+
+// functionID extracts the function ID from a relative name
+// ("locations/{l}/functions/{id}") or a full GCP name.
+func functionID(name string) string {
+	if i := strings.Index(name, "/functions/"); i >= 0 {
+		return name[i+len("/functions/"):]
+	}
+	return strings.TrimPrefix(name, "functions/")
+}
+
+// resourceName returns the "name" path param, or a 400 when absent.
+func resourceName(nr *model.NormalizedRequest) (string, error) {
+	n, ok := nr.Params["name"].(string)
+	if !ok || n == "" {
+		return "", model.NewProviderError("InvalidArgument", "missing resource name", 400)
+	}
+	return n, nil
+}
+
+func strParam(nr *model.NormalizedRequest, key string) string {
+	s, _ := nr.Params[key].(string)
+	return s
+}
+
+func bodyString(body map[string]any, key string) string {
+	if body == nil {
+		return ""
+	}
+	s, _ := body[key].(string)
+	return s
+}
+
+func bodyStringMap(body map[string]any, key string) map[string]string {
+	if body == nil {
+		return nil
+	}
+	m, ok := body[key].(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
+func bodyEventTrigger(body map[string]any) *functionsstore.EventTrigger {
+	if body == nil {
+		return nil
+	}
+	et, ok := body["eventTrigger"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := &functionsstore.EventTrigger{
+		EventType: stringOf(et["eventType"]),
+		Resource:  stringOf(et["resource"]),
+		Service:   stringOf(et["service"]),
+	}
+	return out
+}
+
+func stringOf(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+// functionFromBody builds the store Function from a request body, deriving the
+// HTTPS trigger URL when no eventTrigger is present.
+func functionFromBody(nr *model.NormalizedRequest, body map[string]any, location, id string) functionsstore.Function {
+	now := clock.Now().UTC()
+	f := functionsstore.Function{
+		ID:                   id,
+		Location:             location,
+		Runtime:              bodyString(body, "runtime"),
+		EntryPoint:           bodyString(body, "entryPoint"),
+		SourceUploadURL:      bodyString(body, "sourceUploadUrl"),
+		SourceArchiveURL:     bodyString(body, "sourceArchiveUrl"),
+		EnvironmentVariables: bodyStringMap(body, "environmentVariables"),
+		Status:               "ACTIVE",
+		CreateTime:           now,
+		UpdateTime:           now,
+		Labels:               bodyStringMap(body, "labels"),
+		AvailableMemoryMB:    256,
+		Timeout:              "60s",
+		Description:          bodyString(body, "description"),
+	}
+	if v := bodyString(body, "timeout"); v != "" {
+		f.Timeout = v
+	}
+	if n, ok := body["availableMemoryMb"].(float64); ok && n > 0 {
+		f.AvailableMemoryMB = int(n)
+	}
+	if et := bodyEventTrigger(body); et != nil {
+		f.EventTrigger = et
+	} else {
+		f.HttpsTriggerURL = defaultHttpsTriggerURL(nr.AccountID, location, id)
+	}
+	return f
+}
+
+// functionToMap renders a store Function as a CloudFunction wire map.
+func functionToMap(nr *model.NormalizedRequest, f functionsstore.Function) map[string]any {
+	out := map[string]any{
+		"name":   nr.ResourceID("cloud-function", f.Location+"/"+f.ID),
+		"status": f.Status,
+	}
+	if !f.UpdateTime.IsZero() {
+		out["updateTime"] = f.UpdateTime.Format(time.RFC3339Nano)
+	}
+	if f.Runtime != "" {
+		out["runtime"] = f.Runtime
+	}
+	if f.EntryPoint != "" {
+		out["entryPoint"] = f.EntryPoint
+	}
+	if f.SourceUploadURL != "" {
+		out["sourceUploadUrl"] = f.SourceUploadURL
+	}
+	if f.SourceArchiveURL != "" {
+		out["sourceArchiveUrl"] = f.SourceArchiveURL
+	}
+	if f.EventTrigger != nil {
+		out["eventTrigger"] = map[string]any{
+			"eventType": f.EventTrigger.EventType,
+			"resource":  f.EventTrigger.Resource,
+			"service":   f.EventTrigger.Service,
+		}
+	} else if f.HttpsTriggerURL != "" {
+		out["httpsTrigger"] = map[string]any{
+			"url":           f.HttpsTriggerURL,
+			"securityLevel": "SECURE_ALWAYS",
+		}
+	}
+	if f.EnvironmentVariables != nil {
+		out["environmentVariables"] = f.EnvironmentVariables
+	}
+	if f.Labels != nil {
+		out["labels"] = f.Labels
+	}
+	if f.AvailableMemoryMB > 0 {
+		out["availableMemoryMb"] = f.AvailableMemoryMB
+	}
+	if f.Timeout != "" {
+		out["timeout"] = f.Timeout
+	}
+	if f.Description != "" {
+		out["description"] = f.Description
+	}
+	return out
+}
+
+func mapErr(err error) error {
+	if errors.Is(err, functionsstore.ErrNoSuchFunction) {
+		return model.NewProviderError("NotFound", "function not found", 404)
+	}
+	return err
+}
+
+func (p *Provider) CreateFunction(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	location := strParam(nr, "location")
+	if location == "" {
+		return nil, model.NewProviderError("InvalidArgument", "missing location", 400)
+	}
+	body, _ := nr.Params["body"].(map[string]any)
+	id := strParam(nr, "functionId")
+	if id == "" {
+		if n := bodyString(body, "name"); n != "" {
+			id = functionID(n)
+		}
+	}
+	if id == "" {
+		return nil, model.NewProviderError("InvalidArgument", "missing functionId", 400)
+	}
+	f := functionFromBody(nr, body, location, id)
+	if err := p.functions.CreateFunction(ctx, nr.AccountID, location, id, f); err != nil {
+		if errors.Is(err, functionsstore.ErrAlreadyExists) {
+			return nil, model.NewProviderError("AlreadyExists", "function already exists", 409)
+		}
+		return nil, err
+	}
+	return provider.OK(functionToMap(nr, f)), nil
+}
+
+func (p *Provider) GetFunction(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	name, err := resourceName(nr)
+	if err != nil {
+		return nil, err
+	}
+	location := strParam(nr, "location")
+	f, err := p.functions.GetFunction(ctx, nr.AccountID, location, functionID(name))
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	return provider.OK(functionToMap(nr, f)), nil
+}
+
+func (p *Provider) ListFunctions(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	location := strParam(nr, "location")
+	fns, err := p.functions.ListFunctions(ctx, nr.AccountID, location)
+	if err != nil {
+		return nil, err
+	}
+	page, next := paging.Page(fns, func(f functionsstore.Function) string { return f.ID }, nr.Params)
+	items := make([]any, 0, len(page))
+	for _, f := range page {
+		items = append(items, functionToMap(nr, f))
+	}
+	resp := map[string]any{"functions": items}
+	if next != "" {
+		resp["nextPageToken"] = next
+	}
+	return provider.OK(resp), nil
+}
+
+func (p *Provider) UpdateFunction(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	name, err := resourceName(nr)
+	if err != nil {
+		return nil, err
+	}
+	location := strParam(nr, "location")
+	id := functionID(name)
+	f, err := p.functions.GetFunction(ctx, nr.AccountID, location, id)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	body, _ := nr.Params["body"].(map[string]any)
+	// PATCH is a merge: apply only the fields present in the body.
+	if v := bodyString(body, "runtime"); v != "" {
+		f.Runtime = v
+	}
+	if v := bodyString(body, "entryPoint"); v != "" {
+		f.EntryPoint = v
+	}
+	if v := bodyString(body, "sourceUploadUrl"); v != "" {
+		f.SourceUploadURL = v
+	}
+	if v := bodyString(body, "sourceArchiveUrl"); v != "" {
+		f.SourceArchiveURL = v
+	}
+	if env := bodyStringMap(body, "environmentVariables"); env != nil {
+		f.EnvironmentVariables = env
+	}
+	if labels := bodyStringMap(body, "labels"); labels != nil {
+		f.Labels = labels
+	}
+	if v := bodyString(body, "description"); v != "" {
+		f.Description = v
+	}
+	if v := bodyString(body, "timeout"); v != "" {
+		f.Timeout = v
+	}
+	if n, ok := body["availableMemoryMb"].(float64); ok && n > 0 {
+		f.AvailableMemoryMB = int(n)
+	}
+	if et := bodyEventTrigger(body); et != nil {
+		f.EventTrigger = et
+	}
+	f.UpdateTime = clock.Now().UTC()
+	if err := p.functions.UpdateFunction(ctx, nr.AccountID, location, id, f); err != nil {
+		return nil, mapErr(err)
+	}
+	return provider.OK(functionToMap(nr, f)), nil
+}
+
+func (p *Provider) DeleteFunction(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	name, err := resourceName(nr)
+	if err != nil {
+		return nil, err
+	}
+	location := strParam(nr, "location")
+	if err := p.functions.DeleteFunction(ctx, nr.AccountID, location, functionID(name)); err != nil {
+		return nil, mapErr(err)
+	}
+	return &model.ProviderResponse{HTTPStatus: 200, Data: map[string]any{}}, nil
+}
+
+// CallFunction invokes a function synchronously via the Lambda executor. The
+// request payload is the CallFunctionRequest.data string; the executor (mock
+// echo by default, Docker/K8s under JAISCLOUD_EXECUTOR_MODE) runs the
+// function's entryPoint and returns the result as a string.
+func (p *Provider) CallFunction(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	name, err := resourceName(nr)
+	if err != nil {
+		return nil, err
+	}
+	location := strParam(nr, "location")
+	id := functionID(name)
+	f, err := p.functions.GetFunction(ctx, nr.AccountID, location, id)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	body, _ := nr.Params["body"].(map[string]any)
+	data := bodyString(body, "data")
+
+	timeout, err := time.ParseDuration(f.Timeout)
+	if err != nil || timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	invCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req := lambdaexec.InvokeRequest{
+		FunctionName: f.ID,
+		Runtime:      f.Runtime,
+		Handler:      f.EntryPoint,
+		EnvVars:      f.EnvironmentVariables,
+		Payload:      []byte(data),
+		AccountID:    nr.AccountID,
+		MemoryMB:     f.AvailableMemoryMB,
+		TimeoutSecs:  int(timeout.Seconds()),
+	}
+	executionID := uuid.New().String()
+	result, err := p.executor.Invoke(invCtx, req)
+	if err != nil {
+		return provider.OK(map[string]any{
+			"executionId": executionID,
+			"error":       err.Error(),
+		}), nil
+	}
+	return provider.OK(map[string]any{
+		"executionId": executionID,
+		"result":      string(result.Payload),
+	}), nil
+}
+
+// GenerateUploadUrl returns a fake signed upload URL for source deployment.
+func (p *Provider) GenerateUploadUrl(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	location := strParam(nr, "location")
+	project := nr.AccountID
+	return provider.OK(map[string]any{
+		"uploadUrl": fmt.Sprintf("https://storage.googleapis.com/uploads/%s/%s/%s.zip",
+			project, location, uuid.New().String()),
+	}), nil
+}
+
+func (p *Provider) requireFunction(ctx context.Context, nr *model.NormalizedRequest) error {
+	name, err := resourceName(nr)
+	if err != nil {
+		return err
+	}
+	if _, err := p.functions.GetFunction(ctx, nr.AccountID, strParam(nr, "location"), functionID(name)); err != nil {
+		return mapErr(err)
+	}
+	return nil
+}
+
+func (p *Provider) FunctionGetIamPolicy(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	name, err := resourceName(nr)
+	if err != nil {
+		return nil, err
+	}
+	if err := p.requireFunction(ctx, nr); err != nil {
+		return nil, err
+	}
+	id := strParam(nr, "location") + "/" + functionID(name)
+	return provider.OK(policy.ToMap(policy.Load(ctx, p.resources, nr.AccountID, rtFunctionPolicy, id))), nil
+}
+
+func (p *Provider) FunctionSetIamPolicy(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	name, err := resourceName(nr)
+	if err != nil {
+		return nil, err
+	}
+	if err := p.requireFunction(ctx, nr); err != nil {
+		return nil, err
+	}
+	body, _ := nr.Params["body"].(map[string]any)
+	pol, err := policy.Set(ctx, p.resources, nr.AccountID, rtFunctionPolicy, strParam(nr, "location")+"/"+functionID(name), body)
+	if err != nil {
+		return nil, err
+	}
+	return provider.OK(policy.ToMap(pol)), nil
+}
+
+func (p *Provider) FunctionTestIamPermissions(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	if _, err := resourceName(nr); err != nil {
+		return nil, err
+	}
+	if err := p.requireFunction(ctx, nr); err != nil {
+		return nil, err
+	}
+	body, _ := nr.Params["body"].(map[string]any)
+	return provider.OK(map[string]any{"permissions": policy.TestPermissions(policy.Permissions(body))}), nil
+}

--- a/internal/gcp/provider/functions/function_test.go
+++ b/internal/gcp/provider/functions/function_test.go
@@ -1,0 +1,286 @@
+package functions
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	lambdaexec "jaiscloud/internal/executor/lambda"
+	"jaiscloud/internal/gcp/resource"
+	functionsstore "jaiscloud/internal/gcp/store/functions"
+	"jaiscloud/internal/model"
+	"jaiscloud/internal/store"
+)
+
+// stubExecutor captures the InvokeRequest and optionally returns a fixed error.
+type stubExecutor struct {
+	req     lambdaexec.InvokeRequest
+	invoked bool
+	err     error
+}
+
+func (e *stubExecutor) Invoke(_ context.Context, req lambdaexec.InvokeRequest) (lambdaexec.InvokeResult, error) {
+	e.req = req
+	e.invoked = true
+	if e.err != nil {
+		return lambdaexec.InvokeResult{}, e.err
+	}
+	return lambdaexec.InvokeResult{Payload: req.Payload}, nil
+}
+
+func (e *stubExecutor) DeleteFunction(_ context.Context, _ string) {}
+func (e *stubExecutor) Reset(_ context.Context)                    {}
+func (e *stubExecutor) Close() error                               { return nil }
+
+func newNR(params map[string]any) *model.NormalizedRequest {
+	if params == nil {
+		params = map[string]any{}
+	}
+	return &model.NormalizedRequest{AccountID: "proj", Params: params, ResourceID: resource.ResourceID("proj")}
+}
+
+func TestFunctionCRUD(t *testing.T) {
+	ctx := context.Background()
+	p := New(functionsstore.NewMemoryStore(), store.NewMemoryResourceStore(), nil)
+
+	// Create.
+	nr := newNR(map[string]any{
+		"location":   "us-central1",
+		"functionId": "hello",
+		"body": map[string]any{
+			"runtime":              "nodejs20",
+			"entryPoint":           "helloWorld",
+			"environmentVariables": map[string]any{"K": "V"},
+		},
+	})
+	resp, err := p.CreateFunction(ctx, nr)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if resp.Data["name"] != "projects/proj/locations/us-central1/functions/hello" {
+		t.Errorf("unexpected name: %v", resp.Data["name"])
+	}
+	if resp.Data["status"] != "ACTIVE" {
+		t.Errorf("expected ACTIVE, got %v", resp.Data["status"])
+	}
+	ht, _ := resp.Data["httpsTrigger"].(map[string]any)
+	if ht == nil || ht["url"] == "" {
+		t.Errorf("expected httpsTrigger.url on HTTP function")
+	}
+
+	// Get.
+	nr = newNR(map[string]any{"location": "us-central1", "name": "locations/us-central1/functions/hello"})
+	resp, err = p.GetFunction(ctx, nr)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if resp.Data["entryPoint"] != "helloWorld" {
+		t.Errorf("unexpected entryPoint: %v", resp.Data["entryPoint"])
+	}
+
+	// Update (PATCH merge).
+	nr = newNR(map[string]any{"location": "us-central1", "name": "locations/us-central1/functions/hello",
+		"body": map[string]any{"runtime": "nodejs22"}})
+	resp, err = p.UpdateFunction(ctx, nr)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if resp.Data["runtime"] != "nodejs22" || resp.Data["entryPoint"] != "helloWorld" {
+		t.Errorf("unexpected update result: %v", resp.Data)
+	}
+
+	// List.
+	nr = newNR(map[string]any{"location": "us-central1"})
+	resp, err = p.ListFunctions(ctx, nr)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	fns, _ := resp.Data["functions"].([]any)
+	if len(fns) != 1 {
+		t.Errorf("expected 1 function, got %d", len(fns))
+	}
+
+	// Delete.
+	nr = newNR(map[string]any{"location": "us-central1", "name": "locations/us-central1/functions/hello"})
+	if _, err := p.DeleteFunction(ctx, nr); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	nr = newNR(map[string]any{"location": "us-central1", "name": "locations/us-central1/functions/hello"})
+	if _, err := p.GetFunction(ctx, nr); err == nil {
+		t.Errorf("expected NotFound after delete")
+	}
+}
+
+func TestCallFunctionMockEcho(t *testing.T) {
+	ctx := context.Background()
+	p := New(functionsstore.NewMemoryStore(), store.NewMemoryResourceStore(), nil)
+
+	nr := newNR(map[string]any{
+		"location":   "us-central1",
+		"functionId": "echo",
+		"body":       map[string]any{"runtime": "nodejs20", "entryPoint": "handler"},
+	})
+	if _, err := p.CreateFunction(ctx, nr); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Call with the mock executor: result echoes the request data.
+	nr = newNR(map[string]any{"location": "us-central1", "name": "locations/us-central1/functions/echo",
+		"body": map[string]any{"data": "hello world"}})
+	resp, err := p.CallFunction(ctx, nr)
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if resp.Data["result"] != "hello world" {
+		t.Errorf("expected echo result, got %v", resp.Data["result"])
+	}
+	if id, _ := resp.Data["executionId"].(string); id == "" {
+		t.Errorf("expected non-empty executionId")
+	}
+
+	// Calling a missing function → 404.
+	nr = newNR(map[string]any{"location": "us-central1", "name": "locations/us-central1/functions/missing",
+		"body": map[string]any{"data": "x"}})
+	if _, err := p.CallFunction(ctx, nr); err == nil {
+		t.Errorf("expected NotFound calling missing function")
+	}
+}
+
+func TestGenerateUploadUrl(t *testing.T) {
+	ctx := context.Background()
+	p := New(functionsstore.NewMemoryStore(), store.NewMemoryResourceStore(), nil)
+	nr := newNR(map[string]any{"location": "us-central1"})
+	resp, err := p.GenerateUploadUrl(ctx, nr)
+	if err != nil {
+		t.Fatalf("generateUploadUrl: %v", err)
+	}
+	if u, _ := resp.Data["uploadUrl"].(string); u == "" {
+		t.Errorf("expected non-empty uploadUrl")
+	}
+}
+
+func TestIamPolicyLocationScoped(t *testing.T) {
+	ctx := context.Background()
+	p := New(functionsstore.NewMemoryStore(), store.NewMemoryResourceStore(), nil)
+
+	// Same function ID in two locations.
+	for _, loc := range []string{"us-central1", "europe-west1"} {
+		nr := newNR(map[string]any{
+			"location":   loc,
+			"functionId": "foo",
+			"body":       map[string]any{"runtime": "nodejs20", "entryPoint": "handler"},
+		})
+		if _, err := p.CreateFunction(ctx, nr); err != nil {
+			t.Fatalf("create %s: %v", loc, err)
+		}
+	}
+
+	// Set policy in us-central1.
+	set := newNR(map[string]any{
+		"location": "us-central1",
+		"name":     "locations/us-central1/functions/foo",
+		"body": map[string]any{
+			"bindings": []any{
+				map[string]any{"role": "roles/cloudfunctions.invoker", "members": []any{"allUsers"}},
+			},
+		},
+	})
+	if _, err := p.FunctionSetIamPolicy(ctx, set); err != nil {
+		t.Fatalf("set iam: %v", err)
+	}
+
+	// Same id in a DIFFERENT location must return an empty policy.
+	get := newNR(map[string]any{
+		"location": "europe-west1",
+		"name":     "locations/europe-west1/functions/foo",
+	})
+	resp, err := p.FunctionGetIamPolicy(ctx, get)
+	if err != nil {
+		t.Fatalf("get iam other location: %v", err)
+	}
+	if b, _ := resp.Data["bindings"].([]any); len(b) != 0 {
+		t.Errorf("expected empty bindings in other location, got %v", b)
+	}
+
+	// Same location must still return the policy.
+	get2 := newNR(map[string]any{
+		"location": "us-central1",
+		"name":     "locations/us-central1/functions/foo",
+	})
+	resp2, err := p.FunctionGetIamPolicy(ctx, get2)
+	if err != nil {
+		t.Fatalf("get iam same location: %v", err)
+	}
+	if b, _ := resp2.Data["bindings"].([]any); len(b) != 1 {
+		t.Errorf("expected 1 binding in same location, got %v", b)
+	}
+}
+
+func TestCallFunctionExecutorErrorReturns200(t *testing.T) {
+	ctx := context.Background()
+	exec := &stubExecutor{err: errors.New("boom")}
+	p := New(functionsstore.NewMemoryStore(), store.NewMemoryResourceStore(), exec)
+
+	nr := newNR(map[string]any{
+		"location":   "us-central1",
+		"functionId": "f",
+		"body":       map[string]any{"runtime": "nodejs20", "entryPoint": "handler"},
+	})
+	if _, err := p.CreateFunction(ctx, nr); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	nr = newNR(map[string]any{"location": "us-central1", "name": "locations/us-central1/functions/f",
+		"body": map[string]any{"data": "x"}})
+	resp, err := p.CallFunction(ctx, nr)
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if resp.HTTPStatus != 200 {
+		t.Errorf("expected HTTP 200, got %d", resp.HTTPStatus)
+	}
+	if got, _ := resp.Data["error"].(string); got != "boom" {
+		t.Errorf("expected error=boom, got %v", resp.Data["error"])
+	}
+	if _, ok := resp.Data["result"]; ok {
+		t.Errorf("expected no result on failure")
+	}
+	if id, _ := resp.Data["executionId"].(string); id == "" {
+		t.Errorf("expected non-empty executionId")
+	}
+}
+
+func TestCallFunctionPropagatesMemoryAndTimeout(t *testing.T) {
+	ctx := context.Background()
+	exec := &stubExecutor{}
+	p := New(functionsstore.NewMemoryStore(), store.NewMemoryResourceStore(), exec)
+
+	nr := newNR(map[string]any{
+		"location":   "us-central1",
+		"functionId": "f",
+		"body": map[string]any{
+			"runtime":           "nodejs20",
+			"entryPoint":        "handler",
+			"availableMemoryMb": float64(512),
+			"timeout":           "120s",
+		},
+	})
+	if _, err := p.CreateFunction(ctx, nr); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	nr = newNR(map[string]any{"location": "us-central1", "name": "locations/us-central1/functions/f",
+		"body": map[string]any{"data": "hello"}})
+	if _, err := p.CallFunction(ctx, nr); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	if !exec.invoked {
+		t.Fatalf("executor not invoked")
+	}
+	if exec.req.MemoryMB != 512 {
+		t.Errorf("expected MemoryMB=512, got %d", exec.req.MemoryMB)
+	}
+	if exec.req.TimeoutSecs != 120 {
+		t.Errorf("expected TimeoutSecs=120, got %d", exec.req.TimeoutSecs)
+	}
+}

--- a/internal/gcp/resource/resource.go
+++ b/internal/gcp/resource/resource.go
@@ -45,8 +45,11 @@ var formatters = map[string]func(project, name string) string{
 	// The name argument is the relative path after the project, i.e.
 	// "databases/{db}/documents/{path}".
 	"firestore-document": func(p, n string) string { return fmt.Sprintf("projects/%s/%s", p, n) },
-	// Cloud Functions
-	"cloud-function": func(p, n string) string { return fmt.Sprintf("projects/%s/locations/-/functions/%s", p, n) },
+	// Cloud Functions — names embed the location; callers pass "location/function".
+	"cloud-function": func(p, n string) string {
+		loc, fn := fnLoc(n)
+		return fmt.Sprintf("projects/%s/locations/%s/functions/%s", p, loc, fn)
+	},
 }
 
 // ResourceID returns a function that formats GCP resource names for a project.
@@ -115,4 +118,13 @@ func parts4(name string) (loc, ring, key, ver string) {
 	default:
 		return "global", name, "", ""
 	}
+}
+
+// fnLoc splits a "location/function" name. A name with no slash defaults the
+// location to "-" (the GCP wildcard region).
+func fnLoc(name string) (loc, fn string) {
+	if i := strings.IndexByte(name, '/'); i >= 0 {
+		return name[:i], name[i+1:]
+	}
+	return "-", name
 }

--- a/internal/gcp/resource/resource_test.go
+++ b/internal/gcp/resource/resource_test.go
@@ -18,6 +18,7 @@ func TestResourceIDFormatters(t *testing.T) {
 		{"kms-cryptokey", "us/keyring1/key1", "projects/proj/locations/us/keyRings/keyring1/cryptoKeys/key1"},
 		{"kms-cryptokey-version", "us/keyring1/key1/3", "projects/proj/locations/us/keyRings/keyring1/cryptoKeys/key1/cryptoKeyVersions/3"},
 		{"service-account", "sa@x.iam.gserviceaccount.com", "projects/proj/serviceAccounts/sa@x.iam.gserviceaccount.com"},
+		{"cloud-function", "us-central1/fn", "projects/proj/locations/us-central1/functions/fn"},
 		{"cloud-function", "fn", "projects/proj/locations/-/functions/fn"},
 	}
 	for _, tc := range cases {

--- a/internal/gcp/store/functions/memory.go
+++ b/internal/gcp/store/functions/memory.go
@@ -1,0 +1,88 @@
+package functions
+
+import (
+	"context"
+	"sort"
+	"sync"
+)
+
+// MemoryStore is an in-memory Store.
+type MemoryStore struct {
+	mu        sync.RWMutex
+	functions map[string]map[string]Function // projectID+"/"+location → id → function
+}
+
+// NewMemoryStore returns an empty in-memory store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{functions: make(map[string]map[string]Function)}
+}
+
+func lkey(projectID, location string) string { return projectID + "/" + location }
+
+func (s *MemoryStore) CreateFunction(_ context.Context, projectID, location, id string, f Function) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := lkey(projectID, location)
+	if s.functions[key] == nil {
+		s.functions[key] = make(map[string]Function)
+	}
+	if _, ok := s.functions[key][id]; ok {
+		return ErrAlreadyExists
+	}
+	f.ID = id
+	f.Location = location
+	s.functions[key][id] = f
+	return nil
+}
+
+func (s *MemoryStore) GetFunction(_ context.Context, projectID, location, id string) (Function, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	f, ok := s.functions[lkey(projectID, location)][id]
+	if !ok {
+		return Function{}, ErrNoSuchFunction
+	}
+	return f, nil
+}
+
+func (s *MemoryStore) UpdateFunction(_ context.Context, projectID, location, id string, f Function) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := lkey(projectID, location)
+	if _, ok := s.functions[key][id]; !ok {
+		return ErrNoSuchFunction
+	}
+	f.ID = id
+	f.Location = location
+	s.functions[key][id] = f
+	return nil
+}
+
+func (s *MemoryStore) DeleteFunction(_ context.Context, projectID, location, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := lkey(projectID, location)
+	if _, ok := s.functions[key][id]; !ok {
+		return ErrNoSuchFunction
+	}
+	delete(s.functions[key], id)
+	return nil
+}
+
+func (s *MemoryStore) ListFunctions(_ context.Context, projectID, location string) ([]Function, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	m := s.functions[lkey(projectID, location)]
+	result := make([]Function, 0, len(m))
+	for _, f := range m {
+		result = append(result, f)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result, nil
+}
+
+func (s *MemoryStore) Reset(_ context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.functions = make(map[string]map[string]Function)
+}

--- a/internal/gcp/store/functions/memory_test.go
+++ b/internal/gcp/store/functions/memory_test.go
@@ -1,0 +1,84 @@
+package functions
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestMemoryStoreFunctionCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+
+	// Create.
+	f := Function{ID: "a", Runtime: "nodejs20", EntryPoint: "hello", Status: "ACTIVE",
+		EnvironmentVariables: map[string]string{"K": "V"}, Labels: map[string]string{"team": "x"}}
+	if err := s.CreateFunction(ctx, "proj", "us-central1", "a", f); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Duplicate → ErrAlreadyExists.
+	if err := s.CreateFunction(ctx, "proj", "us-central1", "a", Function{ID: "a"}); err != ErrAlreadyExists {
+		t.Fatalf("expected ErrAlreadyExists, got %v", err)
+	}
+
+	// Get.
+	got, err := s.GetFunction(ctx, "proj", "us-central1", "a")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.ID != "a" || got.Runtime != "nodejs20" || got.EnvironmentVariables["K"] != "V" || got.Labels["team"] != "x" {
+		t.Fatalf("unexpected function: %+v", got)
+	}
+
+	// Same ID under a different location is independent.
+	if err := s.CreateFunction(ctx, "proj", "europe-west1", "a", Function{ID: "a"}); err != nil {
+		t.Fatalf("create other location: %v", err)
+	}
+
+	// Update.
+	upd := got
+	upd.Runtime = "nodejs22"
+	if err := s.UpdateFunction(ctx, "proj", "us-central1", "a", upd); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got, _ = s.GetFunction(ctx, "proj", "us-central1", "a")
+	if got.Runtime != "nodejs22" {
+		t.Fatalf("expected nodejs22, got %s", got.Runtime)
+	}
+
+	// List (sorted, location-scoped).
+	s.CreateFunction(ctx, "proj", "us-central1", "c", Function{ID: "c"})
+	s.CreateFunction(ctx, "proj", "us-central1", "b", Function{ID: "b"})
+	all, err := s.ListFunctions(ctx, "proj", "us-central1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(all) != 3 || all[0].ID != "a" || all[1].ID != "b" || all[2].ID != "c" {
+		t.Fatalf("unexpected list order: %+v", all)
+	}
+	other, _ := s.ListFunctions(ctx, "proj", "europe-west1")
+	if len(other) != 1 {
+		t.Fatalf("expected 1 in other location, got %d", len(other))
+	}
+
+	// Delete.
+	if err := s.DeleteFunction(ctx, "proj", "us-central1", "a"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := s.GetFunction(ctx, "proj", "us-central1", "a"); err != ErrNoSuchFunction {
+		t.Fatalf("expected ErrNoSuchFunction, got %v", err)
+	}
+	if err := s.DeleteFunction(ctx, "proj", "us-central1", "a"); err != ErrNoSuchFunction {
+		t.Fatalf("expected ErrNoSuchFunction on delete missing, got %v", err)
+	}
+}
+
+func TestMemoryStoreReset(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	_ = s.CreateFunction(ctx, "proj", "us-central1", "a", Function{ID: "a", CreateTime: time.Now()})
+	s.Reset(ctx)
+	if _, err := s.GetFunction(ctx, "proj", "us-central1", "a"); err != ErrNoSuchFunction {
+		t.Fatalf("expected ErrNoSuchFunction after reset, got %v", err)
+	}
+}

--- a/internal/gcp/store/functions/postgres.go
+++ b/internal/gcp/store/functions/postgres.go
@@ -1,0 +1,149 @@
+package functions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sort"
+
+	"jaiscloud/internal/clock"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgresStore implements Store against jc_functions.
+type PostgresStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresStore returns a Postgres-backed store.
+func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore {
+	return &PostgresStore{pool: pool}
+}
+
+// nullableJSON marshals v to JSONB, or returns nil (SQL NULL) when v is nil.
+func nullableJSON(v any) any {
+	if v == nil {
+		return nil
+	}
+	b, _ := json.Marshal(v)
+	return json.RawMessage(b)
+}
+
+func (s *PostgresStore) CreateFunction(ctx context.Context, projectID, location, id string, f Function) error {
+	if f.CreateTime.IsZero() {
+		f.CreateTime = clock.Now()
+	}
+	if f.UpdateTime.IsZero() {
+		f.UpdateTime = f.CreateTime
+	}
+	env, _ := json.Marshal(f.EnvironmentVariables)
+	labels, _ := json.Marshal(f.Labels)
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO jc_functions
+			(project_id, location, function_id, runtime, entry_point, source_upload_url, source_archive_url,
+			 https_trigger_url, event_trigger, environment_variables, status, create_time, update_time, labels,
+			 available_memory_mb, timeout, description)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)
+	`, projectID, location, id, f.Runtime, f.EntryPoint, f.SourceUploadURL, f.SourceArchiveURL,
+		f.HttpsTriggerURL, nullableJSON(f.EventTrigger), json.RawMessage(env), f.Status, f.CreateTime, f.UpdateTime,
+		json.RawMessage(labels), f.AvailableMemoryMB, f.Timeout, f.Description)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrAlreadyExists
+		}
+		return err
+	}
+	return nil
+}
+
+func scanFunction(row pgx.Row) (Function, error) {
+	var f Function
+	var eventTrigger, env, labels []byte
+	err := row.Scan(&f.ID, &f.Location, &f.Runtime, &f.EntryPoint, &f.SourceUploadURL, &f.SourceArchiveURL,
+		&f.HttpsTriggerURL, &eventTrigger, &env, &f.Status, &f.CreateTime, &f.UpdateTime, &labels,
+		&f.AvailableMemoryMB, &f.Timeout, &f.Description)
+	if err != nil {
+		return Function{}, err
+	}
+	if len(eventTrigger) > 0 {
+		json.Unmarshal(eventTrigger, &f.EventTrigger)
+	}
+	json.Unmarshal(env, &f.EnvironmentVariables)
+	json.Unmarshal(labels, &f.Labels)
+	return f, nil
+}
+
+func (s *PostgresStore) GetFunction(ctx context.Context, projectID, location, id string) (Function, error) {
+	f, err := scanFunction(s.pool.QueryRow(ctx, `
+		SELECT function_id, location, runtime, entry_point, source_upload_url, source_archive_url,
+		       https_trigger_url, event_trigger, environment_variables, status, create_time, update_time, labels,
+		       available_memory_mb, timeout, description
+		FROM jc_functions WHERE project_id=$1 AND location=$2 AND function_id=$3
+	`, projectID, location, id))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Function{}, ErrNoSuchFunction
+	}
+	return f, err
+}
+
+func (s *PostgresStore) UpdateFunction(ctx context.Context, projectID, location, id string, f Function) error {
+	env, _ := json.Marshal(f.EnvironmentVariables)
+	labels, _ := json.Marshal(f.Labels)
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE jc_functions SET runtime=$4, entry_point=$5, source_upload_url=$6, source_archive_url=$7,
+		       https_trigger_url=$8, event_trigger=$9, environment_variables=$10, status=$11, update_time=$12, labels=$13,
+		       available_memory_mb=$14, timeout=$15, description=$16
+		WHERE project_id=$1 AND location=$2 AND function_id=$3
+	`, projectID, location, id, f.Runtime, f.EntryPoint, f.SourceUploadURL, f.SourceArchiveURL,
+		f.HttpsTriggerURL, nullableJSON(f.EventTrigger), json.RawMessage(env), f.Status, f.UpdateTime,
+		json.RawMessage(labels), f.AvailableMemoryMB, f.Timeout, f.Description)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNoSuchFunction
+	}
+	return nil
+}
+
+func (s *PostgresStore) DeleteFunction(ctx context.Context, projectID, location, id string) error {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM jc_functions WHERE project_id=$1 AND location=$2 AND function_id=$3`, projectID, location, id)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNoSuchFunction
+	}
+	return nil
+}
+
+func (s *PostgresStore) ListFunctions(ctx context.Context, projectID, location string) ([]Function, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT function_id, location, runtime, entry_point, source_upload_url, source_archive_url,
+		       https_trigger_url, event_trigger, environment_variables, status, create_time, update_time, labels,
+		       available_memory_mb, timeout, description
+		FROM jc_functions WHERE project_id=$1 AND location=$2 ORDER BY function_id
+	`, projectID, location)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []Function
+	for rows.Next() {
+		f, err := scanFunction(rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, f)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result, rows.Err()
+}
+
+func (s *PostgresStore) Reset(ctx context.Context) {
+	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_functions`)
+}

--- a/internal/gcp/store/functions/snapshot.go
+++ b/internal/gcp/store/functions/snapshot.go
@@ -1,0 +1,123 @@
+package functions
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+)
+
+// --- Memory store ---
+
+func (s *MemoryStore) IsEmpty(_ context.Context) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.functions) == 0, nil
+}
+
+func (s *MemoryStore) Snapshot(_ context.Context, w io.Writer) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return json.NewEncoder(w).Encode(map[string]any{"functions": s.functions})
+}
+
+func (s *MemoryStore) Restore(_ context.Context, r io.Reader) error {
+	var snap struct {
+		Functions map[string]map[string]Function `json:"functions"`
+	}
+	if err := json.NewDecoder(r).Decode(&snap); err != nil {
+		return err
+	}
+	if snap.Functions == nil {
+		snap.Functions = map[string]map[string]Function{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.functions = snap.Functions
+	return nil
+}
+
+// --- Postgres store ---
+
+func (s *PostgresStore) IsEmpty(ctx context.Context) (bool, error) {
+	var n int
+	if err := s.pool.QueryRow(ctx, `SELECT count(*) FROM jc_functions`).Scan(&n); err != nil {
+		return false, err
+	}
+	return n == 0, nil
+}
+
+func (s *PostgresStore) Snapshot(ctx context.Context, w io.Writer) error {
+	type functionRow struct {
+		ProjectID string   `json:"projectId"`
+		Function  Function `json:"function"`
+	}
+	functions := make([]functionRow, 0)
+	rows, err := s.pool.Query(ctx, `
+		SELECT project_id, function_id, location, runtime, entry_point, source_upload_url, source_archive_url,
+		       https_trigger_url, event_trigger, environment_variables, status, create_time, update_time, labels,
+		       available_memory_mb, timeout, description
+		FROM jc_functions ORDER BY project_id, location, function_id
+	`)
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		var r functionRow
+		var eventTrigger, env, labels []byte
+		if err := rows.Scan(&r.ProjectID, &r.Function.ID, &r.Function.Location, &r.Function.Runtime, &r.Function.EntryPoint,
+			&r.Function.SourceUploadURL, &r.Function.SourceArchiveURL, &r.Function.HttpsTriggerURL, &eventTrigger, &env,
+			&r.Function.Status, &r.Function.CreateTime, &r.Function.UpdateTime, &labels, &r.Function.AvailableMemoryMB,
+			&r.Function.Timeout, &r.Function.Description); err != nil {
+			rows.Close()
+			return err
+		}
+		if len(eventTrigger) > 0 {
+			json.Unmarshal(eventTrigger, &r.Function.EventTrigger)
+		}
+		json.Unmarshal(env, &r.Function.EnvironmentVariables)
+		json.Unmarshal(labels, &r.Function.Labels)
+		functions = append(functions, r)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	return json.NewEncoder(w).Encode(map[string]any{"functions": functions})
+}
+
+func (s *PostgresStore) Restore(ctx context.Context, r io.Reader) error {
+	var snap struct {
+		Functions []struct {
+			ProjectID string   `json:"projectId"`
+			Function  Function `json:"function"`
+		} `json:"functions"`
+	}
+	if err := json.NewDecoder(r).Decode(&snap); err != nil {
+		return err
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `DELETE FROM jc_functions`); err != nil {
+		return err
+	}
+	for _, r := range snap.Functions {
+		env, _ := json.Marshal(r.Function.EnvironmentVariables)
+		labels, _ := json.Marshal(r.Function.Labels)
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO jc_functions
+				(project_id, location, function_id, runtime, entry_point, source_upload_url, source_archive_url,
+				 https_trigger_url, event_trigger, environment_variables, status, create_time, update_time, labels,
+				 available_memory_mb, timeout, description)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)
+		`, r.ProjectID, r.Function.Location, r.Function.ID, r.Function.Runtime, r.Function.EntryPoint,
+			r.Function.SourceUploadURL, r.Function.SourceArchiveURL, r.Function.HttpsTriggerURL, nullableJSON(r.Function.EventTrigger),
+			json.RawMessage(env), r.Function.Status, r.Function.CreateTime, r.Function.UpdateTime, json.RawMessage(labels),
+			r.Function.AvailableMemoryMB, r.Function.Timeout, r.Function.Description); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}

--- a/internal/gcp/store/functions/snapshot_test.go
+++ b/internal/gcp/store/functions/snapshot_test.go
@@ -1,0 +1,33 @@
+package functions
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+func TestMemoryStoreSnapshotRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	f := Function{ID: "a", Runtime: "nodejs20", EntryPoint: "hello",
+		EnvironmentVariables: map[string]string{"K": "V"}, Labels: map[string]string{"team": "x"}}
+	if err := s.CreateFunction(ctx, "proj", "us-central1", "a", f); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := s.Snapshot(ctx, &buf); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	dst := NewMemoryStore()
+	if err := dst.Restore(ctx, &buf); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	got, err := dst.GetFunction(ctx, "proj", "us-central1", "a")
+	if err != nil {
+		t.Fatalf("get after restore: %v", err)
+	}
+	if got.Runtime != "nodejs20" || got.EntryPoint != "hello" || got.EnvironmentVariables["K"] != "V" || got.Labels["team"] != "x" {
+		t.Fatalf("restored function wrong: %+v", got)
+	}
+}

--- a/internal/gcp/store/functions/store.go
+++ b/internal/gcp/store/functions/store.go
@@ -1,0 +1,55 @@
+// Package functions provides the Cloud Functions v1 store. Functions live in a
+// dedicated jc_functions table (mirroring the AWS Lambda function store),
+// scoped by project + location (the GCP resource name is
+// projects/{project}/locations/{location}/functions/{name}).
+package functions
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	ErrNoSuchFunction = errors.New("NoSuchFunction")
+	ErrAlreadyExists  = errors.New("AlreadyExists")
+)
+
+// EventTrigger is a source that fires events in response to a condition in
+// another service (mirrors the CloudFunction.eventTrigger wire shape).
+type EventTrigger struct {
+	EventType string `json:"eventType"`
+	Resource  string `json:"resource"`
+	Service   string `json:"service,omitempty"`
+}
+
+// Function is Cloud Functions v1 function metadata.
+type Function struct {
+	ID                   string            // function ID (last segment of name)
+	Location             string            // region
+	Runtime              string            // e.g. "nodejs20"
+	EntryPoint           string            // the source function to execute
+	SourceUploadURL      string            // generated upload URL (fake)
+	SourceArchiveURL     string            // gs:// source archive
+	HttpsTriggerURL      string            // derived deployed URL (output-only)
+	EventTrigger         *EventTrigger     // nil for HTTP-triggered functions
+	EnvironmentVariables map[string]string // env vars available during execution
+	Status               string            // e.g. "ACTIVE"
+	CreateTime           time.Time
+	UpdateTime           time.Time
+	Labels               map[string]string
+	AvailableMemoryMB    int
+	Timeout              string // e.g. "60s"
+	Description          string
+}
+
+// Store is the Cloud Functions v1 store.
+type Store interface {
+	CreateFunction(ctx context.Context, projectID, location, id string, f Function) error
+	GetFunction(ctx context.Context, projectID, location, id string) (Function, error)
+	UpdateFunction(ctx context.Context, projectID, location, id string, f Function) error
+	DeleteFunction(ctx context.Context, projectID, location, id string) error
+	ListFunctions(ctx context.Context, projectID, location string) ([]Function, error)
+
+	Reset(ctx context.Context)
+}

--- a/internal/gcp/store/migrations/020_functions.sql
+++ b/internal/gcp/store/migrations/020_functions.sql
@@ -1,0 +1,23 @@
+-- Cloud Functions v1 metadata. Functions are project+location scoped; the
+-- canonical resource name is
+-- projects/{project}/locations/{location}/functions/{function_id}.
+CREATE TABLE IF NOT EXISTS jc_functions (
+    project_id            TEXT        NOT NULL,
+    location              TEXT        NOT NULL,
+    function_id           TEXT        NOT NULL,
+    runtime               TEXT        NOT NULL DEFAULT '',
+    entry_point           TEXT        NOT NULL DEFAULT '',
+    source_upload_url     TEXT        NOT NULL DEFAULT '',
+    source_archive_url    TEXT        NOT NULL DEFAULT '',
+    https_trigger_url     TEXT        NOT NULL DEFAULT '',
+    event_trigger         JSONB,
+    environment_variables JSONB       NOT NULL DEFAULT '{}',
+    status                TEXT        NOT NULL DEFAULT 'ACTIVE',
+    create_time           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    update_time           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    labels                JSONB       NOT NULL DEFAULT '{}',
+    available_memory_mb   INT         NOT NULL DEFAULT 256,
+    timeout               TEXT        NOT NULL DEFAULT '60s',
+    description           TEXT        NOT NULL DEFAULT '',
+    PRIMARY KEY (project_id, location, function_id)
+);

--- a/tests/integration/gcp/functions_test.go
+++ b/tests/integration/gcp/functions_test.go
@@ -1,0 +1,55 @@
+package gcp_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFunctionsAcceptanceFlow covers the Cloud Functions v1 wire surface:
+// create → get → list → call (mock echo) → delete, over the JSON REST API.
+func TestFunctionsAcceptanceFlow(t *testing.T) {
+	resetState(t)
+
+	const project = "proj"
+	const location = "us-central1"
+	base := "/v1/projects/" + project + "/locations/" + location + "/functions"
+
+	// Create (functionId query param).
+	resp, body := do(t, "POST", base+"?functionId=hello",
+		[]byte(`{"runtime":"nodejs20","entryPoint":"helloWorld"}`),
+		map[string]string{"Content-Type": "application/json"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	fn := jsonMap(t, body)
+	require.Equal(t, "projects/proj/locations/us-central1/functions/hello", fn["name"])
+	require.Equal(t, "ACTIVE", fn["status"])
+	require.Equal(t, "nodejs20", fn["runtime"])
+
+	// Get.
+	resp, body = do(t, "GET", base+"/hello", nil, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "helloWorld", jsonMap(t, body)["entryPoint"])
+
+	// List.
+	resp, body = do(t, "GET", base, nil, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	items, _ := jsonMap(t, body)["functions"].([]any)
+	require.Len(t, items, 1)
+
+	// Call (mock echo returns the request data).
+	resp, body = do(t, "POST", base+"/hello:call",
+		[]byte(`{"data":"ping"}`), map[string]string{"Content-Type": "application/json"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	call := jsonMap(t, body)
+	require.Equal(t, "ping", call["result"])
+	require.NotEmpty(t, call["executionId"])
+
+	// Delete.
+	resp, _ = do(t, "DELETE", base+"/hello", nil, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Gone after delete.
+	resp, _ = do(t, "GET", base+"/hello", nil, nil)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+}

--- a/tests/integration/gcp/sdkv1/functions_test.go
+++ b/tests/integration/gcp/sdkv1/functions_test.go
@@ -1,0 +1,57 @@
+package sdkv1_test
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/api/cloudfunctions/v1"
+	"google.golang.org/api/option"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSDKCloudFunctions exercises the Cloud Functions v1 REST apiary client
+// against the emulator: create (by resource name in the body), get, list, call,
+// and delete.
+func TestSDKCloudFunctions(t *testing.T) {
+	ctx := context.Background()
+	svc, err := cloudfunctions.NewService(ctx, option.WithEndpoint(endpoint()), option.WithoutAuthentication())
+	require.NoError(t, err)
+
+	const parent = "projects/proj/locations/us-central1"
+	name := parent + "/functions/" + unique("fn")
+
+	// Create returns an Operation in real GCP; the emulator completes
+	// synchronously and returns the function resource, so we only assert the
+	// call succeeds and then verify via Get.
+	_, err = svc.Projects.Locations.Functions.Create(parent, &cloudfunctions.CloudFunction{
+		Name:       name,
+		Runtime:    "nodejs20",
+		EntryPoint: "helloWorld",
+	}).Do()
+	require.NoError(t, err)
+
+	fn, err := svc.Projects.Locations.Functions.Get(name).Do()
+	require.NoError(t, err)
+	require.Equal(t, name, fn.Name)
+	require.Equal(t, "nodejs20", fn.Runtime)
+	require.Equal(t, "helloWorld", fn.EntryPoint)
+	require.Equal(t, "ACTIVE", fn.Status)
+
+	list, err := svc.Projects.Locations.Functions.List(parent).Do()
+	require.NoError(t, err)
+	require.NotEmpty(t, list.Functions)
+
+	call, err := svc.Projects.Locations.Functions.Call(name, &cloudfunctions.CallFunctionRequest{
+		Data: "ping",
+	}).Do()
+	require.NoError(t, err)
+	require.Equal(t, "ping", call.Result)
+	require.NotEmpty(t, call.ExecutionId)
+
+	_, err = svc.Projects.Locations.Functions.Delete(name).Do()
+	require.NoError(t, err)
+
+	_, err = svc.Projects.Locations.Functions.Get(name).Do()
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Adds **Cloud Functions v1** (the AWS Lambda analogue) to the `jaiscloud-gcp` emulator, reusing the existing Lambda execution engine.

## Scope

- **Provider** `internal/gcp/provider/functions/` — `CreateFunction`, `GetFunction`, `ListFunctions` (pageToken/pageSize), `UpdateFunction` (PATCH), `DeleteFunction`, `CallFunction` (`:call`), `GenerateUploadUrl`, and IAM (`getIamPolicy`/`setIamPolicy`/`testIamPermissions`, location-scoped).
- **Invocation reuses `internal/executor/lambda`** — `CallFunction` builds an `InvokeRequest` (with `MemoryMB` + parsed `TimeoutSecs` and a `context.WithTimeout`) and returns `{executionId, result}` on success or `{executionId, error}` (HTTP 200) on failure — matching `CallFunctionResponse`. Mock echo by default; Docker/K8s under `JAISCLOUD_EXECUTOR_MODE`.
- **Store** `internal/gcp/store/functions/` — memory + Postgres + snapshot (Snapshotter parity) + migration `020_functions.sql` (`jc_functions`).
- **Adapter + wiring** — `functions` service descriptor, router/jsoncodec/resource formatter, and `main.go` registration.

## Tests

- Provider + store unit tests (incl. location-scoped IAM, executor-error → 200, memory/timeout propagation).
- Raw-HTTP `TestFunctionsAcceptanceFlow` and apiary `TestSDKCloudFunctions`.

## Notes / deviations (documented)

- `Create`/`Patch`/`Delete` return the `CloudFunction`/empty synchronously rather than a `google.longrunning.Operation` (the emulator completes synchronously). Poll-based deploy clients (`gcloud`/Terraform) are out of scope.
- `generateDownloadUrl`, `locations.list`, `updateMask`, and memory/timeout validation are not implemented (follow-ups).

## Verification

`go build` / `go vet` / `gofmt` clean; `go test -race` green for provider + store; no `internal/gcp` regressions; REST regression (`sdkv1` + raw HTTP) green.
