### PR TITLE
fix(gcp): reseed GCS generation on restore; replace time.Now in fires…

### DIFF
--- a/cmd/jaiscloud-gcp/main.go
+++ b/cmd/jaiscloud-gcp/main.go
@@ -173,6 +173,7 @@ func startCmd() *cobra.Command {
 			adminHandler.RegisterResetter(storageP)
 			adminHandler.RegisterResetter(firestoreP)
 			adminHandler.RegisterResetter(firestoreGRPC)
+			adminHandler.RegisterPostRestoreHook(storageP)
 			if snap, ok := stores.resources.(admin.Snapshotter); ok {
 				adminHandler.RegisterSnapshotter("resources", snap)
 			}

--- a/internal/gcp/provider/firestore/service.go
+++ b/internal/gcp/provider/firestore/service.go
@@ -86,7 +86,7 @@ type readSet struct {
 func newTxnID() []byte {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
-		return []byte(time.Now().Format(time.RFC3339Nano))
+		return []byte(clock.Now().Format(time.RFC3339Nano))
 	}
 	return b
 }

--- a/internal/gcp/provider/storage/storage.go
+++ b/internal/gcp/provider/storage/storage.go
@@ -129,6 +129,17 @@ func (p *Provider) SeedGeneration(ctx context.Context) {
 	p.seedGeneration(ctx)
 }
 
+// Name satisfies admin.PostRestoreHook.
+func (p *Provider) Name() string { return "gcs-generation" }
+
+// OnRestore re-seeds the generation counter after an admin import so that
+// generations stay monotonic past the highest generation present in the
+// imported snapshot (mirrors the startup-time SeedGeneration call).
+func (p *Provider) OnRestore(ctx context.Context) error {
+	p.SeedGeneration(ctx)
+	return nil
+}
+
 // nextGen returns a unique, monotonically-increasing object generation.
 func (p *Provider) nextGen() string {
 	p.genMu.Lock()


### PR DESCRIPTION
…tore

- Register storage.Provider as a PostRestoreHook so GCS object generation counter is re-seeded after admin import, keeping generations monotonic.
- Replace the only non-test time.Now() in provider code (firestore newTxnID fallback) with clock.Now(), preserving frozen/offset clock behavior.

## Description
Short description of the change and the motivation.

## How to test
Describe steps to reproduce and test the change. Include commands to run unit and integration tests if applicable.

## Checklist
- [ ] I have run `gofmt` and `goimports` on my changes
- [ ] I have added/updated tests where applicable
- [ ] CI passes (unit + integration)
- [ ] I have added documentation if needed
