### PR TITLE
feat(gcp): Cloud Datastore (Datastore mode) emulator

### DIFF
--- a/cmd/jaiscloud-gcp/main.go
+++ b/cmd/jaiscloud-gcp/main.go
@@ -23,6 +23,7 @@ import (
 	gcpadapter "jaiscloud/internal/gcp/adapter"
 	"jaiscloud/internal/gcp/crypto"
 	grpcserver "jaiscloud/internal/gcp/grpc"
+	grpcdatastore "jaiscloud/internal/gcp/grpc/datastore"
 	grpcfirestore "jaiscloud/internal/gcp/grpc/firestore"
 	grpckms "jaiscloud/internal/gcp/grpc/kms"
 	grpclogging "jaiscloud/internal/gcp/grpc/logging"
@@ -39,6 +40,7 @@ import (
 	secretmanagerprovider "jaiscloud/internal/gcp/provider/secretmanager"
 	storageprovider "jaiscloud/internal/gcp/provider/storage"
 	gcpstore "jaiscloud/internal/gcp/store"
+	datastorestore "jaiscloud/internal/gcp/store/datastore"
 	firestorestore "jaiscloud/internal/gcp/store/firestore"
 	functionsstore "jaiscloud/internal/gcp/store/functions"
 	"jaiscloud/internal/gcp/store/gcs"
@@ -53,6 +55,7 @@ import (
 	"jaiscloud/internal/snapshottypes"
 	"jaiscloud/internal/store"
 
+	datastorepb "cloud.google.com/go/datastore/apiv1/datastorepb"
 	firestorepb "cloud.google.com/go/firestore/apiv1/firestorepb"
 	iampb "cloud.google.com/go/iam/apiv1/iampb"
 	kmspb "cloud.google.com/go/kms/apiv1/kmspb"
@@ -174,8 +177,10 @@ func startCmd() *cobra.Command {
 			kmsGRPC := grpckms.NewService(stores.keys, stores.resources, crypto.NewEnvelopeEncryptor(stores.keys), cfg.ProjectID)
 			loggingGRPC := grpclogging.NewService(stores.logEntries, cfg.ProjectID)
 			storageGRPC := grpcstorage.NewService(stores.objects, storageP, cfg.ProjectID)
+			datastoreGRPC := grpcdatastore.NewService(stores.entities, cfg.ProjectID)
 			gserv := grpcserver.NewServer(fmt.Sprintf(":%d", grpcPort))
 			firestorepb.RegisterFirestoreServer(gserv.GRPC(), firestoreGRPC)
+			datastorepb.RegisterDatastoreServer(gserv.GRPC(), datastoreGRPC)
 			pubsubpb.RegisterPublisherServer(gserv.GRPC(), pubsubGRPC)
 			pubsubpb.RegisterSubscriberServer(gserv.GRPC(), pubsubGRPC)
 			kmspb.RegisterKeyManagementServiceServer(gserv.GRPC(), kmsGRPC)
@@ -200,6 +205,7 @@ func startCmd() *cobra.Command {
 			adminHandler.RegisterResetter(stores.secrets)
 			adminHandler.RegisterResetter(stores.keys)
 			adminHandler.RegisterResetter(stores.documents)
+			adminHandler.RegisterResetter(stores.entities)
 			adminHandler.RegisterResetter(stores.functions)
 			adminHandler.RegisterResetter(stores.logEntries)
 			adminHandler.RegisterResetter(stores.resources)
@@ -225,6 +231,9 @@ func startCmd() *cobra.Command {
 			}
 			if snap, ok := stores.documents.(admin.Snapshotter); ok {
 				adminHandler.RegisterSnapshotter("firestore_documents", snap)
+			}
+			if snap, ok := stores.entities.(admin.Snapshotter); ok {
+				adminHandler.RegisterSnapshotter("datastore_entities", snap)
 			}
 			if snap, ok := stores.functions.(admin.Snapshotter); ok {
 				adminHandler.RegisterSnapshotter("functions", snap)
@@ -392,6 +401,7 @@ type stores struct {
 	secrets    secretmanagerstore.Store
 	keys       kmsstore.Store
 	documents  firestorestore.FirestoreStore
+	entities   datastorestore.Store
 	functions  functionsstore.Store
 	logEntries loggingstore.Store
 	resources  store.ResourceStore
@@ -420,6 +430,7 @@ func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*st
 			secrets:    secretmanagerstore.NewPostgresStore(pg.Pool()),
 			keys:       kmsstore.NewPostgresStore(pg.Pool()),
 			documents:  firestorestore.NewPostgresStore(pg.Pool()),
+			entities:   datastorestore.NewPostgresStore(pg.Pool()),
 			functions:  functionsstore.NewPostgresStore(pg.Pool()),
 			logEntries: loggingstore.NewPostgresStore(pg.Pool()),
 			resources:  pg,
@@ -434,6 +445,7 @@ func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*st
 			secrets:    secretmanagerstore.NewMemoryStore(),
 			keys:       kmsstore.NewMemoryStore(),
 			documents:  firestorestore.NewMemoryStore(),
+			entities:   datastorestore.NewMemoryStore(),
 			functions:  functionsstore.NewMemoryStore(),
 			logEntries: loggingstore.NewMemoryStore(),
 			resources:  store.NewMemoryResourceStore(),
@@ -451,6 +463,7 @@ func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*st
 		secrets:    secretmanagerstore.NewMemoryStore(),
 		keys:       kmsstore.NewMemoryStore(),
 		documents:  firestorestore.NewMemoryStore(),
+		entities:   datastorestore.NewMemoryStore(),
 		functions:  functionsstore.NewMemoryStore(),
 		logEntries: loggingstore.NewMemoryStore(),
 		resources:  store.NewMemoryResourceStore(),

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module jaiscloud
 go 1.26.3
 
 require (
+	cloud.google.com/go/datastore v1.22.0
 	cloud.google.com/go/firestore v1.25.0
 	cloud.google.com/go/iam v1.13.0
 	cloud.google.com/go/kms v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/datastore v1.22.0 h1:FOyx2Ag6ibD2wFkz9S8EiNrmBugia8pQOfpyJxi2yqA=
+cloud.google.com/go/datastore v1.22.0/go.mod h1:aopSX+Whx0lHspWWBj+AjWt68/zjYsPfDe3LjWtqZg8=
 cloud.google.com/go/firestore v1.25.0 h1:yY3rQKyQXNhnhETdseNayF6W1p4x0bdg9ZYS4hKJfOw=
 cloud.google.com/go/firestore v1.25.0/go.mod h1:0PU6hj+r/QlhB6BLsRX+Kt/SYefTXrpYrBeHbYaSis8=
 cloud.google.com/go/iam v1.13.0 h1:ufT3FPT5rFFXu6UtLkNoxaOaV5EuA1dsSkmemCSTo6U=

--- a/internal/gcp/grpc/datastore/service.go
+++ b/internal/gcp/grpc/datastore/service.go
@@ -1,0 +1,763 @@
+// Package datastore implements the Cloud Datastore (v1) gRPC service
+// (google.datastore.v1.Datastore) over the shared datastorestore.Store, so
+// entities written via the Go SDK are stored and queried consistently.
+//
+// The emulator is intentionally non-transactional: it does not implement
+// optimistic-concurrency transactions. BeginTransaction mints an opaque id so
+// SDK init paths that poll the transaction surface do not error, and
+// Rollback is a no-op, but a TRANSACTIONAL Commit (or a Commit carrying a
+// transaction selector) is rejected with Unimplemented rather than being
+// silently committed as a non-transactional write.
+package datastore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	datastorepb "cloud.google.com/go/datastore/apiv1/datastorepb"
+
+	grpcutil "jaiscloud/internal/gcp/grpc"
+	datastorestore "jaiscloud/internal/gcp/store/datastore"
+	"jaiscloud/internal/model"
+
+	"google.golang.org/genproto/googleapis/type/latlng"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Service implements datastorepb.DatastoreServer over the shared store.
+type Service struct {
+	datastorepb.UnimplementedDatastoreServer
+
+	store       datastorestore.Store
+	defaultProj string
+}
+
+// NewService returns a Datastore gRPC service backed by the shared store.
+// defaultProj is the config-default project used when a request carries none.
+func NewService(store datastorestore.Store, defaultProj string) *Service {
+	return &Service{store: store, defaultProj: defaultProj}
+}
+
+// mapError translates a store/service error into a gRPC status error. The
+// store's ErrInvalidKey sentinel is not a ProviderError, so it is mapped to
+// InvalidArgument here rather than falling through to Internal.
+func mapError(err error) error {
+	if errors.Is(err, datastorestore.ErrInvalidKey) {
+		return grpcutil.GRPCStatus(model.NewProviderError("InvalidArgument", "invalid key", 400))
+	}
+	return grpcutil.GRPCStatus(err)
+}
+
+// txnSeq mints opaque transaction ids for BeginTransaction (non-transactional
+// operations do not need full OCC; a unique id suffices so SDK init paths that
+// poll the txn surface do not error).
+var txnSeq int64
+
+func (s *Service) project(ctx context.Context, reqProject string) string {
+	if reqProject != "" {
+		return reqProject
+	}
+	return grpcutil.ProjectFromMetadata(ctx, s.defaultProj)
+}
+
+// ─── Datastore service ────────────────────────────────────────────────────────
+
+func (s *Service) Commit(ctx context.Context, req *datastorepb.CommitRequest) (*datastorepb.CommitResponse, error) {
+	// The emulator is non-transactional: a TRANSACTIONAL commit (or one carrying
+	// a transaction selector) is rejected rather than silently applied as a
+	// non-transactional write. See the package doc.
+	if req.GetMode() == datastorepb.CommitRequest_TRANSACTIONAL || len(req.GetTransaction()) > 0 {
+		return nil, mapError(model.NewProviderError("UnsupportedOperation", "transactions are not supported by this emulator", 501))
+	}
+
+	project := s.project(ctx, req.GetProjectId())
+	results := make([]*datastorepb.MutationResult, 0, len(req.GetMutations()))
+	for _, m := range req.GetMutations() {
+		mr := &datastorepb.MutationResult{Version: 1}
+		switch op := m.GetOperation().(type) {
+		case *datastorepb.Mutation_Insert:
+			e, allocated, err := s.resolveEntity(ctx, project, op.Insert)
+			if err != nil {
+				return nil, mapError(err)
+			}
+			if err := s.store.Insert(ctx, project, e); err != nil {
+				if errors.Is(err, datastorestore.ErrEntityExists) {
+					return nil, mapError(model.NewProviderError("AlreadyExists", "entity already exists", 409))
+				}
+				return nil, mapError(err)
+			}
+			if allocated {
+				mr.Key = keyProto(e.Key, project)
+			}
+		case *datastorepb.Mutation_Upsert:
+			e, allocated, err := s.resolveEntity(ctx, project, op.Upsert)
+			if err != nil {
+				return nil, mapError(err)
+			}
+			if err := s.store.Upsert(ctx, project, e); err != nil {
+				return nil, mapError(err)
+			}
+			if allocated {
+				mr.Key = keyProto(e.Key, project)
+			}
+		case *datastorepb.Mutation_Update:
+			e, err := entityFromProto(op.Update)
+			if err != nil {
+				return nil, mapError(err)
+			}
+			if e.Key == "" {
+				return nil, mapError(model.NewProviderError("InvalidArgument", "update key is incomplete", 400))
+			}
+			if err := s.store.Update(ctx, project, e); err != nil {
+				if errors.Is(err, datastorestore.ErrEntityNotFound) {
+					return nil, mapError(model.NewProviderError("FailedPrecondition", "entity not found", 404))
+				}
+				return nil, mapError(err)
+			}
+		case *datastorepb.Mutation_Delete:
+			key, err := deleteKey(op.Delete)
+			if err != nil {
+				return nil, mapError(err)
+			}
+			if err := s.store.Delete(ctx, project, key); err != nil {
+				return nil, mapError(err)
+			}
+		default:
+			return nil, mapError(model.NewProviderError("InvalidArgument", "mutation has no operation", 400))
+		}
+		results = append(results, mr)
+	}
+	return &datastorepb.CommitResponse{
+		MutationResults: results,
+		// CommitTime is not set for non-transactional commits (see the proto).
+	}, nil
+}
+
+func (s *Service) Lookup(ctx context.Context, req *datastorepb.LookupRequest) (*datastorepb.LookupResponse, error) {
+	project := s.project(ctx, req.GetProjectId())
+	resp := &datastorepb.LookupResponse{}
+	for _, k := range req.GetKeys() {
+		key, kind, complete, err := canonicalKey(k)
+		if err != nil {
+			return nil, mapError(err)
+		}
+		if !complete {
+			return nil, mapError(model.NewProviderError("InvalidArgument", "lookup key is incomplete", 400))
+		}
+		e, err := s.store.Get(ctx, project, key)
+		switch {
+		case errors.Is(err, datastorestore.ErrEntityNotFound):
+			resp.Missing = append(resp.Missing, &datastorepb.EntityResult{
+				Entity:  &datastorepb.Entity{Key: keyProto(key, project)},
+				Version: 1,
+			})
+		case err != nil:
+			return nil, mapError(err)
+		default:
+			_ = kind
+			resp.Found = append(resp.Found, &datastorepb.EntityResult{
+				Entity:  entityToProto(e, project),
+				Version: 1,
+			})
+		}
+	}
+	return resp, nil
+}
+
+func (s *Service) RunQuery(ctx context.Context, req *datastorepb.RunQueryRequest) (*datastorepb.RunQueryResponse, error) {
+	project := s.project(ctx, req.GetProjectId())
+	batch := &datastorepb.QueryResultBatch{
+		EntityResultType: datastorepb.EntityResult_FULL,
+		MoreResults:      datastorepb.QueryResultBatch_NO_MORE_RESULTS,
+	}
+
+	var q *datastorepb.Query
+	switch qt := req.GetQueryType().(type) {
+	case *datastorepb.RunQueryRequest_Query:
+		q = qt.Query
+	case *datastorepb.RunQueryRequest_GqlQuery:
+		return nil, mapError(model.NewProviderError("InvalidArgument", "GQL queries are not supported", 400))
+	default:
+		return nil, mapError(model.NewProviderError("InvalidArgument", "run query request has no query", 400))
+	}
+
+	kind := ""
+	if q != nil && len(q.GetKind()) > 0 {
+		kind = q.GetKind()[0].GetName()
+	}
+	entities, err := s.store.ListKind(ctx, project, kind)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	for _, e := range entities {
+		if q != nil {
+			match, err := matchesFilter(e, q.GetFilter())
+			if err != nil {
+				return nil, mapError(err)
+			}
+			if !match {
+				continue
+			}
+		}
+		batch.EntityResults = append(batch.EntityResults, &datastorepb.EntityResult{
+			Entity:  entityToProto(e, project),
+			Version: 1,
+		})
+	}
+	return &datastorepb.RunQueryResponse{Batch: batch}, nil
+}
+
+func (s *Service) BeginTransaction(ctx context.Context, req *datastorepb.BeginTransactionRequest) (*datastorepb.BeginTransactionResponse, error) {
+	return &datastorepb.BeginTransactionResponse{
+		Transaction: []byte("txn-" + strconv.FormatInt(atomic.AddInt64(&txnSeq, 1), 10)),
+	}, nil
+}
+
+func (s *Service) Rollback(ctx context.Context, req *datastorepb.RollbackRequest) (*datastorepb.RollbackResponse, error) {
+	return &datastorepb.RollbackResponse{}, nil
+}
+
+func (s *Service) AllocateIds(ctx context.Context, req *datastorepb.AllocateIdsRequest) (*datastorepb.AllocateIdsResponse, error) {
+	project := s.project(ctx, req.GetProjectId())
+	// AllocateIds only accepts incomplete keys; a complete key is rejected.
+	for _, k := range req.GetKeys() {
+		_, _, complete, err := canonicalKey(k)
+		if err != nil {
+			return nil, mapError(err)
+		}
+		if complete {
+			return nil, mapError(model.NewProviderError("InvalidArgument", "allocate ids requires incomplete keys", 400))
+		}
+	}
+	ids, err := s.store.AllocateIDs(ctx, project, len(req.GetKeys()))
+	if err != nil {
+		return nil, mapError(err)
+	}
+	resp := &datastorepb.AllocateIdsResponse{}
+	for i, k := range req.GetKeys() {
+		completed, err := completeKey(k, project, ids[i])
+		if err != nil {
+			return nil, mapError(err)
+		}
+		resp.Keys = append(resp.Keys, completed)
+	}
+	return resp, nil
+}
+
+// resolveEntity transcodes a mutation entity and, when its key path is
+// incomplete, allocates a numeric ID. The bool reports whether an ID was
+// allocated (so Commit can echo the resolved key back in MutationResult.Key).
+// For an explicitly-keyed entity, the per-project ID allocator is advanced past
+// the explicit numeric ID so AllocateIds never reissues an ID already in use.
+func (s *Service) resolveEntity(ctx context.Context, project string, p *datastorepb.Entity) (datastorestore.Entity, bool, error) {
+	e, err := entityFromProto(p)
+	if err != nil {
+		return e, false, err
+	}
+	if e.Key == "" {
+		ids, err := s.store.AllocateIDs(ctx, project, 1)
+		if err != nil {
+			return e, false, err
+		}
+		e.Key = datastorestore.KeyOfID(e.Kind, ids[0])
+		return e, true, nil
+	}
+	if err := s.advanceAllocator(ctx, project, e.Key); err != nil {
+		return e, false, err
+	}
+	return e, false, nil
+}
+
+// advanceAllocator advances the project's ID allocator past an explicitly-used
+// numeric ID (name keys are ignored; they never collide with allocated IDs).
+func (s *Service) advanceAllocator(ctx context.Context, project, key string) error {
+	_, idOrName, ok := datastorestore.SplitKey(key)
+	if !ok {
+		return nil
+	}
+	id, _, isID := datastorestore.ParseIDOrName(idOrName)
+	if !isID {
+		return nil
+	}
+	return s.store.AdvanceIDs(ctx, project, id)
+}
+
+// deleteKey requires a complete key and returns its canonical string.
+func deleteKey(k *datastorepb.Key) (string, error) {
+	key, _, complete, err := canonicalKey(k)
+	if err != nil {
+		return "", err
+	}
+	if !complete {
+		return "", model.NewProviderError("InvalidArgument", "delete key is incomplete", 400)
+	}
+	return key, nil
+}
+
+// ─── key transcoding ──────────────────────────────────────────────────────────
+
+// canonicalKey converts a proto Key to the store's canonical key string
+// "kind/id-or-name" using the (single, last) path element's kind and
+// id-or-name. complete is false for an incomplete key path. Ancestor
+// (multi-element) paths and non-default namespace/database scopes are not
+// supported and return InvalidArgument rather than silently collapsing to the
+// last path element.
+func canonicalKey(k *datastorepb.Key) (key, kind string, complete bool, err error) {
+	if k == nil {
+		return "", "", false, nil
+	}
+	if pid := k.GetPartitionId(); pid != nil {
+		if pid.GetNamespaceId() != "" {
+			return "", "", false, model.NewProviderError("InvalidArgument", "namespaced keys are not supported", 400)
+		}
+		if pid.GetDatabaseId() != "" {
+			return "", "", false, model.NewProviderError("InvalidArgument", "database-scoped keys are not supported", 400)
+		}
+	}
+	path := k.GetPath()
+	if len(path) == 0 {
+		return "", "", false, nil
+	}
+	if len(path) > 1 {
+		return "", "", false, model.NewProviderError("InvalidArgument", "ancestor keys are not supported", 400)
+	}
+	el := path[0]
+	kind = el.GetKind()
+	if id, ok := el.GetIdType().(*datastorepb.Key_PathElement_Id); ok {
+		return datastorestore.KeyOfID(kind, id.Id), kind, true, nil
+	}
+	if name, ok := el.GetIdType().(*datastorepb.Key_PathElement_Name); ok {
+		return datastorestore.KeyOfName(kind, name.Name), kind, true, nil
+	}
+	return "", kind, false, nil
+}
+
+// keyProto reconstructs a single-element proto Key from the canonical key
+// string, tagging the partition with the owning project.
+func keyProto(key, project string) *datastorepb.Key {
+	kind, idOrName, ok := datastorestore.SplitKey(key)
+	if !ok {
+		return nil
+	}
+	el := &datastorepb.Key_PathElement{Kind: kind}
+	id, name, isID := datastorestore.ParseIDOrName(idOrName)
+	if isID {
+		el.IdType = &datastorepb.Key_PathElement_Id{Id: id}
+	} else {
+		el.IdType = &datastorepb.Key_PathElement_Name{Name: name}
+	}
+	return &datastorepb.Key{
+		PartitionId: &datastorepb.PartitionId{ProjectId: project},
+		Path:        []*datastorepb.Key_PathElement{el},
+	}
+}
+
+// completeKey fills the last path element of an incomplete key with the given
+// numeric ID, preserving partition and ancestor path elements.
+func completeKey(k *datastorepb.Key, project string, id int64) (*datastorepb.Key, error) {
+	if k == nil || len(k.GetPath()) == 0 {
+		return nil, model.NewProviderError("InvalidArgument", "cannot allocate an id for an empty key path", 400)
+	}
+	out := &datastorepb.Key{
+		PartitionId: k.GetPartitionId(),
+		Path:        make([]*datastorepb.Key_PathElement, len(k.GetPath())),
+	}
+	for i, el := range k.GetPath() {
+		out.Path[i] = &datastorepb.Key_PathElement{Kind: el.GetKind()}
+		if i < len(k.GetPath())-1 {
+			out.Path[i].IdType = el.GetIdType()
+		} else {
+			out.Path[i].IdType = &datastorepb.Key_PathElement_Id{Id: id}
+		}
+	}
+	if out.PartitionId == nil {
+		out.PartitionId = &datastorepb.PartitionId{ProjectId: project}
+	} else if out.PartitionId.GetProjectId() == "" {
+		out.PartitionId.ProjectId = project
+	}
+	return out, nil
+}
+
+// ─── entity transcoding ───────────────────────────────────────────────────────
+
+func entityFromProto(p *datastorepb.Entity) (datastorestore.Entity, error) {
+	e := datastorestore.Entity{Properties: map[string]datastorestore.Value{}}
+	if p == nil {
+		return e, nil
+	}
+	if k := p.GetKey(); k != nil {
+		key, kind, complete, err := canonicalKey(k)
+		if err != nil {
+			return e, err
+		}
+		e.Kind = kind
+		if complete {
+			e.Key = key
+		}
+	}
+	for name, v := range p.GetProperties() {
+		sv, err := valueFromProto(v)
+		if err != nil {
+			return e, err
+		}
+		e.Properties[name] = sv
+	}
+	return e, nil
+}
+
+func entityToProto(e datastorestore.Entity, project string) *datastorepb.Entity {
+	props := make(map[string]*datastorepb.Value, len(e.Properties))
+	for name, v := range e.Properties {
+		props[name] = valueToProto(v, project)
+	}
+	out := &datastorepb.Entity{Properties: props}
+	if e.Key != "" {
+		out.Key = keyProto(e.Key, project)
+	}
+	return out
+}
+
+// ─── value transcoding ────────────────────────────────────────────────────────
+
+func valueFromProto(p *datastorepb.Value) (datastorestore.Value, error) {
+	if p == nil {
+		return datastorestore.Value{}, nil
+	}
+	switch v := p.GetValueType().(type) {
+	case *datastorepb.Value_NullValue:
+		s := "NULL_VALUE"
+		return datastorestore.Value{NullValue: &s}, nil
+	case *datastorepb.Value_BooleanValue:
+		b := v.BooleanValue
+		return datastorestore.Value{BooleanValue: &b}, nil
+	case *datastorepb.Value_IntegerValue:
+		n := v.IntegerValue
+		return datastorestore.Value{IntegerValue: &n}, nil
+	case *datastorepb.Value_DoubleValue:
+		f := v.DoubleValue
+		return datastorestore.Value{DoubleValue: &f}, nil
+	case *datastorepb.Value_TimestampValue:
+		s := v.TimestampValue.AsTime().UTC().Format(time.RFC3339Nano)
+		return datastorestore.Value{TimestampValue: &s}, nil
+	case *datastorepb.Value_KeyValue:
+		key, _, complete, err := canonicalKey(v.KeyValue)
+		if err != nil {
+			return datastorestore.Value{}, err
+		}
+		if !complete {
+			return datastorestore.Value{}, model.NewProviderError("InvalidArgument", "key value is incomplete", 400)
+		}
+		return datastorestore.Value{KeyValue: &key}, nil
+	case *datastorepb.Value_StringValue:
+		s := v.StringValue
+		return datastorestore.Value{StringValue: &s}, nil
+	case *datastorepb.Value_BlobValue:
+		return datastorestore.Value{BlobValue: v.BlobValue}, nil
+	case *datastorepb.Value_GeoPointValue:
+		g := datastorestore.GeoPoint{
+			Latitude:  v.GeoPointValue.GetLatitude(),
+			Longitude: v.GeoPointValue.GetLongitude(),
+		}
+		return datastorestore.Value{GeoPointValue: &g}, nil
+	case *datastorepb.Value_EntityValue:
+		e, err := entityFromProto(v.EntityValue)
+		if err != nil {
+			return datastorestore.Value{}, err
+		}
+		return datastorestore.Value{EntityValue: &e}, nil
+	case *datastorepb.Value_ArrayValue:
+		arr := datastorestore.ArrayValue{Values: make([]datastorestore.Value, 0, len(v.ArrayValue.GetValues()))}
+		for _, x := range v.ArrayValue.GetValues() {
+			xv, err := valueFromProto(x)
+			if err != nil {
+				return datastorestore.Value{}, err
+			}
+			arr.Values = append(arr.Values, xv)
+		}
+		return datastorestore.Value{ArrayValue: &arr}, nil
+	}
+	return datastorestore.Value{}, nil
+}
+
+func valueToProto(v datastorestore.Value, project string) *datastorepb.Value {
+	switch {
+	case v.NullValue != nil:
+		return &datastorepb.Value{ValueType: &datastorepb.Value_NullValue{NullValue: structpb.NullValue_NULL_VALUE}}
+	case v.BooleanValue != nil:
+		return &datastorepb.Value{ValueType: &datastorepb.Value_BooleanValue{BooleanValue: *v.BooleanValue}}
+	case v.IntegerValue != nil:
+		return &datastorepb.Value{ValueType: &datastorepb.Value_IntegerValue{IntegerValue: *v.IntegerValue}}
+	case v.DoubleValue != nil:
+		return &datastorepb.Value{ValueType: &datastorepb.Value_DoubleValue{DoubleValue: *v.DoubleValue}}
+	case v.TimestampValue != nil:
+		t, err := time.Parse(time.RFC3339Nano, *v.TimestampValue)
+		if err != nil {
+			t = time.Time{}
+		}
+		return &datastorepb.Value{ValueType: &datastorepb.Value_TimestampValue{TimestampValue: timestamppb.New(t)}}
+	case v.KeyValue != nil:
+		return &datastorepb.Value{ValueType: &datastorepb.Value_KeyValue{KeyValue: keyProto(*v.KeyValue, project)}}
+	case v.StringValue != nil:
+		return &datastorepb.Value{ValueType: &datastorepb.Value_StringValue{StringValue: *v.StringValue}}
+	case v.BlobValue != nil:
+		return &datastorepb.Value{ValueType: &datastorepb.Value_BlobValue{BlobValue: v.BlobValue}}
+	case v.GeoPointValue != nil:
+		return &datastorepb.Value{ValueType: &datastorepb.Value_GeoPointValue{GeoPointValue: &latlng.LatLng{
+			Latitude:  v.GeoPointValue.Latitude,
+			Longitude: v.GeoPointValue.Longitude,
+		}}}
+	case v.EntityValue != nil:
+		return &datastorepb.Value{ValueType: &datastorepb.Value_EntityValue{EntityValue: entityToProto(*v.EntityValue, project)}}
+	case v.ArrayValue != nil:
+		arr := &datastorepb.ArrayValue{Values: make([]*datastorepb.Value, 0, len(v.ArrayValue.Values))}
+		for _, x := range v.ArrayValue.Values {
+			arr.Values = append(arr.Values, valueToProto(x, project))
+		}
+		return &datastorepb.Value{ValueType: &datastorepb.Value_ArrayValue{ArrayValue: arr}}
+	}
+	return &datastorepb.Value{}
+}
+
+// ─── query filter evaluation ──────────────────────────────────────────────────
+
+// matchesFilter evaluates a Query.Filter against an entity. It supports
+// PropertyFilter EQUAL, NOT_EQUAL, IN, and the four comparison operators
+// (LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL), and
+// CompositeFilter AND over those property filters. Unsupported operators
+// (HAS_ANCESTOR, NOT_IN, unspecified/unknown) and CompositeFilter OR return an
+// InvalidArgument error rather than matching everything.
+func matchesFilter(e datastorestore.Entity, f *datastorepb.Filter) (bool, error) {
+	if f == nil {
+		return true, nil
+	}
+	switch ft := f.GetFilterType().(type) {
+	case *datastorepb.Filter_PropertyFilter:
+		return matchesPropertyFilter(e, ft.PropertyFilter)
+	case *datastorepb.Filter_CompositeFilter:
+		cf := ft.CompositeFilter
+		if cf == nil {
+			return true, nil
+		}
+		switch cf.GetOp() {
+		case datastorepb.CompositeFilter_AND:
+			for _, sub := range cf.GetFilters() {
+				match, err := matchesFilter(e, sub)
+				if err != nil {
+					return false, err
+				}
+				if !match {
+					return false, nil
+				}
+			}
+			return true, nil
+		default:
+			return false, unsupportedQueryOperator(cf.GetOp().String())
+		}
+	default:
+		return false, unsupportedQueryOperator("unknown filter")
+	}
+}
+
+// unsupportedQueryOperator returns an InvalidArgument error for a filter
+// operator the emulator does not implement (fail closed, never match-all).
+func unsupportedQueryOperator(op string) error {
+	return model.NewProviderError("InvalidArgument", "unsupported query operator: "+op, 400)
+}
+
+func matchesPropertyFilter(e datastorestore.Entity, pf *datastorepb.PropertyFilter) (bool, error) {
+	if pf == nil || pf.GetProperty() == nil {
+		return false, unsupportedQueryOperator("missing property filter")
+	}
+	prop := pf.GetProperty().GetName()
+	val, ok := e.Properties[prop]
+
+	filterVal, err := valueFromProto(pf.GetValue())
+	if err != nil {
+		return false, err
+	}
+
+	switch pf.GetOp() {
+	case datastorepb.PropertyFilter_EQUAL:
+		return ok && valueEqual(val, filterVal), nil
+	case datastorepb.PropertyFilter_NOT_EQUAL:
+		return ok && !valueEqual(val, filterVal), nil
+	case datastorepb.PropertyFilter_IN:
+		if !ok || filterVal.ArrayValue == nil {
+			return false, nil
+		}
+		for _, el := range filterVal.ArrayValue.Values {
+			if valueEqual(val, el) {
+				return true, nil
+			}
+		}
+		return false, nil
+	case datastorepb.PropertyFilter_LESS_THAN,
+		datastorepb.PropertyFilter_LESS_THAN_OR_EQUAL,
+		datastorepb.PropertyFilter_GREATER_THAN,
+		datastorepb.PropertyFilter_GREATER_THAN_OR_EQUAL:
+		if !ok {
+			return false, nil
+		}
+		c, comparable := valueCompare(val, filterVal)
+		if !comparable {
+			return false, nil
+		}
+		switch pf.GetOp() {
+		case datastorepb.PropertyFilter_LESS_THAN:
+			return c < 0, nil
+		case datastorepb.PropertyFilter_LESS_THAN_OR_EQUAL:
+			return c <= 0, nil
+		case datastorepb.PropertyFilter_GREATER_THAN:
+			return c > 0, nil
+		default:
+			return c >= 0, nil
+		}
+	default:
+		return false, unsupportedQueryOperator(pf.GetOp().String())
+	}
+}
+
+// numericValue reports the numeric value of v (integer or double) as a float64.
+func numericValue(v datastorestore.Value) (float64, bool) {
+	if v.IntegerValue != nil {
+		return float64(*v.IntegerValue), true
+	}
+	if v.DoubleValue != nil {
+		return *v.DoubleValue, true
+	}
+	return 0, false
+}
+
+// valueCompare compares two values for ordering, returning -1, 0, or 1. ok is
+// false when the two values are not orderable (different types, or an
+// unsupported type such as geo point/entity/array). Integers and doubles
+// compare numerically, matching Datastore semantics.
+func valueCompare(a, b datastorestore.Value) (int, bool) {
+	an, aNum := numericValue(a)
+	bn, bNum := numericValue(b)
+	if aNum || bNum {
+		if !aNum || !bNum {
+			return 0, false
+		}
+		switch {
+		case an < bn:
+			return -1, true
+		case an > bn:
+			return 1, true
+		default:
+			return 0, true
+		}
+	}
+	switch {
+	case a.StringValue != nil || b.StringValue != nil:
+		if a.StringValue == nil || b.StringValue == nil {
+			return 0, false
+		}
+		return strings.Compare(*a.StringValue, *b.StringValue), true
+	case a.BooleanValue != nil || b.BooleanValue != nil:
+		if a.BooleanValue == nil || b.BooleanValue == nil {
+			return 0, false
+		}
+		switch {
+		case *a.BooleanValue == *b.BooleanValue:
+			return 0, true
+		case !*a.BooleanValue && *b.BooleanValue:
+			return -1, true
+		default:
+			return 1, true
+		}
+	case a.TimestampValue != nil || b.TimestampValue != nil:
+		if a.TimestampValue == nil || b.TimestampValue == nil {
+			return 0, false
+		}
+		at, errA := time.Parse(time.RFC3339Nano, *a.TimestampValue)
+		bt, errB := time.Parse(time.RFC3339Nano, *b.TimestampValue)
+		if errA != nil || errB != nil {
+			return 0, false
+		}
+		switch {
+		case at.Before(bt):
+			return -1, true
+		case at.After(bt):
+			return 1, true
+		default:
+			return 0, true
+		}
+	case a.KeyValue != nil || b.KeyValue != nil:
+		if a.KeyValue == nil || b.KeyValue == nil {
+			return 0, false
+		}
+		return strings.Compare(*a.KeyValue, *b.KeyValue), true
+	case a.BlobValue != nil || b.BlobValue != nil:
+		if a.BlobValue == nil || b.BlobValue == nil {
+			return 0, false
+		}
+		return bytes.Compare(a.BlobValue, b.BlobValue), true
+	}
+	return 0, false
+}
+
+func valueEqual(a, b datastorestore.Value) bool {
+	an, aNum := numericValue(a)
+	bn, bNum := numericValue(b)
+	if aNum || bNum {
+		return aNum && bNum && an == bn
+	}
+	switch {
+	case a.NullValue != nil || b.NullValue != nil:
+		return a.NullValue != nil && b.NullValue != nil
+	case a.BooleanValue != nil || b.BooleanValue != nil:
+		return a.BooleanValue != nil && b.BooleanValue != nil && *a.BooleanValue == *b.BooleanValue
+	case a.StringValue != nil || b.StringValue != nil:
+		return a.StringValue != nil && b.StringValue != nil && *a.StringValue == *b.StringValue
+	case a.TimestampValue != nil || b.TimestampValue != nil:
+		return a.TimestampValue != nil && b.TimestampValue != nil && *a.TimestampValue == *b.TimestampValue
+	case a.KeyValue != nil || b.KeyValue != nil:
+		return a.KeyValue != nil && b.KeyValue != nil && *a.KeyValue == *b.KeyValue
+	case a.BlobValue != nil || b.BlobValue != nil:
+		return a.BlobValue != nil && b.BlobValue != nil && bytes.Equal(a.BlobValue, b.BlobValue)
+	case a.GeoPointValue != nil || b.GeoPointValue != nil:
+		return a.GeoPointValue != nil && b.GeoPointValue != nil && *a.GeoPointValue == *b.GeoPointValue
+	case a.EntityValue != nil || b.EntityValue != nil:
+		if a.EntityValue == nil || b.EntityValue == nil {
+			return false
+		}
+		return entityEqual(*a.EntityValue, *b.EntityValue)
+	case a.ArrayValue != nil || b.ArrayValue != nil:
+		if a.ArrayValue == nil || b.ArrayValue == nil {
+			return false
+		}
+		if len(a.ArrayValue.Values) != len(b.ArrayValue.Values) {
+			return false
+		}
+		for i := range a.ArrayValue.Values {
+			if !valueEqual(a.ArrayValue.Values[i], b.ArrayValue.Values[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func entityEqual(a, b datastorestore.Entity) bool {
+	if a.Key != b.Key {
+		return false
+	}
+	if len(a.Properties) != len(b.Properties) {
+		return false
+	}
+	for k, av := range a.Properties {
+		bv, ok := b.Properties[k]
+		if !ok || !valueEqual(av, bv) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/gcp/grpc/datastore/service_test.go
+++ b/internal/gcp/grpc/datastore/service_test.go
@@ -1,0 +1,562 @@
+package datastore
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	datastorepb "cloud.google.com/go/datastore/apiv1/datastorepb"
+
+	datastorestore "jaiscloud/internal/gcp/store/datastore"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+func testServer(t *testing.T) (datastorepb.DatastoreClient, func()) {
+	t.Helper()
+	svc := NewService(datastorestore.NewMemoryStore(), "test")
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	datastorepb.RegisterDatastoreServer(srv, svc)
+	go srv.Serve(ln)
+
+	conn, err := grpc.NewClient(ln.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		srv.Stop()
+		t.Fatalf("dial: %v", err)
+	}
+	return datastorepb.NewDatastoreClient(conn), func() { conn.Close(); srv.Stop() }
+}
+
+func nameKey(kind, name string) *datastorepb.Key {
+	return &datastorepb.Key{
+		PartitionId: &datastorepb.PartitionId{ProjectId: "test"},
+		Path: []*datastorepb.Key_PathElement{{
+			Kind:   kind,
+			IdType: &datastorepb.Key_PathElement_Name{Name: name},
+		}},
+	}
+}
+
+func incompleteKey(kind string) *datastorepb.Key {
+	return &datastorepb.Key{
+		PartitionId: &datastorepb.PartitionId{ProjectId: "test"},
+		Path:        []*datastorepb.Key_PathElement{{Kind: kind}},
+	}
+}
+
+func strVal(s string) *datastorepb.Value {
+	return &datastorepb.Value{ValueType: &datastorepb.Value_StringValue{StringValue: s}}
+}
+
+func boolVal(b bool) *datastorepb.Value {
+	return &datastorepb.Value{ValueType: &datastorepb.Value_BooleanValue{BooleanValue: b}}
+}
+
+func intVal(n int64) *datastorepb.Value {
+	return &datastorepb.Value{ValueType: &datastorepb.Value_IntegerValue{IntegerValue: n}}
+}
+
+func doubleVal(f float64) *datastorepb.Value {
+	return &datastorepb.Value{ValueType: &datastorepb.Value_DoubleValue{DoubleValue: f}}
+}
+
+func idKey(kind string, id int64) *datastorepb.Key {
+	return &datastorepb.Key{
+		PartitionId: &datastorepb.PartitionId{ProjectId: "test"},
+		Path: []*datastorepb.Key_PathElement{{
+			Kind:   kind,
+			IdType: &datastorepb.Key_PathElement_Id{Id: id},
+		}},
+	}
+}
+
+func entity(key *datastorepb.Key, props map[string]*datastorepb.Value) *datastorepb.Entity {
+	return &datastorepb.Entity{Key: key, Properties: props}
+}
+
+func TestCommitInsertUpsertUpdateDelete(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	key := nameKey("Task", "a")
+
+	// insert.
+	resp, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Insert{Insert: entity(key, map[string]*datastorepb.Value{"Done": boolVal(false)})},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if len(resp.GetMutationResults()) != 1 {
+		t.Fatalf("insert results = %v", resp.GetMutationResults())
+	}
+
+	// insert on existing fails with AlreadyExists.
+	if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Insert{Insert: entity(key, map[string]*datastorepb.Value{})},
+		}},
+	}); status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("duplicate insert err = %v, want AlreadyExists", err)
+	}
+
+	// update on existing.
+	if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Update{Update: entity(key, map[string]*datastorepb.Value{"Done": boolVal(true)})},
+		}},
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	// update on missing fails with FailedPrecondition.
+	if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Update{Update: entity(nameKey("Task", "missing"), map[string]*datastorepb.Value{})},
+		}},
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("update missing err = %v, want FailedPrecondition", err)
+	}
+
+	// upsert.
+	if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Upsert{Upsert: entity(key, map[string]*datastorepb.Value{"Done": boolVal(false), "Desc": strVal("x")})},
+		}},
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// delete.
+	if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Delete{Delete: key},
+		}},
+	}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	// get after delete → missing.
+	look, err := client.Lookup(ctx, &datastorepb.LookupRequest{ProjectId: "test", Keys: []*datastorepb.Key{key}})
+	if err != nil {
+		t.Fatalf("lookup after delete: %v", err)
+	}
+	if len(look.GetMissing()) != 1 {
+		t.Fatalf("missing = %v, want 1", look.GetMissing())
+	}
+}
+
+func TestCommitInsertAutoAllocatesKey(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resp, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Insert{Insert: entity(incompleteKey("Task"), map[string]*datastorepb.Value{"Done": boolVal(false)})},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("insert incomplete: %v", err)
+	}
+	mr := resp.GetMutationResults()[0]
+	if mr.GetKey() == nil {
+		t.Fatal("auto-allocated key is nil")
+	}
+	el := mr.GetKey().GetPath()[len(mr.GetKey().GetPath())-1]
+	if el.GetId() <= 0 {
+		t.Fatalf("allocated id = %d, want > 0", el.GetId())
+	}
+
+	// The allocated key is retrievable.
+	look, err := client.Lookup(ctx, &datastorepb.LookupRequest{ProjectId: "test", Keys: []*datastorepb.Key{mr.GetKey()}})
+	if err != nil {
+		t.Fatalf("lookup allocated: %v", err)
+	}
+	if len(look.GetFound()) != 1 {
+		t.Fatalf("found = %v, want 1", look.GetFound())
+	}
+}
+
+func TestLookupFoundAndMissing(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	key := nameKey("Task", "a")
+	if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Upsert{Upsert: entity(key, map[string]*datastorepb.Value{"Desc": strVal("hi")})},
+		}},
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	look, err := client.Lookup(ctx, &datastorepb.LookupRequest{
+		ProjectId: "test",
+		Keys:      []*datastorepb.Key{key, nameKey("Task", "missing")},
+	})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if len(look.GetFound()) != 1 {
+		t.Fatalf("found = %v, want 1", look.GetFound())
+	}
+	got := look.GetFound()[0].GetEntity()
+	if got.GetProperties()["Desc"].GetStringValue() != "hi" {
+		t.Fatalf("found properties = %v", got.GetProperties())
+	}
+	if len(look.GetMissing()) != 1 {
+		t.Fatalf("missing = %v, want 1", look.GetMissing())
+	}
+}
+
+func TestRunQueryEqualityFilter(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	put := func(name string, done bool) {
+		if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+			ProjectId: "test",
+			Mutations: []*datastorepb.Mutation{{
+				Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", name), map[string]*datastorepb.Value{
+					"Done": boolVal(done),
+					"Desc": strVal(name),
+				})},
+			}},
+		}); err != nil {
+			t.Fatalf("put %s: %v", name, err)
+		}
+	}
+	put("a", false)
+	put("b", true)
+
+	q := &datastorepb.Query{
+		Kind: []*datastorepb.KindExpression{{Name: "Task"}},
+		Filter: &datastorepb.Filter{FilterType: &datastorepb.Filter_PropertyFilter{PropertyFilter: &datastorepb.PropertyFilter{
+			Property: &datastorepb.PropertyReference{Name: "Done"},
+			Op:       datastorepb.PropertyFilter_EQUAL,
+			Value:    boolVal(false),
+		}}},
+	}
+	resp, err := client.RunQuery(ctx, &datastorepb.RunQueryRequest{
+		ProjectId: "test",
+		QueryType: &datastorepb.RunQueryRequest_Query{Query: q},
+	})
+	if err != nil {
+		t.Fatalf("runquery: %v", err)
+	}
+	results := resp.GetBatch().GetEntityResults()
+	if len(results) != 1 {
+		t.Fatalf("query results = %v, want 1 (Done=false)", results)
+	}
+	if results[0].GetEntity().GetProperties()["Desc"].GetStringValue() != "a" {
+		t.Fatalf("query matched = %v, want 'a'", results[0].GetEntity().GetProperties())
+	}
+}
+
+func TestRunQueryCompositeAnd(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	put := func(name, desc string, done bool) {
+		if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+			ProjectId: "test",
+			Mutations: []*datastorepb.Mutation{{
+				Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", name), map[string]*datastorepb.Value{
+					"Done": boolVal(done),
+					"Desc": strVal(desc),
+				})},
+			}},
+		}); err != nil {
+			t.Fatalf("put %s: %v", name, err)
+		}
+	}
+	put("a", "x", false)
+	put("b", "y", true)
+
+	propFilter := func(name string, v *datastorepb.Value) *datastorepb.Filter {
+		return &datastorepb.Filter{FilterType: &datastorepb.Filter_PropertyFilter{PropertyFilter: &datastorepb.PropertyFilter{
+			Property: &datastorepb.PropertyReference{Name: name},
+			Op:       datastorepb.PropertyFilter_EQUAL,
+			Value:    v,
+		}}}
+	}
+	q := &datastorepb.Query{
+		Kind: []*datastorepb.KindExpression{{Name: "Task"}},
+		Filter: &datastorepb.Filter{FilterType: &datastorepb.Filter_CompositeFilter{CompositeFilter: &datastorepb.CompositeFilter{
+			Op:      datastorepb.CompositeFilter_AND,
+			Filters: []*datastorepb.Filter{propFilter("Desc", strVal("y")), propFilter("Done", boolVal(true))},
+		}}},
+	}
+	resp, err := client.RunQuery(ctx, &datastorepb.RunQueryRequest{
+		ProjectId: "test",
+		QueryType: &datastorepb.RunQueryRequest_Query{Query: q},
+	})
+	if err != nil {
+		t.Fatalf("runquery: %v", err)
+	}
+	results := resp.GetBatch().GetEntityResults()
+	if len(results) != 1 || results[0].GetEntity().GetProperties()["Desc"].GetStringValue() != "y" {
+		t.Fatalf("composite AND results = %v, want exactly ['y']", results)
+	}
+}
+
+func TestAllocateIds(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resp, err := client.AllocateIds(ctx, &datastorepb.AllocateIdsRequest{
+		ProjectId: "test",
+		Keys:      []*datastorepb.Key{incompleteKey("Task"), incompleteKey("Task")},
+	})
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+	keys := resp.GetKeys()
+	if len(keys) != 2 {
+		t.Fatalf("allocated = %d keys, want 2", len(keys))
+	}
+	first := keys[0].GetPath()[0].GetId()
+	second := keys[1].GetPath()[0].GetId()
+	if first <= 0 || second <= first {
+		t.Fatalf("allocated ids = %d, %d; want positive and monotonic", first, second)
+	}
+}
+
+func TestRunQueryLessThanFilter(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	put := func(name string, priority int64) {
+		if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+			ProjectId: "test",
+			Mutations: []*datastorepb.Mutation{{
+				Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", name), map[string]*datastorepb.Value{
+					"Priority": intVal(priority),
+				})},
+			}},
+		}); err != nil {
+			t.Fatalf("put %s: %v", name, err)
+		}
+	}
+	put("low", 1)
+	put("mid", 5)
+	put("high", 10)
+
+	q := &datastorepb.Query{
+		Kind: []*datastorepb.KindExpression{{Name: "Task"}},
+		Filter: &datastorepb.Filter{FilterType: &datastorepb.Filter_PropertyFilter{PropertyFilter: &datastorepb.PropertyFilter{
+			Property: &datastorepb.PropertyReference{Name: "Priority"},
+			Op:       datastorepb.PropertyFilter_LESS_THAN,
+			Value:    intVal(5),
+		}}},
+	}
+	resp, err := client.RunQuery(ctx, &datastorepb.RunQueryRequest{
+		ProjectId: "test",
+		QueryType: &datastorepb.RunQueryRequest_Query{Query: q},
+	})
+	if err != nil {
+		t.Fatalf("runquery: %v", err)
+	}
+	results := resp.GetBatch().GetEntityResults()
+	if len(results) != 1 {
+		t.Fatalf("less-than results = %v, want exactly 1", results)
+	}
+	got := results[0].GetEntity().GetKey().GetPath()[0].GetName()
+	if got != "low" {
+		t.Fatalf("less-than matched = %q, want 'low'", got)
+	}
+}
+
+func TestRunQueryUnsupportedOperatorsFailClosed(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"Done": boolVal(false)})},
+		}},
+	}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	// HAS_ANCESTOR is an unsupported operator → InvalidArgument, not match-all.
+	hasAncestor := &datastorepb.Query{
+		Kind: []*datastorepb.KindExpression{{Name: "Task"}},
+		Filter: &datastorepb.Filter{FilterType: &datastorepb.Filter_PropertyFilter{PropertyFilter: &datastorepb.PropertyFilter{
+			Property: &datastorepb.PropertyReference{Name: "Done"},
+			Op:       datastorepb.PropertyFilter_HAS_ANCESTOR,
+			Value:    boolVal(false),
+		}}},
+	}
+	if _, err := client.RunQuery(ctx, &datastorepb.RunQueryRequest{
+		ProjectId: "test",
+		QueryType: &datastorepb.RunQueryRequest_Query{Query: hasAncestor},
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("HAS_ANCESTOR err = %v, want InvalidArgument", err)
+	}
+
+	// CompositeFilter OR is unsupported → InvalidArgument.
+	or := &datastorepb.Query{
+		Kind: []*datastorepb.KindExpression{{Name: "Task"}},
+		Filter: &datastorepb.Filter{FilterType: &datastorepb.Filter_CompositeFilter{CompositeFilter: &datastorepb.CompositeFilter{
+			Op: datastorepb.CompositeFilter_OR,
+			Filters: []*datastorepb.Filter{
+				{FilterType: &datastorepb.Filter_PropertyFilter{PropertyFilter: &datastorepb.PropertyFilter{Property: &datastorepb.PropertyReference{Name: "Done"}, Op: datastorepb.PropertyFilter_EQUAL, Value: boolVal(false)}}},
+				{FilterType: &datastorepb.Filter_PropertyFilter{PropertyFilter: &datastorepb.PropertyFilter{Property: &datastorepb.PropertyReference{Name: "Done"}, Op: datastorepb.PropertyFilter_EQUAL, Value: boolVal(true)}}},
+			},
+		}}},
+	}
+	if _, err := client.RunQuery(ctx, &datastorepb.RunQueryRequest{
+		ProjectId: "test",
+		QueryType: &datastorepb.RunQueryRequest_Query{Query: or},
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("OR err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestRunQueryGqlNotSupported(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := client.RunQuery(ctx, &datastorepb.RunQueryRequest{
+		ProjectId: "test",
+		QueryType: &datastorepb.RunQueryRequest_GqlQuery{GqlQuery: &datastorepb.GqlQuery{QueryString: "SELECT * FROM Task"}},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("GQL err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestCommitUpdateIncompleteKey(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Update{Update: entity(incompleteKey("Task"), map[string]*datastorepb.Value{})},
+		}},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("update incomplete err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestAllocateIdsCompleteKey(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := client.AllocateIds(ctx, &datastorepb.AllocateIdsRequest{
+		ProjectId: "test",
+		Keys:      []*datastorepb.Key{idKey("Task", 1)},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("allocate complete err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestMultiElementKeyRejected(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	multi := &datastorepb.Key{
+		PartitionId: &datastorepb.PartitionId{ProjectId: "test"},
+		Path: []*datastorepb.Key_PathElement{
+			{Kind: "Parent", IdType: &datastorepb.Key_PathElement_Id{Id: 1}},
+			{Kind: "Child", IdType: &datastorepb.Key_PathElement_Id{Id: 2}},
+		},
+	}
+	if _, err := client.Lookup(ctx, &datastorepb.LookupRequest{
+		ProjectId: "test",
+		Keys:      []*datastorepb.Key{multi},
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("multi-element lookup err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestExplicitIDAdvancesAllocator(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Upsert{Upsert: entity(idKey("Task", 100), map[string]*datastorepb.Value{})},
+		}},
+	}); err != nil {
+		t.Fatalf("upsert explicit id: %v", err)
+	}
+
+	resp, err := client.AllocateIds(ctx, &datastorepb.AllocateIdsRequest{
+		ProjectId: "test",
+		Keys:      []*datastorepb.Key{incompleteKey("Task")},
+	})
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+	got := resp.GetKeys()[0].GetPath()[0].GetId()
+	if got <= 100 {
+		t.Fatalf("allocated id = %d, want > 100", got)
+	}
+}
+
+func TestValueEqualNumeric(t *testing.T) {
+	int3 := datastorestore.Value{IntegerValue: ptrInt64(3)}
+	dbl3 := datastorestore.Value{DoubleValue: ptrFloat64(3.0)}
+	int5 := datastorestore.Value{IntegerValue: ptrInt64(5)}
+
+	if !valueEqual(int3, dbl3) {
+		t.Fatal("valueEqual(int 3, double 3.0) = false")
+	}
+	if !valueEqual(dbl3, int3) {
+		t.Fatal("valueEqual(double 3.0, int 3) = false")
+	}
+	if valueEqual(int3, int5) {
+		t.Fatal("valueEqual(int 3, int 5) = true")
+	}
+	if valueEqual(int3, datastorestore.Value{DoubleValue: ptrFloat64(3.5)}) {
+		t.Fatal("valueEqual(int 3, double 3.5) = true")
+	}
+
+	if c, ok := valueCompare(int3, int5); !ok || c >= 0 {
+		t.Fatalf("valueCompare(int 3, int 5) = %d, %v; want < 0", c, ok)
+	}
+	if c, ok := valueCompare(dbl3, int5); !ok || c >= 0 {
+		t.Fatalf("valueCompare(double 3.0, int 5) = %d, %v; want < 0", c, ok)
+	}
+}
+
+func ptrInt64(n int64) *int64       { return &n }
+func ptrFloat64(f float64) *float64 { return &f }

--- a/internal/gcp/store/datastore/memory.go
+++ b/internal/gcp/store/datastore/memory.go
@@ -1,0 +1,117 @@
+package datastore
+
+import (
+	"context"
+	"sort"
+	"sync"
+)
+
+// MemoryStore is an in-memory Store. Entities are keyed by (project, key).
+type MemoryStore struct {
+	mu        sync.RWMutex
+	entities  map[string]map[string]Entity // project → key → entity
+	allocator map[string]int64             // project → next id
+}
+
+// NewMemoryStore returns an empty in-memory store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		entities:  make(map[string]map[string]Entity),
+		allocator: make(map[string]int64),
+	}
+}
+
+func (s *MemoryStore) Get(_ context.Context, project, key string) (Entity, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	e, ok := s.entities[project][key]
+	if !ok {
+		return Entity{}, ErrEntityNotFound
+	}
+	return e, nil
+}
+
+func (s *MemoryStore) Insert(_ context.Context, project string, e Entity) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.entities[project][e.Key]; ok {
+		return ErrEntityExists
+	}
+	if s.entities[project] == nil {
+		s.entities[project] = make(map[string]Entity)
+	}
+	s.entities[project][e.Key] = e
+	return nil
+}
+
+func (s *MemoryStore) Upsert(_ context.Context, project string, e Entity) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.entities[project] == nil {
+		s.entities[project] = make(map[string]Entity)
+	}
+	s.entities[project][e.Key] = e
+	return nil
+}
+
+func (s *MemoryStore) Update(_ context.Context, project string, e Entity) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.entities[project][e.Key]; !ok {
+		return ErrEntityNotFound
+	}
+	s.entities[project][e.Key] = e
+	return nil
+}
+
+func (s *MemoryStore) Delete(_ context.Context, project, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.entities[project], key)
+	return nil
+}
+
+func (s *MemoryStore) ListKind(_ context.Context, project, kind string) ([]Entity, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]Entity, 0)
+	for _, e := range s.entities[project] {
+		if kind != "" && e.Kind != kind {
+			continue
+		}
+		result = append(result, e)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Key < result[j].Key })
+	return result, nil
+}
+
+func (s *MemoryStore) AllocateIDs(_ context.Context, project string, n int) ([]int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	start := s.allocator[project]
+	if start == 0 {
+		start = 1
+	}
+	s.allocator[project] = start + int64(n)
+	ids := make([]int64, n)
+	for i := range ids {
+		ids[i] = start + int64(i)
+	}
+	return ids, nil
+}
+
+func (s *MemoryStore) AdvanceIDs(_ context.Context, project string, max int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if max >= s.allocator[project] {
+		s.allocator[project] = max + 1
+	}
+	return nil
+}
+
+func (s *MemoryStore) Reset(_ context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entities = make(map[string]map[string]Entity)
+	s.allocator = make(map[string]int64)
+}

--- a/internal/gcp/store/datastore/memory_test.go
+++ b/internal/gcp/store/datastore/memory_test.go
@@ -1,0 +1,196 @@
+package datastore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+)
+
+func str(v string) Value { s := v; return Value{StringValue: &s} }
+func bl(v bool) Value    { b := v; return Value{BooleanValue: &b} }
+func num(v int64) Value  { n := v; return Value{IntegerValue: &n} }
+
+func testEntity(kind, name string, props map[string]Value) Entity {
+	return Entity{Kind: kind, Key: KeyOfName(kind, name), Properties: props}
+}
+
+func TestMemoryStoreCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+
+	e := testEntity("Task", "a", map[string]Value{"Description": str("hi"), "Done": bl(false)})
+
+	if err := s.Insert(ctx, "p1", e); err != nil {
+		t.Fatal(err)
+	}
+	// duplicate insert fails.
+	if err := s.Insert(ctx, "p1", e); !errors.Is(err, ErrEntityExists) {
+		t.Fatalf("duplicate insert = %v, want ErrEntityExists", err)
+	}
+
+	got, err := s.Get(ctx, "p1", e.Key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Properties["Description"].StringValue == nil || *got.Properties["Description"].StringValue != "hi" {
+		t.Fatalf("get = %+v", got)
+	}
+
+	// upsert overwrites.
+	e.Properties["Done"] = bl(true)
+	if err := s.Upsert(ctx, "p1", e); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.Get(ctx, "p1", e.Key)
+	if got.Properties["Done"].BooleanValue == nil || !*got.Properties["Done"].BooleanValue {
+		t.Fatalf("after upsert = %+v", got)
+	}
+
+	// update on missing fails.
+	missing := testEntity("Task", "missing", map[string]Value{})
+	if err := s.Update(ctx, "p1", missing); !errors.Is(err, ErrEntityNotFound) {
+		t.Fatalf("update missing = %v, want ErrEntityNotFound", err)
+	}
+
+	// list by kind.
+	e2 := testEntity("Task", "b", map[string]Value{"Done": bl(false)})
+	if err := s.Upsert(ctx, "p1", e2); err != nil {
+		t.Fatal(err)
+	}
+	other := testEntity("Other", "c", map[string]Value{})
+	if err := s.Upsert(ctx, "p1", other); err != nil {
+		t.Fatal(err)
+	}
+	list, err := s.ListKind(ctx, "p1", "Task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 2 || list[0].Key != e.Key || list[1].Key != e2.Key {
+		t.Fatalf("list = %+v", list)
+	}
+
+	// delete + get missing.
+	if err := s.Delete(ctx, "p1", e.Key); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Get(ctx, "p1", e.Key); !errors.Is(err, ErrEntityNotFound) {
+		t.Fatalf("get after delete = %v, want ErrEntityNotFound", err)
+	}
+}
+
+func TestMemoryStoreAllocateIDs(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+
+	ids, err := s.AllocateIDs(ctx, "p1", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 3 || ids[0] != 1 || ids[1] != 2 || ids[2] != 3 {
+		t.Fatalf("first batch = %v", ids)
+	}
+	ids, _ = s.AllocateIDs(ctx, "p1", 2)
+	if ids[0] != 4 || ids[1] != 5 {
+		t.Fatalf("second batch = %v", ids)
+	}
+	// per-project counters are independent.
+	ids, _ = s.AllocateIDs(ctx, "p2", 1)
+	if ids[0] != 1 {
+		t.Fatalf("p2 first id = %v", ids)
+	}
+}
+
+func TestMemoryStoreSnapshotRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	_ = s.Upsert(ctx, "p1", testEntity("Task", "a", map[string]Value{"Done": bl(false)}))
+	_ = s.Upsert(ctx, "p2", testEntity("Task", "b", map[string]Value{"Done": bl(true)}))
+	_, _ = s.AllocateIDs(ctx, "p1", 5)
+
+	var buf bytes.Buffer
+	if err := s.Snapshot(ctx, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	s2 := NewMemoryStore()
+	if err := s2.Restore(ctx, &buf); err != nil {
+		t.Fatal(err)
+	}
+	list, _ := s2.ListKind(ctx, "p1", "Task")
+	if len(list) != 1 || list[0].Key != KeyOfName("Task", "a") {
+		t.Fatalf("restored p1 = %+v", list)
+	}
+	list, _ = s2.ListKind(ctx, "p2", "Task")
+	if len(list) != 1 {
+		t.Fatalf("restored p2 = %+v", list)
+	}
+	// allocator counter must be restored so IDs stay monotonic.
+	ids, _ := s2.AllocateIDs(ctx, "p1", 1)
+	if ids[0] != 6 {
+		t.Fatalf("restored allocator = %v, want 6", ids)
+	}
+}
+
+func TestMemoryStoreReset(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	_ = s.Upsert(ctx, "p1", testEntity("Task", "a", nil))
+	s.Reset(ctx)
+	if list, _ := s.ListKind(ctx, "p1", "Task"); len(list) != 0 {
+		t.Fatalf("after reset = %+v", list)
+	}
+	if ids, _ := s.AllocateIDs(ctx, "p1", 1); ids[0] != 1 {
+		t.Fatalf("allocator after reset = %v", ids)
+	}
+}
+
+func TestMemoryStoreAdvanceIDs(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+
+	// Advancing past an explicit ID means the next allocation skips it.
+	if err := s.AdvanceIDs(ctx, "p1", 100); err != nil {
+		t.Fatal(err)
+	}
+	ids, _ := s.AllocateIDs(ctx, "p1", 1)
+	if ids[0] != 101 {
+		t.Fatalf("after advance(100), allocated = %v, want 101", ids)
+	}
+
+	// Advancing below the current cursor is a no-op.
+	if err := s.AdvanceIDs(ctx, "p1", 50); err != nil {
+		t.Fatal(err)
+	}
+	ids, _ = s.AllocateIDs(ctx, "p1", 1)
+	if ids[0] != 102 {
+		t.Fatalf("after no-op advance, allocated = %v, want 102", ids)
+	}
+
+	// Per-project counters are independent.
+	ids, _ = s.AllocateIDs(ctx, "p2", 1)
+	if ids[0] != 1 {
+		t.Fatalf("p2 first id = %v, want 1", ids)
+	}
+}
+
+func TestKeyHelpers(t *testing.T) {
+	if KeyOfID("Task", 42) != "Task/id:42" {
+		t.Fatalf("KeyOfID = %q", KeyOfID("Task", 42))
+	}
+	if KeyOfName("Task", "foo") != "Task/name:foo" {
+		t.Fatalf("KeyOfName = %q", KeyOfName("Task", "foo"))
+	}
+	kind, idOrName, ok := SplitKey("Task/name:foo")
+	if !ok || kind != "Task" || idOrName != "name:foo" {
+		t.Fatalf("SplitKey = %q %q %v", kind, idOrName, ok)
+	}
+	id, name, isID := ParseIDOrName("id:42")
+	if !isID || id != 42 || name != "" {
+		t.Fatalf("ParseIDOrName id = %d %q %v", id, name, isID)
+	}
+	id, name, isID = ParseIDOrName("name:foo")
+	if isID || id != 0 || name != "foo" {
+		t.Fatalf("ParseIDOrName name = %d %q %v", id, name, isID)
+	}
+}

--- a/internal/gcp/store/datastore/postgres.go
+++ b/internal/gcp/store/datastore/postgres.go
@@ -1,0 +1,211 @@
+package datastore
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgresStore implements Store against the jc_datastore_entities table plus
+// the jc_datastore_id_allocator counter. The Datastore migration
+// (gcpstore.MigrationFS, migration 022) must have run before use.
+type PostgresStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresStore returns a Postgres-backed Store.
+func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore {
+	return &PostgresStore{pool: pool}
+}
+
+// entityCols is the SELECT column list for jc_datastore_entities (the project
+// and name_or_id columns are re-derivable from Key and scanned but discarded).
+const entityCols = "project, kind, name_or_id, properties"
+
+func scanEntity(scan func(...any) error) (Entity, error) {
+	var e Entity
+	var project, nameOrID string
+	var props []byte
+	if err := scan(&project, &e.Kind, &nameOrID, &props); err != nil {
+		return Entity{}, err
+	}
+	if len(props) > 0 {
+		_ = json.Unmarshal(props, &e.Properties)
+	}
+	if e.Properties == nil {
+		e.Properties = map[string]Value{}
+	}
+	e.Key = e.Kind + "/" + nameOrID
+	return e, nil
+}
+
+func propertiesJSON(props map[string]Value) []byte {
+	if props == nil {
+		props = map[string]Value{}
+	}
+	b, err := json.Marshal(props)
+	if err != nil {
+		return []byte("{}")
+	}
+	return b
+}
+
+// splitKeyCols decomposes an entity's canonical key into the kind and tagged
+// id-or-name columns.
+func splitKeyCols(e Entity) (kind, nameOrID string, err error) {
+	kind, nameOrID, ok := SplitKey(e.Key)
+	if !ok {
+		return "", "", ErrInvalidKey
+	}
+	return kind, nameOrID, nil
+}
+
+func (s *PostgresStore) Get(ctx context.Context, project, key string) (Entity, error) {
+	kind, nameOrID, ok := SplitKey(key)
+	if !ok {
+		return Entity{}, ErrInvalidKey
+	}
+	row := s.pool.QueryRow(ctx, `SELECT `+entityCols+` FROM jc_datastore_entities WHERE project=$1 AND kind=$2 AND name_or_id=$3`, project, kind, nameOrID)
+	e, err := scanEntity(row.Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Entity{}, ErrEntityNotFound
+	}
+	return e, err
+}
+
+func (s *PostgresStore) Insert(ctx context.Context, project string, e Entity) error {
+	kind, nameOrID, err := splitKeyCols(e)
+	if err != nil {
+		return err
+	}
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO jc_datastore_entities (project, kind, name_or_id, properties)
+		VALUES ($1,$2,$3,$4)
+	`, project, kind, nameOrID, propertiesJSON(e.Properties))
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrEntityExists
+		}
+		return fmt.Errorf("datastore Insert: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) Upsert(ctx context.Context, project string, e Entity) error {
+	kind, nameOrID, err := splitKeyCols(e)
+	if err != nil {
+		return err
+	}
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO jc_datastore_entities (project, kind, name_or_id, properties)
+		VALUES ($1,$2,$3,$4)
+		ON CONFLICT (project, kind, name_or_id) DO UPDATE SET properties = EXCLUDED.properties
+	`, project, kind, nameOrID, propertiesJSON(e.Properties))
+	if err != nil {
+		return fmt.Errorf("datastore Upsert: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) Update(ctx context.Context, project string, e Entity) error {
+	kind, nameOrID, err := splitKeyCols(e)
+	if err != nil {
+		return err
+	}
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE jc_datastore_entities SET properties=$4
+		WHERE project=$1 AND kind=$2 AND name_or_id=$3
+	`, project, kind, nameOrID, propertiesJSON(e.Properties))
+	if err != nil {
+		return fmt.Errorf("datastore Update: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrEntityNotFound
+	}
+	return nil
+}
+
+func (s *PostgresStore) Delete(ctx context.Context, project, key string) error {
+	kind, nameOrID, ok := SplitKey(key)
+	if !ok {
+		return ErrInvalidKey
+	}
+	_, err := s.pool.Exec(ctx, `DELETE FROM jc_datastore_entities WHERE project=$1 AND kind=$2 AND name_or_id=$3`, project, kind, nameOrID)
+	return err
+}
+
+func (s *PostgresStore) ListKind(ctx context.Context, project, kind string) ([]Entity, error) {
+	var rows pgx.Rows
+	var err error
+	if kind == "" {
+		rows, err = s.pool.Query(ctx, `SELECT `+entityCols+` FROM jc_datastore_entities WHERE project=$1 ORDER BY kind, name_or_id`, project)
+	} else {
+		rows, err = s.pool.Query(ctx, `SELECT `+entityCols+` FROM jc_datastore_entities WHERE project=$1 AND kind=$2 ORDER BY name_or_id`, project, kind)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make([]Entity, 0)
+	for rows.Next() {
+		e, err := scanEntity(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, e)
+	}
+	return result, rows.Err()
+}
+
+func (s *PostgresStore) AllocateIDs(ctx context.Context, project string, n int) ([]int64, error) {
+	if n <= 0 {
+		return []int64{}, nil
+	}
+	if _, err := s.pool.Exec(ctx, `
+		INSERT INTO jc_datastore_id_allocator (project_id, next_id)
+		VALUES ($1, 1)
+		ON CONFLICT (project_id) DO NOTHING
+	`, project); err != nil {
+		return nil, err
+	}
+	var next int64
+	if err := s.pool.QueryRow(ctx, `
+		UPDATE jc_datastore_id_allocator SET next_id = next_id + $2
+		WHERE project_id = $1
+		RETURNING next_id
+	`, project, int64(n)).Scan(&next); err != nil {
+		return nil, err
+	}
+	start := next - int64(n)
+	ids := make([]int64, n)
+	for i := range ids {
+		ids[i] = start + int64(i)
+	}
+	return ids, nil
+}
+
+func (s *PostgresStore) AdvanceIDs(ctx context.Context, project string, max int64) error {
+	if _, err := s.pool.Exec(ctx, `
+		INSERT INTO jc_datastore_id_allocator (project_id, next_id)
+		VALUES ($1, 1)
+		ON CONFLICT (project_id) DO NOTHING
+	`, project); err != nil {
+		return err
+	}
+	_, err := s.pool.Exec(ctx, `
+		UPDATE jc_datastore_id_allocator SET next_id = GREATEST(next_id, $2)
+		WHERE project_id = $1
+	`, project, max+1)
+	return err
+}
+
+func (s *PostgresStore) Reset(ctx context.Context) {
+	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_datastore_entities`)
+	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_datastore_id_allocator`)
+}

--- a/internal/gcp/store/datastore/snapshot.go
+++ b/internal/gcp/store/datastore/snapshot.go
@@ -1,0 +1,171 @@
+package datastore
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"sort"
+)
+
+// snapRow is one (project, entity) pair in the snapshot envelope.
+type snapRow struct {
+	Project string `json:"project"`
+	Entity  Entity `json:"entity"`
+}
+
+// datastoreSnap is the JSON snapshot shape shared by both backends. The
+// allocator counter is snapshotted so that IDs stay monotonic across restore
+// (an AllocateIds result that was never stored as an entity still advances the
+// counter).
+type datastoreSnap struct {
+	Entities  []snapRow        `json:"entities"`
+	Allocator map[string]int64 `json:"allocator,omitempty"`
+}
+
+// MemoryStore Snapshot/Restore/IsEmpty.
+
+func (s *MemoryStore) IsEmpty(_ context.Context) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.entities) == 0, nil
+}
+
+func (s *MemoryStore) Snapshot(_ context.Context, w io.Writer) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	snap := datastoreSnap{Allocator: s.allocator}
+	projects := make([]string, 0, len(s.entities))
+	for p := range s.entities {
+		projects = append(projects, p)
+	}
+	sort.Strings(projects)
+	for _, p := range projects {
+		keys := make([]string, 0, len(s.entities[p]))
+		for k := range s.entities[p] {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			snap.Entities = append(snap.Entities, snapRow{Project: p, Entity: s.entities[p][k]})
+		}
+	}
+	return json.NewEncoder(w).Encode(snap)
+}
+
+func (s *MemoryStore) Restore(_ context.Context, r io.Reader) error {
+	var snap datastoreSnap
+	if err := json.NewDecoder(r).Decode(&snap); err != nil {
+		return err
+	}
+	entities := make(map[string]map[string]Entity)
+	for _, row := range snap.Entities {
+		if entities[row.Project] == nil {
+			entities[row.Project] = make(map[string]Entity)
+		}
+		entities[row.Project][row.Entity.Key] = row.Entity
+	}
+	allocator := snap.Allocator
+	if allocator == nil {
+		allocator = make(map[string]int64)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entities = entities
+	s.allocator = allocator
+	return nil
+}
+
+// PostgresStore Snapshot/Restore/IsEmpty.
+
+func (s *PostgresStore) IsEmpty(ctx context.Context) (bool, error) {
+	var n int
+	if err := s.pool.QueryRow(ctx, `SELECT count(*) FROM jc_datastore_entities`).Scan(&n); err != nil {
+		return false, err
+	}
+	return n == 0, nil
+}
+
+func (s *PostgresStore) Snapshot(ctx context.Context, w io.Writer) error {
+	rows, err := s.pool.Query(ctx, `
+		SELECT `+entityCols+` FROM jc_datastore_entities ORDER BY project, kind, name_or_id
+	`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	snap := datastoreSnap{Allocator: make(map[string]int64)}
+	for rows.Next() {
+		var row snapRow
+		var nameOrID string
+		var props []byte
+		if err := rows.Scan(&row.Project, &row.Entity.Kind, &nameOrID, &props); err != nil {
+			return err
+		}
+		if len(props) > 0 {
+			_ = json.Unmarshal(props, &row.Entity.Properties)
+		}
+		if row.Entity.Properties == nil {
+			row.Entity.Properties = map[string]Value{}
+		}
+		row.Entity.Key = row.Entity.Kind + "/" + nameOrID
+		snap.Entities = append(snap.Entities, row)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	allocRows, err := s.pool.Query(ctx, `SELECT project_id, next_id FROM jc_datastore_id_allocator`)
+	if err != nil {
+		return err
+	}
+	defer allocRows.Close()
+	for allocRows.Next() {
+		var p string
+		var n int64
+		if err := allocRows.Scan(&p, &n); err != nil {
+			return err
+		}
+		snap.Allocator[p] = n
+	}
+	if err := allocRows.Err(); err != nil {
+		return err
+	}
+	return json.NewEncoder(w).Encode(snap)
+}
+
+func (s *PostgresStore) Restore(ctx context.Context, r io.Reader) error {
+	var snap datastoreSnap
+	if err := json.NewDecoder(r).Decode(&snap); err != nil {
+		return err
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `DELETE FROM jc_datastore_entities`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM jc_datastore_id_allocator`); err != nil {
+		return err
+	}
+	for _, row := range snap.Entities {
+		kind, nameOrID, ok := SplitKey(row.Entity.Key)
+		if !ok {
+			return ErrInvalidKey
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO jc_datastore_entities (project, kind, name_or_id, properties)
+			VALUES ($1,$2,$3,$4)
+		`, row.Project, kind, nameOrID, propertiesJSON(row.Entity.Properties)); err != nil {
+			return err
+		}
+	}
+	for p, n := range snap.Allocator {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO jc_datastore_id_allocator (project_id, next_id) VALUES ($1,$2)
+		`, p, n); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}

--- a/internal/gcp/store/datastore/store.go
+++ b/internal/gcp/store/datastore/store.go
@@ -1,0 +1,127 @@
+// Package datastore provides the Cloud Datastore entity data-plane store.
+// Entities live in the dedicated jc_datastore_entities table (Postgres) or in
+// memory. Datastore is the DynamoDB analogue: a key-value/document store of
+// kind + key + properties, with a per-project numeric-ID allocator.
+package datastore
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+)
+
+// Sentinel errors returned by the store, mapped to gRPC status codes by the
+// service (errors.Is-compatible, matching the firestore/logging conventions).
+var (
+	ErrEntityNotFound = errors.New("EntityNotFound")
+	ErrEntityExists   = errors.New("EntityExists")
+	ErrInvalidKey     = errors.New("InvalidKey")
+)
+
+// GeoPoint is a Datastore geo_point_value ({latitude, longitude}).
+type GeoPoint struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
+// ArrayValue is the Datastore array_value container.
+type ArrayValue struct {
+	Values []Value `json:"values,omitempty"`
+}
+
+// Value is a Datastore value: exactly one variant field is set. It mirrors the
+// Datastore wire Value one-of (null, boolean, integer, double, timestamp, key,
+// string, blob, geo point, entity, array). Integers and doubles are split
+// (unlike DynamoDB's arbitrary-precision number), and key_value stores a key as
+// its canonical string form (see KeyOfID/KeyOfName).
+type Value struct {
+	NullValue      *string     `json:"nullValue,omitempty"`
+	BooleanValue   *bool       `json:"booleanValue,omitempty"`
+	IntegerValue   *int64      `json:"integerValue,omitempty"`
+	DoubleValue    *float64    `json:"doubleValue,omitempty"`
+	TimestampValue *string     `json:"timestampValue,omitempty"` // RFC 3339
+	KeyValue       *string     `json:"keyValue,omitempty"`       // canonical key
+	StringValue    *string     `json:"stringValue,omitempty"`
+	BlobValue      []byte      `json:"blobValue,omitempty"` // base64 on the wire
+	GeoPointValue  *GeoPoint   `json:"geoPointValue,omitempty"`
+	EntityValue    *Entity     `json:"entityValue,omitempty"`
+	ArrayValue     *ArrayValue `json:"arrayValue,omitempty"`
+}
+
+// Entity is a stored Datastore entity. Kind is the entity kind (denormalized
+// for kind-scoped queries). Key is the stable canonical key string
+// "kind/id-or-name" (see KeyOfID/KeyOfName); the store's primary key is
+// (project, Key). Properties is the property map keyed by property name.
+type Entity struct {
+	Kind       string           `json:"kind"`
+	Key        string           `json:"key"`
+	Properties map[string]Value `json:"properties"`
+}
+
+// Store is the Cloud Datastore entity data-plane store. Entities are
+// project-scoped and keyed by their canonical key string.
+type Store interface {
+	// Get returns the entity at key, or ErrEntityNotFound.
+	Get(ctx context.Context, project, key string) (Entity, error)
+	// Insert stores a new entity, or ErrEntityExists if one exists at key.
+	Insert(ctx context.Context, project string, e Entity) error
+	// Upsert stores an entity, overwriting any existing one at key.
+	Upsert(ctx context.Context, project string, e Entity) error
+	// Update replaces an existing entity, or ErrEntityNotFound.
+	Update(ctx context.Context, project string, e Entity) error
+	// Delete removes the entity at key. Idempotent.
+	Delete(ctx context.Context, project, key string) error
+	// ListKind returns every entity of the given kind in the project, sorted by
+	// key. An empty kind returns every entity in the project.
+	ListKind(ctx context.Context, project, kind string) ([]Entity, error)
+	// AllocateIDs reserves n positive, monotonic numeric IDs for the project.
+	AllocateIDs(ctx context.Context, project string, n int) ([]int64, error)
+	// AdvanceIDs advances the project's numeric-ID allocator so the next
+	// allocated ID is strictly greater than max. Used to ensure AllocateIDs
+	// never reissues an ID that was already assigned to an explicitly-keyed
+	// (numeric) entity.
+	AdvanceIDs(ctx context.Context, project string, max int64) error
+	Reset(ctx context.Context)
+}
+
+// KeyOfID returns the canonical key string for a numeric-ID key: "kind/id:<id>".
+func KeyOfID(kind string, id int64) string {
+	return kind + "/" + "id:" + strconv.FormatInt(id, 10)
+}
+
+// KeyOfName returns the canonical key string for a name key: "kind/name:<name>".
+func KeyOfName(kind, name string) string {
+	return kind + "/" + "name:" + name
+}
+
+// SplitKey parses "kind/id-or-name" into its kind and tagged id-or-name. ok is
+// false when the key is malformed.
+func SplitKey(key string) (kind, idOrName string, ok bool) {
+	kind, idOrName, ok = strings.Cut(key, "/")
+	if !ok || kind == "" || idOrName == "" {
+		return "", "", false
+	}
+	return kind, idOrName, true
+}
+
+// ParseIDOrName parses a tagged id-or-name ("id:<n>" or "name:<s>") into its
+// numeric id (isID=true) or name (isID=false).
+func ParseIDOrName(s string) (id int64, name string, isID bool) {
+	tag, val, ok := strings.Cut(s, ":")
+	if !ok {
+		return 0, "", false
+	}
+	switch tag {
+	case "id":
+		n, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return 0, "", false
+		}
+		return n, "", true
+	case "name":
+		return 0, val, false
+	default:
+		return 0, "", false
+	}
+}

--- a/internal/gcp/store/migrations/022_datastore.sql
+++ b/internal/gcp/store/migrations/022_datastore.sql
@@ -1,0 +1,21 @@
+-- Cloud Datastore entity data plane. Entities are keyed by (project, kind,
+-- name-or-id). name_or_id is the tagged identifier: "id:<decimal>" for
+-- numeric-ID keys or "name:<value>" for name keys; the canonical key string is
+-- "kind/name_or_id". properties is the raw map[string]Value JSON (Datastore
+-- wire Value one-of shapes).
+CREATE TABLE IF NOT EXISTS jc_datastore_entities (
+    project    TEXT        NOT NULL,
+    kind       TEXT        NOT NULL,
+    name_or_id TEXT        NOT NULL,
+    properties JSONB       NOT NULL DEFAULT '{}',
+    PRIMARY KEY (project, kind, name_or_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_jc_datastore_entities_kind
+    ON jc_datastore_entities (project, kind);
+
+-- Per-project numeric ID allocator (monotonic counter backing AllocateIds).
+CREATE TABLE IF NOT EXISTS jc_datastore_id_allocator (
+    project_id TEXT   PRIMARY KEY,
+    next_id    BIGINT NOT NULL DEFAULT 1
+);

--- a/tests/integration/gcp/pending/datastore_test.go
+++ b/tests/integration/gcp/pending/datastore_test.go
@@ -1,5 +1,3 @@
-//go:build gcp_pending
-
 package tests
 
 import (


### PR DESCRIPTION
## Summary

Adds **Cloud Datastore** (Firestore in Datastore mode) to the `jaiscloud-gcp` emulator, over the gRPC transport (`google.datastore.v1.Datastore`).

## Scope

- **gRPC service** `internal/gcp/grpc/datastore/` — `Commit` (insert/upsert/update/delete mutations), `Lookup` (found/missing), `RunQuery` (kind + property filter), `AllocateIds`, `BeginTransaction`/`Rollback` (stubs), `ReserveIds`/`RunAggregationQuery` (Unimplemented).
- **Store** `internal/gcp/store/datastore/` — memory + Postgres + snapshot (Snapshotter parity) + migration `022_datastore.sql` (`jc_datastore_entities` + a per-project `jc_datastore_id_allocator`).
- **`Value`/`Key`/`Entity` transcoding** — the 11-variant `Value` one-of (int/double split, timestamp, blob base64, key, geoPoint, array, entity, null).
- **Query** — `PropertyFilter` (EQUAL/NOT_EQUAL/IN + the four comparison operators, type-aware with numeric int/double coercion) + `CompositeFilter AND`.
- **Wiring** — registered on the gRPC server in `main.go`.
- **Acceptance test flipped** — `tests/integration/gcp/pending/datastore_test.go` had its `gcp_pending` tag removed and now passes (`cloud.google.com/go/datastore`).

## Fidelity fixes (from the architect review)

- Query operators fail closed — unsupported operators/`OR`/GQL return `InvalidArgument`, never match-all.
- `ErrInvalidKey`/incomplete-key mutations map to `InvalidArgument` (not `Internal`).
- Transactional `Commit` is rejected with `Unimplemented` (documented non-transactional contract) instead of silently non-atomic.
- `AllocateIds` rejects complete keys; explicit numeric IDs advance the allocator (no collision).
- Multi-element keys and non-default `namespace_id`/`database_id` fail loudly (`InvalidArgument`).
- `commit_time` omitted for non-transactional commits.

## Verification

`go build` / `go vet` / `gofmt` clean; `go test -race` green; no `internal/gcp` regressions; acceptance `TestDatastore` passes; REST `sdkv1` parity green.

## Deferred

`ReserveIds`/`RunAggregationQuery` remain `Unimplemented`; transactions are stubs; namespaces/database IDs are single-project only.
