### PR TITLE
ci(gcp): split test-gcp into unit/integration/persistence jobs; wire monitoring + pending SDK tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,147 @@ jobs:
           cache-from: type=gha,scope=jaiscloud
           cache-to: type=gha,mode=max,scope=jaiscloud
 
-  # ─── GCP unit + integration tests ──────────────────────────────────────────
-  # Builds and boots jaiscloud-gcp, then runs the GCP unit + integration suites.
-  test-gcp:
+  # ─── GCP unit + integration + persistence tests ────────────────────────────
+
+  # Unit tests for the shared engine packages the GCP Dataproc/Spark path
+  # depends on (no services required).
+  test-gcp-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.26'
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-gcp-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-gcp-
+            ${{ runner.os }}-go-
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Run GCP unit tests
+        run: go test -race -count=1 ./internal/gcp/... ./internal/sparkhelpers/... ./internal/k8shelpers/... ./internal/platform/... ./internal/executor/...
+
+  # Builds and boots jaiscloud-gcp on both REST (8080) and gRPC (8081) ports,
+  # then runs the raw-HTTP and per-SDK integration suites against the emulator.
+  test-gcp-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.26'
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-gcp-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-gcp-
+            ${{ runner.os }}-go-
+
+      - name: Download modules
+        run: |
+          go mod download
+          for m in sdk sdkv1 sdk-firestore sdk-monitoring sdk-workflows sdk-dataproc pending; do
+            (cd tests/integration/gcp/$m && go mod download)
+          done
+
+      - name: Build jaiscloud-gcp
+        run: go build -o jaiscloud-gcp ./cmd/jaiscloud-gcp/
+
+      - name: Start jaiscloud-gcp (background)
+        run: |
+          ./jaiscloud-gcp start --port 8080 --grpc-port 8081 > gcp-server.log 2>&1 & echo $! > gcp-server.pid
+
+      - name: Wait for GCP server health
+        run: |
+          for i in {1..60}; do
+            if curl -sfS http://localhost:8080/_jaiscloud/health >/dev/null 2>&1; then
+              echo "gcp server healthy"; exit 0
+            fi
+            sleep 1
+          done
+          cat gcp-server.log
+          exit 1
+
+      - name: Run raw-HTTP integration tests
+        run: go test -race -count=1 -timeout 120s ./tests/integration/gcp/
+
+      - name: Run GCS REST SDK tests
+        working-directory: tests/integration/gcp/sdk
+        env:
+          STORAGE_EMULATOR_HOST: http://localhost:8080
+        run: go test -v -count=1 -timeout 120s ./...
+
+      - name: Run Phase 1 REST SDK tests
+        working-directory: tests/integration/gcp/sdkv1
+        env:
+          GCP_EMULATOR_ENDPOINT: http://localhost:8080/
+        run: go test -v -count=1 -timeout 120s ./...
+
+      - name: Run Workflows SDK tests
+        working-directory: tests/integration/gcp/sdk-workflows
+        env:
+          GCP_EMULATOR_ENDPOINT: http://localhost:8080/
+        run: go test -v -count=1 -timeout 120s ./...
+
+      - name: Run Dataproc SDK tests
+        working-directory: tests/integration/gcp/sdk-dataproc
+        env:
+          GCP_EMULATOR_ENDPOINT: http://localhost:8080/
+        run: go test -v -count=1 -timeout 120s ./...
+
+      - name: Run Firestore gRPC SDK tests
+        working-directory: tests/integration/gcp/sdk-firestore
+        env:
+          FIRESTORE_EMULATOR_HOST: localhost:8081
+        run: go test -v -count=1 -timeout 120s ./...
+
+      - name: Run Monitoring gRPC SDK tests
+        working-directory: tests/integration/gcp/sdk-monitoring
+        env:
+          MONITORING_EMULATOR_HOST: localhost:8081
+        run: go test -v -count=1 -timeout 120s ./...
+
+      - name: Run Logging/Datastore/GCS-gRPC SDK tests
+        working-directory: tests/integration/gcp/pending
+        env:
+          STORAGE_EMULATOR_HOST_GRPC: localhost:8081
+          DATASTORE_EMULATOR_HOST: localhost:8081
+          LOGGING_EMULATOR_HOST: localhost:8081
+          GCP_EMULATOR_PROJECT: test-project
+        run: go test -v -count=1 -timeout 120s ./...
+
+      - name: Upload GCP server log (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gcp-server-log
+          path: gcp-server.log
+
+      - name: Stop GCP server
+        if: always()
+        run: |
+          if [ -f gcp-server.pid ]; then kill $(cat gcp-server.pid) || true; fi
+
+  # Persistence-mode tests backed by a Postgres service container.
+  test-gcp-persistence:
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -139,79 +277,10 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Download modules
-        run: |
-          go mod download
-          cd tests/integration/gcp/sdk && go mod download
-          cd ../sdkv1 && go mod download
-          cd ../sdk-firestore && go mod download
-          cd ../sdk-workflows && go mod download
-          cd ../sdk-dataproc && go mod download
-
-      - name: Run GCP unit tests
-        run: go test -race -count=1 ./internal/gcp/...
+        run: go mod download
 
       - name: Build jaiscloud-gcp
         run: go build -o jaiscloud-gcp ./cmd/jaiscloud-gcp/
-
-      - name: Start jaiscloud-gcp (background)
-        run: |
-          ./jaiscloud-gcp start --port 8080 > gcp-server.log 2>&1 & echo $! > gcp-server.pid
-
-      - name: Wait for GCP server health
-        run: |
-          for i in {1..60}; do
-            if curl -sfS http://localhost:8080/_jaiscloud/health >/dev/null 2>&1; then
-              echo "gcp server healthy"; exit 0
-            fi
-            sleep 1
-          done
-          cat gcp-server.log
-          exit 1
-
-      - name: Run GCP integration tests
-        run: go test -race ./tests/integration/gcp/ -v -count=1 -timeout 120s
-
-      - name: Run GCP SDK integration tests
-        working-directory: tests/integration/gcp/sdk
-        env:
-          STORAGE_EMULATOR_HOST: http://localhost:8080
-        run: go test -race -v -count=1 -timeout 120s ./...
-
-      - name: Run GCP Phase 1 SDK integration tests
-        working-directory: tests/integration/gcp/sdkv1
-        env:
-          GCP_EMULATOR_ENDPOINT: http://localhost:8080/
-        run: go test -race -v -count=1 -timeout 120s ./...
-
-      - name: Run GCP Workflows SDK tests
-        working-directory: tests/integration/gcp/sdk-workflows
-        env:
-          GCP_EMULATOR_ENDPOINT: http://localhost:8080/
-        run: go test -race -v -count=1 -timeout 120s ./...
-
-      - name: Run GCP Dataproc SDK tests
-        working-directory: tests/integration/gcp/sdk-dataproc
-        env:
-          GCP_EMULATOR_ENDPOINT: http://localhost:8080/
-        run: go test -race -v -count=1 -timeout 120s ./...
-
-      - name: Run GCP Firestore SDK tests
-        working-directory: tests/integration/gcp/sdk-firestore
-        env:
-          FIRESTORE_EMULATOR_HOST: localhost:8081
-        run: go test -race -v -count=1 -timeout 120s ./...
-
-      - name: Upload GCP server log (on failure)
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: gcp-server-log
-          path: gcp-server.log
-
-      - name: Stop GCP server
-        if: always()
-        run: |
-          if [ -f gcp-server.pid ]; then kill $(cat gcp-server.pid) || true; fi
 
       - name: Wait for Postgres
         run: |

--- a/tests/integration/gcp/pending/README.md
+++ b/tests/integration/gcp/pending/README.md
@@ -1,23 +1,40 @@
 # Pending GCP service tests
 
-This nested module holds SDK test suites for the GCP services jaiscloud-gcp does
-**not yet implement**: Cloud Logging, Datastore, Managed Kafka, and Cloud Storage
-gRPC v2.
+This nested module holds SDK test suites that live outside the main `sdk*`
+modules. As services get implemented, their tests here are "flipped active"
+(the `gcp_pending` build tag is removed) and run in CI via the
+`test-gcp-integration` job.
 
-**These tests are expected to FAIL.** They are real, complete test bodies (real
-SDK calls + assertions) written ahead of the implementation, serving as the
-acceptance spec to build against — not placeholders. Each is gated behind
-`//go:build gcp_pending`, so they are excluded from normal `go build`/`go test`
-and have no CI impact.
+**Currently active (untagged, run in CI):** Cloud Datastore
+(`datastore_test.go`), Cloud Storage gRPC v2 (`gcs_grpc_test.go`), and Cloud
+Logging (`logging_test.go`).
 
-To run them (and see the current failures):
+**Currently pending (tagged `//go:build gcp_pending`, excluded from normal
+`go build`/`go test` and CI):** Managed Kafka (`kafka_test.go`).
+
+## Running
+
+Against a running `jaiscloud-gcp` (REST `http://localhost:8080`, gRPC
+`localhost:8081`):
 
 ```bash
+# Active tests (no build tag)
+STORAGE_EMULATOR_HOST_GRPC=localhost:8081 \
+DATASTORE_EMULATOR_HOST=localhost:8081 \
+LOGGING_EMULATOR_HOST=localhost:8081 \
+GCP_EMULATOR_PROJECT=test-project \
+go test -count=1 ./...
+
+# Include the still-pending (kafka) test to see its current failures
 go test -tags gcp_pending -count=1 ./...
 ```
 
-against a running `jaiscloud-gcp` (REST `http://localhost:8080`, gRPC
-`localhost:8081`; env vars `GCP_EMULATOR_ENDPOINT` / `GCP_EMULATOR_PROJECT`).
+Client factories live in `internal/testutil/fixtures.go`. Env-var contract:
 
-When a service is implemented, flip its test into the active suite (drop the
-`gcp_pending` build tag and move it alongside the other `sdk*` modules).
+- `STORAGE_EMULATOR_HOST_GRPC` — Storage v2 gRPC endpoint (default `localhost:8081`)
+- `DATASTORE_EMULATOR_HOST` — Datastore gRPC endpoint (native SDK var)
+- `LOGGING_EMULATOR_HOST` — Logging v2 gRPC endpoint (default `localhost:8081`)
+- `GCP_EMULATOR_PROJECT` — project id (default `test-project`)
+
+When the pending service is implemented, drop its `gcp_pending` build tag (and
+optionally move the file alongside the other `sdk*` modules).

--- a/tests/integration/gcp/pending/internal/testutil/fixtures.go
+++ b/tests/integration/gcp/pending/internal/testutil/fixtures.go
@@ -7,6 +7,7 @@ package testutil
 import (
 	"context"
 	"os"
+	"strings"
 
 	"cloud.google.com/go/datastore"
 	logging "cloud.google.com/go/logging/apiv2"
@@ -25,9 +26,22 @@ func ProjectID() string {
 }
 
 // StorageGRPCClient returns a Cloud Storage v2 gRPC client configured for the
-// emulator. Reads STORAGE_EMULATOR_HOST (e.g. localhost:8081).
+// emulator. Reads STORAGE_EMULATOR_HOST_GRPC (e.g. localhost:8081) — the
+// gRPC-specific var, distinct from STORAGE_EMULATOR_HOST which targets the REST
+// JSON API. The endpoint is dialed explicitly because the storage gRPC client
+// only honors STORAGE_EMULATOR_HOST_GRPC natively.
 func StorageGRPCClient(ctx context.Context) *storage.Client {
-	client, err := storage.NewGRPCClient(ctx)
+	host := os.Getenv("STORAGE_EMULATOR_HOST_GRPC")
+	if host == "" {
+		host = "localhost:8081"
+	}
+	host = stripScheme(host)
+	client, err := storage.NewGRPCClient(ctx,
+		option.WithEndpoint(host),
+		option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		option.WithoutAuthentication(),
+		storage.WithDisabledClientMetrics(),
+	)
 	if err != nil {
 		panic("failed to create gRPC storage client: " + err.Error())
 	}
@@ -35,7 +49,8 @@ func StorageGRPCClient(ctx context.Context) *storage.Client {
 }
 
 // DatastoreClient returns a Datastore client configured for the emulator.
-// Reads DATASTORE_EMULATOR_HOST (e.g. localhost:8081).
+// Relies on the datastore SDK's native DATASTORE_EMULATOR_HOST env handling
+// (e.g. localhost:8081), so the CI env block must set it.
 func DatastoreClient(ctx context.Context) *datastore.Client {
 	client, err := datastore.NewClient(ctx, ProjectID())
 	if err != nil {
@@ -60,4 +75,13 @@ func LoggingClient(ctx context.Context) *logging.Client {
 		panic("failed to create logging client: " + err.Error())
 	}
 	return client
+}
+
+// stripScheme removes a leading "scheme://" from an endpoint so it can be used
+// as a bare grpc target.
+func stripScheme(host string) string {
+	if i := strings.Index(host, "://"); i >= 0 {
+		return host[i+3:]
+	}
+	return host
 }


### PR DESCRIPTION
## Summary

Reorganizes the GCP test flow in `.github/workflows/ci.yml` and closes two coverage gaps.

## Changes

### `ci.yml` — split `test-gcp` into three parallel jobs

- **`test-gcp-unit`** — `go test -race ./internal/gcp/...` plus the shared engine packages Dataproc depends on (`sparkhelpers`, `k8shelpers`, `platform`, `executor`). No services required.
- **`test-gcp-integration`** — boots `jaiscloud-gcp` on both REST `:8080` and gRPC `:8081` (now with an explicit `--grpc-port 8081`), then runs raw-HTTP integration + the per-SDK suites as individually-named steps. SDK module downloads use a `for` loop instead of the brittle `cd ../…` chain.
- **`test-gcp-persistence`** — Postgres service + the existing `gcp_persistence` suite, moved out of the ephemeral job.

### Coverage fixes

- **`sdk-monitoring`** now wired in (was previously never run).
- **`pending`** module now runs in CI — the *active* Datastore / GCS-gRPC / Logging tests (Kafka remains `gcp_pending`-tagged and excluded).

### Test-infra fix

- `pending/internal/testutil/fixtures.go` — `StorageGRPCClient` now targets the emulator explicitly and reads the correct `STORAGE_EMULATOR_HOST_GRPC` var (the storage gRPC client ignores `STORAGE_EMULATOR_HOST`); scheme is stripped before dialing. `pending/README.md` synced to reflect the actual active/pending split and env-var contract.

### `-race` policy

Kept on unit + raw-HTTP integration; dropped on the network-bound nested SDK modules (matching `test-aws`, which races unit tests only).

## Verification

`go build ./...` + `pending` module build clean; YAML valid (5 jobs). `sdk-monitoring` and the three active `pending` tests (Datastore, GCS-gRPC, Logging) all pass against a locally booted emulator on gRPC `:8081`.

## Notes (deferred, non-blocking)

- gRPC listener is not health-probed (only REST `/_jaiscloud/health`); a future gRPC health check would harden the three gRPC SDK steps.
- The nested-module list in the download loop is hardcoded; a new module must be added there manually.
