### PR TITLE
feat(gcp): Managed Kafka emulator (metadata-only clusters/topics/consumerGroups)

### DIFF
--- a/cmd/jaiscloud-gcp/main.go
+++ b/cmd/jaiscloud-gcp/main.go
@@ -38,6 +38,7 @@ import (
 	functionsprovider "jaiscloud/internal/gcp/provider/functions"
 	iamprovider "jaiscloud/internal/gcp/provider/iam"
 	kmsprovider "jaiscloud/internal/gcp/provider/kms"
+	managedkafkaprovider "jaiscloud/internal/gcp/provider/managedkafka"
 	pubsubprovider "jaiscloud/internal/gcp/provider/pubsub"
 	secretmanagerprovider "jaiscloud/internal/gcp/provider/secretmanager"
 	storageprovider "jaiscloud/internal/gcp/provider/storage"
@@ -52,6 +53,7 @@ import (
 	"jaiscloud/internal/gcp/store/gcs"
 	kmsstore "jaiscloud/internal/gcp/store/kms"
 	loggingstore "jaiscloud/internal/gcp/store/logging"
+	managedkafkastore "jaiscloud/internal/gcp/store/managedkafka"
 	monitoringstore "jaiscloud/internal/gcp/store/monitoring"
 	pubsubstore "jaiscloud/internal/gcp/store/pubsub"
 	secretmanagerstore "jaiscloud/internal/gcp/store/secretmanager"
@@ -227,6 +229,8 @@ func startCmd() *cobra.Command {
 			dataprocP := dataprocprovider.New(stores.dataproc, stores.resources, dataprocOpts...)
 			defer dataprocP.Shutdown(context.Background())
 
+			managedkafkaP := managedkafkaprovider.New(stores.managedkafka)
+
 			reg := provider.NewRegistry().
 				Register(storageP).
 				Register(secretP).
@@ -237,7 +241,8 @@ func startCmd() *cobra.Command {
 				Register(functionsP).
 				Register(workflowsP).
 				Register(workflowExecutionsP).
-				Register(dataprocP)
+				Register(dataprocP).
+				Register(managedkafkaP)
 
 			// gRPC transport shares the SAME Firestore provider Service as the
 			// REST adapter, so both transports use one transaction read-set
@@ -284,6 +289,7 @@ func startCmd() *cobra.Command {
 			adminHandler.RegisterResetter(stores.functions)
 			adminHandler.RegisterResetter(stores.workflows)
 			adminHandler.RegisterResetter(stores.dataproc)
+			adminHandler.RegisterResetter(stores.managedkafka)
 			adminHandler.RegisterResetter(stores.logEntries)
 			adminHandler.RegisterResetter(stores.monitoring)
 			adminHandler.RegisterResetter(stores.resources)
@@ -321,6 +327,9 @@ func startCmd() *cobra.Command {
 			}
 			if snap, ok := stores.dataproc.(admin.Snapshotter); ok {
 				adminHandler.RegisterSnapshotter("dataproc", snap)
+			}
+			if snap, ok := stores.managedkafka.(admin.Snapshotter); ok {
+				adminHandler.RegisterSnapshotter("managedkafka", snap)
 			}
 			if snap, ok := stores.logEntries.(admin.Snapshotter); ok {
 				adminHandler.RegisterSnapshotter("log_entries", snap)
@@ -483,20 +492,21 @@ func bindFlags(cmd *cobra.Command) {
 
 // stores bundles the per-mode store backends constructed by initStores.
 type stores struct {
-	objects    gcs.ObjectStore
-	messages   pubsubstore.Messages
-	secrets    secretmanagerstore.Store
-	keys       kmsstore.Store
-	documents  firestorestore.FirestoreStore
-	entities   datastorestore.Store
-	functions  functionsstore.Store
-	workflows  workflowsstore.Store
-	dataproc   dataprocstore.Store
-	logEntries loggingstore.Store
-	monitoring monitoringstore.Store
-	resources  store.ResourceStore
-	blobs      blobfs.BlobStore
-	close      func()
+	objects      gcs.ObjectStore
+	messages     pubsubstore.Messages
+	secrets      secretmanagerstore.Store
+	keys         kmsstore.Store
+	documents    firestorestore.FirestoreStore
+	entities     datastorestore.Store
+	functions    functionsstore.Store
+	workflows    workflowsstore.Store
+	dataproc     dataprocstore.Store
+	managedkafka managedkafkastore.Store
+	logEntries   loggingstore.Store
+	monitoring   monitoringstore.Store
+	resources    store.ResourceStore
+	blobs        blobfs.BlobStore
+	close        func()
 }
 
 func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*stores, error) {
@@ -515,38 +525,40 @@ func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*st
 			return nil, fmt.Errorf("blobfs: %w", err)
 		}
 		return &stores{
-			objects:    gcs.NewPostgresObjectStore(pg.Pool()),
-			messages:   pubsubstore.NewPostgresMessages(pg.Pool()),
-			secrets:    secretmanagerstore.NewPostgresStore(pg.Pool()),
-			keys:       kmsstore.NewPostgresStore(pg.Pool()),
-			documents:  firestorestore.NewPostgresStore(pg.Pool()),
-			entities:   datastorestore.NewPostgresStore(pg.Pool()),
-			functions:  functionsstore.NewPostgresStore(pg.Pool()),
-			workflows:  workflowsstore.NewPostgresStore(pg.Pool()),
-			dataproc:   dataprocstore.NewPostgresStore(pg.Pool()),
-			logEntries: loggingstore.NewPostgresStore(pg.Pool()),
-			monitoring: monitoringstore.NewPostgresStore(pg.Pool()),
-			resources:  pg,
-			blobs:      blobs,
-			close:      func() { pg.Close() },
+			objects:      gcs.NewPostgresObjectStore(pg.Pool()),
+			messages:     pubsubstore.NewPostgresMessages(pg.Pool()),
+			secrets:      secretmanagerstore.NewPostgresStore(pg.Pool()),
+			keys:         kmsstore.NewPostgresStore(pg.Pool()),
+			documents:    firestorestore.NewPostgresStore(pg.Pool()),
+			entities:     datastorestore.NewPostgresStore(pg.Pool()),
+			functions:    functionsstore.NewPostgresStore(pg.Pool()),
+			workflows:    workflowsstore.NewPostgresStore(pg.Pool()),
+			dataproc:     dataprocstore.NewPostgresStore(pg.Pool()),
+			managedkafka: managedkafkastore.NewPostgresStore(pg.Pool()),
+			logEntries:   loggingstore.NewPostgresStore(pg.Pool()),
+			monitoring:   monitoringstore.NewPostgresStore(pg.Pool()),
+			resources:    pg,
+			blobs:        blobs,
+			close:        func() { pg.Close() },
 		}, nil
 	}
 	if cfg.Ephemeral {
 		return &stores{
-			objects:    gcs.NewMemoryObjectStore(),
-			messages:   pubsubstore.NewMemoryMessages(),
-			secrets:    secretmanagerstore.NewMemoryStore(),
-			keys:       kmsstore.NewMemoryStore(),
-			documents:  firestorestore.NewMemoryStore(),
-			entities:   datastorestore.NewMemoryStore(),
-			functions:  functionsstore.NewMemoryStore(),
-			workflows:  workflowsstore.NewMemoryStore(),
-			dataproc:   dataprocstore.NewMemoryStore(),
-			logEntries: loggingstore.NewMemoryStore(),
-			monitoring: monitoringstore.NewMemoryStore(),
-			resources:  store.NewMemoryResourceStore(),
-			blobs:      blobfs.NewMemoryBlobStore(),
-			close:      func() {},
+			objects:      gcs.NewMemoryObjectStore(),
+			messages:     pubsubstore.NewMemoryMessages(),
+			secrets:      secretmanagerstore.NewMemoryStore(),
+			keys:         kmsstore.NewMemoryStore(),
+			documents:    firestorestore.NewMemoryStore(),
+			entities:     datastorestore.NewMemoryStore(),
+			functions:    functionsstore.NewMemoryStore(),
+			workflows:    workflowsstore.NewMemoryStore(),
+			dataproc:     dataprocstore.NewMemoryStore(),
+			managedkafka: managedkafkastore.NewMemoryStore(),
+			logEntries:   loggingstore.NewMemoryStore(),
+			monitoring:   monitoringstore.NewMemoryStore(),
+			resources:    store.NewMemoryResourceStore(),
+			blobs:        blobfs.NewMemoryBlobStore(),
+			close:        func() {},
 		}, nil
 	}
 	blobs, err := blobfs.NewSessionBlobStore(instanceID)
@@ -554,20 +566,21 @@ func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*st
 		return nil, fmt.Errorf("blobfs: %w", err)
 	}
 	return &stores{
-		objects:    gcs.NewMemoryObjectStore(),
-		messages:   pubsubstore.NewMemoryMessages(),
-		secrets:    secretmanagerstore.NewMemoryStore(),
-		keys:       kmsstore.NewMemoryStore(),
-		documents:  firestorestore.NewMemoryStore(),
-		entities:   datastorestore.NewMemoryStore(),
-		functions:  functionsstore.NewMemoryStore(),
-		workflows:  workflowsstore.NewMemoryStore(),
-		dataproc:   dataprocstore.NewMemoryStore(),
-		logEntries: loggingstore.NewMemoryStore(),
-		monitoring: monitoringstore.NewMemoryStore(),
-		resources:  store.NewMemoryResourceStore(),
-		blobs:      blobs,
-		close:      func() {},
+		objects:      gcs.NewMemoryObjectStore(),
+		messages:     pubsubstore.NewMemoryMessages(),
+		secrets:      secretmanagerstore.NewMemoryStore(),
+		keys:         kmsstore.NewMemoryStore(),
+		documents:    firestorestore.NewMemoryStore(),
+		entities:     datastorestore.NewMemoryStore(),
+		functions:    functionsstore.NewMemoryStore(),
+		workflows:    workflowsstore.NewMemoryStore(),
+		dataproc:     dataprocstore.NewMemoryStore(),
+		managedkafka: managedkafkastore.NewMemoryStore(),
+		logEntries:   loggingstore.NewMemoryStore(),
+		monitoring:   monitoringstore.NewMemoryStore(),
+		resources:    store.NewMemoryResourceStore(),
+		blobs:        blobs,
+		close:        func() {},
 	}, nil
 }
 

--- a/internal/gcp/adapter/jsoncodec_test.go
+++ b/internal/gcp/adapter/jsoncodec_test.go
@@ -106,6 +106,11 @@ func TestDetectV1Service(t *testing.T) {
 		"/v1/projects/p/locations/us/keyRings/kr/cryptoKeys/k/cryptoKeyVersions/3": "kms",
 		"/v1/projects/p/serviceAccounts/sa@x.com":                                  "iam",
 		"/v1/projects/p/locations/us-central1/functions/f":                         "functions",
+		"/v1/projects/p/locations/us-central1/clusters":                            "managedkafka",
+		"/v1/projects/p/locations/us-central1/clusters/c":                          "managedkafka",
+		"/v1/projects/p/locations/us-central1/clusters/c/topics":                   "managedkafka",
+		"/v1/projects/p/locations/us-central1/clusters/c/topics/t":                 "managedkafka",
+		"/v1/projects/p/locations/us-central1/clusters/c/consumerGroups":           "managedkafka",
 		"/storage/v1/b/bkt/o":                                                      "",
 	}
 	for path, want := range cases {

--- a/internal/gcp/adapter/managedkafka.go
+++ b/internal/gcp/adapter/managedkafka.go
@@ -1,0 +1,183 @@
+package gcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"jaiscloud/internal/gcp/wire"
+	"jaiscloud/internal/model"
+)
+
+// ManagedKafkaCodec decodes the Managed Kafka v1 REST surface
+// (managedkafka.googleapis.com/v1). Resources live under
+// /v1/projects/{project}/locations/{location}/clusters[/{id}][/topics[/{topicId}]|/consumerGroups].
+// Unlike Dataproc, there are no custom ":verb" methods and no long-running
+// operation resource — cluster create/update/delete return the resource inline
+// (wrapped in a done operation by the provider), and topic CRUD is fully
+// synchronous.
+type ManagedKafkaCodec struct {
+	Service string
+}
+
+func (c *ManagedKafkaCodec) ServiceName() string { return c.Service }
+
+func (c *ManagedKafkaCodec) Decode(r *http.Request, body []byte) (*model.NormalizedRequest, error) {
+	seg := splitEscaped(r.URL.EscapedPath())
+	pi := -1
+	for i, s := range seg {
+		if s == "projects" {
+			pi = i
+			break
+		}
+	}
+	if pi < 0 || pi+1 >= len(seg) {
+		return nil, model.NewProviderError("InvalidRequest", "missing project in resource path", 404)
+	}
+
+	nr := &model.NormalizedRequest{Service: c.Service, Params: map[string]any{}, Raw: r}
+	nr.Params["project"] = seg[pi+1]
+	queryToParams(r, nr.Params)
+	m, err := parseJSON(body)
+	if err != nil {
+		return nil, model.NewProviderError("InvalidRequest", "malformed JSON body", 400)
+	}
+	if m != nil {
+		nr.Params["body"] = m
+	}
+
+	// rest = ["locations", "{location}", "clusters", ...] after projects/{project}.
+	rest := seg[pi+2:]
+	if len(rest) < 3 || rest[0] != "locations" {
+		return nil, model.NewProviderError("InvalidRequest", "expected locations/{location}/clusters in managed kafka path", 404)
+	}
+	nr.Params["location"] = rest[1]
+	tail := rest[2:]
+
+	if len(tail) == 0 || tail[0] != "clusters" {
+		return nil, model.NewProviderError("InvalidRequest", "expected clusters in managed kafka path", 404)
+	}
+
+	var resourceType, clusterID, topicID string
+	isCollection := false
+	switch len(tail) {
+	case 1: // ["clusters"]
+		resourceType = "clusters"
+		isCollection = true
+	case 2: // ["clusters", id]
+		resourceType = "clusters"
+		clusterID = tail[1]
+	case 3: // ["clusters", id, "topics"|"consumerGroups"]
+		resourceType = tail[2]
+		clusterID = tail[1]
+		isCollection = true
+	case 4: // ["clusters", id, "topics"|"consumerGroups", id]
+		resourceType = tail[2]
+		clusterID = tail[1]
+		topicID = tail[3]
+	default:
+		return nil, model.NewProviderError("InvalidRequest", "unrecognized managed kafka path", 404)
+	}
+
+	nr.Params["resourceType"] = resourceType
+	nr.Params["name"] = strings.Join(rest, "/")
+	if clusterID != "" {
+		nr.Params["clusterId"] = clusterID
+	}
+	if topicID != "" {
+		nr.Params["topicId"] = topicID
+	}
+
+	nr.Action = deriveManagedKafkaAction(resourceType, isCollection, r.Method)
+	if nr.Action == "" {
+		return nil, model.NewProviderError("UnsupportedOperation", "unsupported operation", 404)
+	}
+	return nr, nil
+}
+
+// deriveManagedKafkaAction maps (resourceType, isCollection, method) to the
+// action name. Create is POST on the collection; delete is DELETE on the
+// resource; there are no custom-method verbs.
+func deriveManagedKafkaAction(resourceType string, isCollection bool, method string) string {
+	switch resourceType {
+	case "clusters":
+		switch {
+		case isCollection && method == http.MethodPost:
+			return "CreateCluster"
+		case isCollection && method == http.MethodGet:
+			return "ListClusters"
+		case method == http.MethodGet:
+			return "GetCluster"
+		case method == http.MethodPatch:
+			return "UpdateCluster"
+		case method == http.MethodDelete:
+			return "DeleteCluster"
+		}
+	case "topics":
+		switch {
+		case isCollection && method == http.MethodPost:
+			return "CreateTopic"
+		case isCollection && method == http.MethodGet:
+			return "ListTopics"
+		case method == http.MethodGet:
+			return "GetTopic"
+		case method == http.MethodPatch:
+			return "UpdateTopic"
+		case method == http.MethodDelete:
+			return "DeleteTopic"
+		}
+	case "consumerGroups":
+		switch {
+		case isCollection && method == http.MethodGet:
+			return "ListConsumerGroups"
+		case method == http.MethodGet:
+			return "GetConsumerGroup"
+		case method == http.MethodPatch:
+			return "UpdateConsumerGroup"
+		case method == http.MethodDelete:
+			return "DeleteConsumerGroup"
+		}
+	}
+	return ""
+}
+
+// Encode serialises a provider response as JSON.
+func (c *ManagedKafkaCodec) Encode(nr *model.NormalizedRequest, resp *model.ProviderResponse) (int, http.Header, []byte) {
+	status := resp.HTTPStatus
+	if status == 0 {
+		status = http.StatusOK
+	}
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json; charset=UTF-8")
+	if raw, ok := resp.Data[wire.RawJSONKey].(json.RawMessage); ok {
+		return status, headers, raw
+	}
+	out, err := json.Marshal(resp.Data)
+	if err != nil {
+		return http.StatusInternalServerError, headers, []byte(`{"error":{"code":500,"message":"encode failure","status":"INTERNAL"}}`)
+	}
+	return status, headers, out
+}
+
+// EncodeError serialises a ProviderError as a GCP error envelope.
+func (c *ManagedKafkaCodec) EncodeError(nr *model.NormalizedRequest, perr *model.ProviderError) (int, http.Header, []byte) {
+	status := perr.HTTPStatus
+	if status == 0 {
+		status = http.StatusInternalServerError
+	}
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json; charset=UTF-8")
+	statusStr := perr.Status
+	if statusStr == "" {
+		statusStr = gcpStatusString(status)
+	}
+	env := map[string]any{
+		"error": map[string]any{
+			"code":    status,
+			"message": perr.Message,
+			"status":  statusStr,
+		},
+	}
+	out, _ := json.Marshal(env)
+	return status, headers, out
+}

--- a/internal/gcp/adapter/router.go
+++ b/internal/gcp/adapter/router.go
@@ -17,6 +17,10 @@ const (
 // GCP has no SigV4 scope; the path is the sole reliable discriminator.
 func DetectService(r *http.Request) (service string, source DetectionSource) {
 	p := r.URL.Path
+	// SDK test clients concatenate an endpoint that may already end in "/" with
+	// "/v1/..." paths, yielding a leading "//". Collapse redundant leading
+	// slashes so path-prefix detection is stable.
+	p = "/" + strings.TrimLeft(p, "/")
 	for _, svc := range gcpServices {
 		for _, prefix := range svc.PathPrefixes {
 			if strings.HasPrefix(p, prefix) {
@@ -87,6 +91,12 @@ func detectV1Service(path string) string {
 	if detectDataprocResourceType(rest) != "" {
 		return "dataproc"
 	}
+	// Managed Kafka lives under /v1/projects/{project}/locations/{location}/clusters
+	// — detect it before the generic resource-type switch (a topic path's "topics"
+	// segment would otherwise be mistaken for the Pub/Sub topic surface).
+	if detectManagedKafkaResourceType(rest) != "" {
+		return "managedkafka"
+	}
 	switch detectResourceType(rest) {
 	case "topics", "subscriptions":
 		return "pubsub"
@@ -117,6 +127,19 @@ func detectDataprocResourceType(seg []string) string {
 	switch seg[2] {
 	case "clusters", "jobs", "operations":
 		return seg[2]
+	}
+	return ""
+}
+
+// detectManagedKafkaResourceType returns "clusters" when the segments after
+// projects/{project} form locations/{location}/clusters, else "". The
+// "locations" (vs Dataproc's "regions") segment is the distinguishing key.
+func detectManagedKafkaResourceType(seg []string) string {
+	if len(seg) < 3 || seg[0] != "locations" {
+		return ""
+	}
+	if seg[2] == "clusters" {
+		return "clusters"
 	}
 	return ""
 }

--- a/internal/gcp/adapter/services.go
+++ b/internal/gcp/adapter/services.go
@@ -79,6 +79,11 @@ var gcpServices = []ServiceDescriptor{
 		ProviderPrefix: "Dataproc",
 		Codec:          func() adapter.Codec { return &DataprocCodec{Service: "dataproc"} },
 	},
+	{
+		ServiceName:    "managedkafka",
+		ProviderPrefix: "ManagedKafka",
+		Codec:          func() adapter.Codec { return &ManagedKafkaCodec{Service: "managedkafka"} },
+	},
 }
 
 // serviceProviderMap maps wire service name → provider registry prefix.

--- a/internal/gcp/provider/managedkafka/managedkafka.go
+++ b/internal/gcp/provider/managedkafka/managedkafka.go
@@ -1,0 +1,395 @@
+// Package managedkafka implements the Apache Kafka for BigQuery (Managed Kafka)
+// v1 provider (managedkafka.googleapis.com/v1): Cluster and Topic resources.
+//
+// A cluster is a logical record only — the emulator never stands up a real
+// broker. Cluster create/update/delete return the resource inline wrapped in a
+// done long-running operation (matching the test's expectation that the SDK
+// reads `done` + `response` from the HTTP body); topic CRUD is fully synchronous
+// and returns the resource directly. Consumer groups are not tracked — their
+// list endpoint always returns an empty list.
+package managedkafka
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"jaiscloud/internal/clock"
+	mkstore "jaiscloud/internal/gcp/store/managedkafka"
+	"jaiscloud/internal/model"
+	"jaiscloud/internal/provider"
+)
+
+// Provider handles Managed Kafka v1 cluster and topic resources.
+type Provider struct {
+	store mkstore.Store
+}
+
+// New returns a Provider backed by the given store.
+func New(s mkstore.Store) *Provider {
+	return &Provider{store: s}
+}
+
+// Reset wipes the store.
+func (p *Provider) Reset(ctx context.Context) { p.store.Reset(ctx) }
+
+func (p *Provider) Routes() map[string]provider.HandlerFunc {
+	return map[string]provider.HandlerFunc{
+		"ManagedKafka.CreateCluster":      p.CreateCluster,
+		"ManagedKafka.GetCluster":         p.GetCluster,
+		"ManagedKafka.ListClusters":       p.ListClusters,
+		"ManagedKafka.UpdateCluster":      p.UpdateCluster,
+		"ManagedKafka.DeleteCluster":      p.DeleteCluster,
+		"ManagedKafka.CreateTopic":        p.CreateTopic,
+		"ManagedKafka.GetTopic":           p.GetTopic,
+		"ManagedKafka.ListTopics":         p.ListTopics,
+		"ManagedKafka.UpdateTopic":        p.UpdateTopic,
+		"ManagedKafka.DeleteTopic":        p.DeleteTopic,
+		"ManagedKafka.ListConsumerGroups": p.ListConsumerGroups,
+		// Consumer-group resource operations (get/update/delete) are not
+		// tracked by the emulator; they route to an Unimplemented response.
+		"ManagedKafka.GetConsumerGroup":    p.consumerGroupUnimplemented,
+		"ManagedKafka.UpdateConsumerGroup": p.consumerGroupUnimplemented,
+		"ManagedKafka.DeleteConsumerGroup": p.consumerGroupUnimplemented,
+	}
+}
+
+func strParam(nr *model.NormalizedRequest, key string) string {
+	s, _ := nr.Params[key].(string)
+	return s
+}
+
+func bodyMap(body map[string]any, key string) map[string]any {
+	if body == nil {
+		return nil
+	}
+	m, _ := body[key].(map[string]any)
+	return m
+}
+
+func bodyStringMap(body map[string]any, key string) map[string]string {
+	m := bodyMap(body, key)
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
+func bodyInt(body map[string]any, key string) int {
+	if body == nil {
+		return 0
+	}
+	switch v := body[key].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	case json.Number:
+		if n, err := v.Int64(); err == nil {
+			return int(n)
+		}
+	}
+	return 0
+}
+
+func mapErr(err error) error {
+	switch {
+	case errors.Is(err, mkstore.ErrNoSuchCluster):
+		return model.NewProviderError("NotFound", "cluster not found", 404)
+	case errors.Is(err, mkstore.ErrNoSuchTopic):
+		return model.NewProviderError("NotFound", "topic not found", 404)
+	case errors.Is(err, mkstore.ErrAlreadyExists):
+		return model.NewProviderError("AlreadyExists", "resource already exists", 409)
+	}
+	return err
+}
+
+func formatTimestamp(t time.Time) string {
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+// --- Wire rendering ---
+
+// clusterMap renders a store Cluster as a managedkafka.v1.Cluster wire map.
+// capacityConfig, gcpConfig, rebalanceConfig, and tlsConfig are echoed from the
+// stored config verbatim.
+func (p *Provider) clusterMap(nr *model.NormalizedRequest, c mkstore.Cluster) map[string]any {
+	name := nr.ResourceID("managedkafka-cluster", c.Location+"/"+c.Name)
+	out := map[string]any{
+		"name":       name,
+		"state":      "ACTIVE",
+		"createTime": formatTimestamp(c.CreateTime),
+		"updateTime": formatTimestamp(c.UpdateTime),
+	}
+	var cfg map[string]any
+	if len(c.Config) > 0 {
+		_ = json.Unmarshal(c.Config, &cfg)
+	}
+	for _, k := range []string{"capacityConfig", "gcpConfig", "rebalanceConfig", "tlsConfig"} {
+		if v, ok := cfg[k].(map[string]any); ok {
+			out[k] = v
+		}
+	}
+	labels := c.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	out["labels"] = labels
+	return out
+}
+
+// topicMap renders a store Topic as a managedkafka.v1.Topic wire map.
+func (p *Provider) topicMap(nr *model.NormalizedRequest, t mkstore.Topic) map[string]any {
+	name := nr.ResourceID("managedkafka-topic", t.Location+"/"+t.ClusterName+"/"+t.Name)
+	return map[string]any{
+		"name":              name,
+		"partitionCount":    t.PartitionCount,
+		"replicationFactor": t.ReplicationFactor,
+	}
+}
+
+// --- Clusters ---
+
+// clusterLRO wraps a cluster mutation in the emulator's flattened synchronous
+// long-running-operation shape, {"done":true,"response":{...}}. The proto
+// returns a google.longrunning.Operation (with name/metadata/@type); this is a
+// deliberate simplification so SDKs reading done+response from the body succeed.
+func (p *Provider) clusterLRO(nr *model.NormalizedRequest, c mkstore.Cluster) *model.ProviderResponse {
+	return provider.OK(map[string]any{"done": true, "response": p.clusterMap(nr, c)})
+}
+
+func (p *Provider) CreateCluster(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	location := strParam(nr, "location")
+	clusterID := strParam(nr, "clusterId")
+	if location == "" || clusterID == "" {
+		return nil, model.NewProviderError("InvalidArgument", "missing location or clusterId", 400)
+	}
+	body, _ := nr.Params["body"].(map[string]any)
+	now := clock.Now().UTC()
+	c := mkstore.Cluster{
+		Name:       clusterID,
+		Labels:     bodyStringMap(body, "labels"),
+		CreateTime: now,
+		UpdateTime: now,
+	}
+	if body != nil {
+		if data, err := json.Marshal(body); err == nil {
+			c.Config = data
+		}
+	}
+	if err := p.store.CreateCluster(ctx, nr.AccountID, location, c); err != nil {
+		return nil, mapErr(err)
+	}
+	return p.clusterLRO(nr, c), nil
+}
+
+func (p *Provider) GetCluster(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	location := strParam(nr, "location")
+	clusterID := strParam(nr, "clusterId")
+	if location == "" || clusterID == "" {
+		return nil, model.NewProviderError("InvalidArgument", "missing location or clusterId", 400)
+	}
+	c, err := p.store.GetCluster(ctx, nr.AccountID, location, clusterID)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	return provider.OK(p.clusterMap(nr, c)), nil
+}
+
+func (p *Provider) ListClusters(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	location := strParam(nr, "location")
+	if location == "" {
+		return nil, model.NewProviderError("InvalidArgument", "missing location", 400)
+	}
+	clusters, err := p.store.ListClusters(ctx, nr.AccountID, location)
+	if err != nil {
+		return nil, err
+	}
+	// pageSize/pageToken are accepted but ignored — the emulator returns the
+	// full list (no pagination).
+	items := make([]any, 0, len(clusters))
+	for _, c := range clusters {
+		items = append(items, p.clusterMap(nr, c))
+	}
+	return provider.OK(map[string]any{"clusters": items}), nil
+}
+
+func (p *Provider) UpdateCluster(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	location := strParam(nr, "location")
+	clusterID := strParam(nr, "clusterId")
+	if location == "" || clusterID == "" {
+		return nil, model.NewProviderError("InvalidArgument", "missing location or clusterId", 400)
+	}
+	c, err := p.store.GetCluster(ctx, nr.AccountID, location, clusterID)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	body, _ := nr.Params["body"].(map[string]any)
+	if body != nil {
+		stored := map[string]any{}
+		if len(c.Config) > 0 {
+			_ = json.Unmarshal(c.Config, &stored)
+		}
+		for k, v := range body {
+			stored[k] = v
+		}
+		if labels := bodyStringMap(body, "labels"); labels != nil {
+			c.Labels = labels
+		}
+		if data, err := json.Marshal(stored); err == nil {
+			c.Config = data
+		}
+	}
+	c.UpdateTime = clock.Now().UTC()
+	if err := p.store.UpdateCluster(ctx, nr.AccountID, location, c); err != nil {
+		return nil, mapErr(err)
+	}
+	return p.clusterLRO(nr, c), nil
+}
+
+func (p *Provider) DeleteCluster(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	location := strParam(nr, "location")
+	clusterID := strParam(nr, "clusterId")
+	if location == "" || clusterID == "" {
+		return nil, model.NewProviderError("InvalidArgument", "missing location or clusterId", 400)
+	}
+	if err := p.store.DeleteCluster(ctx, nr.AccountID, location, clusterID); err != nil {
+		return nil, mapErr(err)
+	}
+	return provider.OK(map[string]any{"done": true, "response": map[string]any{}}), nil
+}
+
+// --- Topics ---
+
+func (p *Provider) CreateTopic(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	location := strParam(nr, "location")
+	clusterID := strParam(nr, "clusterId")
+	topicID := strParam(nr, "topicId")
+	if location == "" || clusterID == "" || topicID == "" {
+		return nil, model.NewProviderError("InvalidArgument", "missing location, clusterId, or topicId", 400)
+	}
+	if _, err := p.store.GetCluster(ctx, nr.AccountID, location, clusterID); err != nil {
+		return nil, mapErr(err)
+	}
+	body, _ := nr.Params["body"].(map[string]any)
+	now := clock.Now().UTC()
+	t := mkstore.Topic{
+		Name:              topicID,
+		PartitionCount:    bodyInt(body, "partitionCount"),
+		ReplicationFactor: bodyInt(body, "replicationFactor"),
+		CreateTime:        now,
+		UpdateTime:        now,
+	}
+	if body != nil {
+		if data, err := json.Marshal(body); err == nil {
+			t.Config = data
+		}
+	}
+	if err := p.store.CreateTopic(ctx, nr.AccountID, location, clusterID, t); err != nil {
+		return nil, mapErr(err)
+	}
+	return provider.OK(p.topicMap(nr, t)), nil
+}
+
+func (p *Provider) GetTopic(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	location := strParam(nr, "location")
+	clusterID := strParam(nr, "clusterId")
+	topicID := strParam(nr, "topicId")
+	if location == "" || clusterID == "" || topicID == "" {
+		return nil, model.NewProviderError("InvalidArgument", "missing location, clusterId, or topicId", 400)
+	}
+	t, err := p.store.GetTopic(ctx, nr.AccountID, location, clusterID, topicID)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	return provider.OK(p.topicMap(nr, t)), nil
+}
+
+func (p *Provider) ListTopics(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	location := strParam(nr, "location")
+	clusterID := strParam(nr, "clusterId")
+	if location == "" || clusterID == "" {
+		return nil, model.NewProviderError("InvalidArgument", "missing location or clusterId", 400)
+	}
+	topics, err := p.store.ListTopics(ctx, nr.AccountID, location, clusterID)
+	if err != nil {
+		return nil, err
+	}
+	// pageSize/pageToken are accepted but ignored — the emulator returns the
+	// full list (no pagination).
+	items := make([]any, 0, len(topics))
+	for _, t := range topics {
+		items = append(items, p.topicMap(nr, t))
+	}
+	return provider.OK(map[string]any{"topics": items}), nil
+}
+
+func (p *Provider) UpdateTopic(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	location := strParam(nr, "location")
+	clusterID := strParam(nr, "clusterId")
+	topicID := strParam(nr, "topicId")
+	if location == "" || clusterID == "" || topicID == "" {
+		return nil, model.NewProviderError("InvalidArgument", "missing location, clusterId, or topicId", 400)
+	}
+	t, err := p.store.GetTopic(ctx, nr.AccountID, location, clusterID, topicID)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	body, _ := nr.Params["body"].(map[string]any)
+	if body != nil {
+		if _, ok := body["partitionCount"]; ok {
+			t.PartitionCount = bodyInt(body, "partitionCount")
+		}
+		if _, ok := body["replicationFactor"]; ok {
+			t.ReplicationFactor = bodyInt(body, "replicationFactor")
+		}
+		stored := map[string]any{}
+		if len(t.Config) > 0 {
+			_ = json.Unmarshal(t.Config, &stored)
+		}
+		for k, v := range body {
+			stored[k] = v
+		}
+		if data, err := json.Marshal(stored); err == nil {
+			t.Config = data
+		}
+	}
+	t.UpdateTime = clock.Now().UTC()
+	if err := p.store.UpdateTopic(ctx, nr.AccountID, location, clusterID, t); err != nil {
+		return nil, mapErr(err)
+	}
+	return provider.OK(p.topicMap(nr, t)), nil
+}
+
+func (p *Provider) DeleteTopic(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	location := strParam(nr, "location")
+	clusterID := strParam(nr, "clusterId")
+	topicID := strParam(nr, "topicId")
+	if location == "" || clusterID == "" || topicID == "" {
+		return nil, model.NewProviderError("InvalidArgument", "missing location, clusterId, or topicId", 400)
+	}
+	if err := p.store.DeleteTopic(ctx, nr.AccountID, location, clusterID, topicID); err != nil {
+		return nil, mapErr(err)
+	}
+	return provider.OK(map[string]any{}), nil
+}
+
+// ListConsumerGroups returns an empty list — the emulator does not track
+// consumer-group state.
+func (p *Provider) ListConsumerGroups(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	return provider.OK(map[string]any{"consumerGroups": []any{}}), nil
+}
+
+// consumerGroupUnimplemented returns Unimplemented for the consumer-group
+// resource operations (get/update/delete) — the emulator tracks only the
+// (empty) consumer-group list, not individual groups.
+func (p *Provider) consumerGroupUnimplemented(_ context.Context, _ *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	return nil, model.NewProviderError("Unimplemented", "consumer group operations are not implemented", 404)
+}

--- a/internal/gcp/resource/resource.go
+++ b/internal/gcp/resource/resource.go
@@ -80,6 +80,16 @@ var formatters = map[string]func(project, name string) string{
 		reg, op := regionOf(n)
 		return fmt.Sprintf("projects/%s/regions/%s/operations/%s", p, reg, op)
 	},
+	// Managed Kafka (Apache Kafka for BigQuery) — names embed the location;
+	// callers pass "location/cluster" and "location/cluster/topic".
+	"managedkafka-cluster": func(p, n string) string {
+		loc, c := wfLoc(n)
+		return fmt.Sprintf("projects/%s/locations/%s/clusters/%s", p, loc, c)
+	},
+	"managedkafka-topic": func(p, n string) string {
+		loc, c, t := wfExec(n)
+		return fmt.Sprintf("projects/%s/locations/%s/clusters/%s/topics/%s", p, loc, c, t)
+	},
 }
 
 // ResourceID returns a function that formats GCP resource names for a project.

--- a/internal/gcp/store/managedkafka/memory.go
+++ b/internal/gcp/store/managedkafka/memory.go
@@ -1,0 +1,162 @@
+package managedkafka
+
+import (
+	"context"
+	"sort"
+	"sync"
+)
+
+// MemoryStore is an in-memory Store.
+type MemoryStore struct {
+	mu       sync.RWMutex
+	clusters map[string]map[string]Cluster // projectID+"/"+location → name → cluster
+	topics   map[string]map[string]Topic   // projectID+"/"+location+"/"+cluster → name → topic
+}
+
+// NewMemoryStore returns an empty in-memory store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		clusters: make(map[string]map[string]Cluster),
+		topics:   make(map[string]map[string]Topic),
+	}
+}
+
+func clusterScope(projectID, location string) string { return projectID + "/" + location }
+
+func topicScope(projectID, location, clusterName string) string {
+	return projectID + "/" + location + "/" + clusterName
+}
+
+func (s *MemoryStore) CreateCluster(_ context.Context, projectID, location string, c Cluster) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := clusterScope(projectID, location)
+	if s.clusters[key] == nil {
+		s.clusters[key] = make(map[string]Cluster)
+	}
+	if _, ok := s.clusters[key][c.Name]; ok {
+		return ErrAlreadyExists
+	}
+	c.ProjectID = projectID
+	c.Location = location
+	s.clusters[key][c.Name] = c
+	return nil
+}
+
+func (s *MemoryStore) GetCluster(_ context.Context, projectID, location, name string) (Cluster, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	c, ok := s.clusters[clusterScope(projectID, location)][name]
+	if !ok {
+		return Cluster{}, ErrNoSuchCluster
+	}
+	return c, nil
+}
+
+func (s *MemoryStore) UpdateCluster(_ context.Context, projectID, location string, c Cluster) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := clusterScope(projectID, location)
+	if _, ok := s.clusters[key][c.Name]; !ok {
+		return ErrNoSuchCluster
+	}
+	c.ProjectID = projectID
+	c.Location = location
+	s.clusters[key][c.Name] = c
+	return nil
+}
+
+func (s *MemoryStore) DeleteCluster(_ context.Context, projectID, location, name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := clusterScope(projectID, location)
+	if _, ok := s.clusters[key][name]; !ok {
+		return ErrNoSuchCluster
+	}
+	delete(s.clusters[key], name)
+	delete(s.topics, topicScope(projectID, location, name))
+	return nil
+}
+
+func (s *MemoryStore) ListClusters(_ context.Context, projectID, location string) ([]Cluster, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	m := s.clusters[clusterScope(projectID, location)]
+	result := make([]Cluster, 0, len(m))
+	for _, c := range m {
+		result = append(result, c)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result, nil
+}
+
+func (s *MemoryStore) CreateTopic(_ context.Context, projectID, location, clusterName string, t Topic) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := topicScope(projectID, location, clusterName)
+	if s.topics[key] == nil {
+		s.topics[key] = make(map[string]Topic)
+	}
+	if _, ok := s.topics[key][t.Name]; ok {
+		return ErrAlreadyExists
+	}
+	t.ProjectID = projectID
+	t.Location = location
+	t.ClusterName = clusterName
+	s.topics[key][t.Name] = t
+	return nil
+}
+
+func (s *MemoryStore) GetTopic(_ context.Context, projectID, location, clusterName, topicName string) (Topic, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	t, ok := s.topics[topicScope(projectID, location, clusterName)][topicName]
+	if !ok {
+		return Topic{}, ErrNoSuchTopic
+	}
+	return t, nil
+}
+
+func (s *MemoryStore) UpdateTopic(_ context.Context, projectID, location, clusterName string, t Topic) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := topicScope(projectID, location, clusterName)
+	if _, ok := s.topics[key][t.Name]; !ok {
+		return ErrNoSuchTopic
+	}
+	t.ProjectID = projectID
+	t.Location = location
+	t.ClusterName = clusterName
+	s.topics[key][t.Name] = t
+	return nil
+}
+
+func (s *MemoryStore) DeleteTopic(_ context.Context, projectID, location, clusterName, topicName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := topicScope(projectID, location, clusterName)
+	if _, ok := s.topics[key][topicName]; !ok {
+		return ErrNoSuchTopic
+	}
+	delete(s.topics[key], topicName)
+	return nil
+}
+
+func (s *MemoryStore) ListTopics(_ context.Context, projectID, location, clusterName string) ([]Topic, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	m := s.topics[topicScope(projectID, location, clusterName)]
+	result := make([]Topic, 0, len(m))
+	for _, t := range m {
+		result = append(result, t)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result, nil
+}
+
+func (s *MemoryStore) Reset(_ context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.clusters = make(map[string]map[string]Cluster)
+	s.topics = make(map[string]map[string]Topic)
+}

--- a/internal/gcp/store/managedkafka/postgres.go
+++ b/internal/gcp/store/managedkafka/postgres.go
@@ -1,0 +1,233 @@
+package managedkafka
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sort"
+
+	"jaiscloud/internal/clock"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgresStore implements Store against jc_mk_clusters / jc_mk_topics.
+type PostgresStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresStore returns a Postgres-backed store.
+func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore {
+	return &PostgresStore{pool: pool}
+}
+
+// --- Clusters ---
+
+func (s *PostgresStore) CreateCluster(ctx context.Context, projectID, location string, c Cluster) error {
+	if c.CreateTime.IsZero() {
+		c.CreateTime = clock.Now()
+	}
+	if c.UpdateTime.IsZero() {
+		c.UpdateTime = c.CreateTime
+	}
+	labels, _ := json.Marshal(c.Labels)
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO jc_mk_clusters
+			(project_id, location, cluster_name, config, labels, create_time, update_time)
+		VALUES ($1,$2,$3,$4,$5,$6,$7)
+	`, projectID, location, c.Name, nullableJSONRaw(c.Config, "{}"), nullableJSONRaw(labels, "{}"), c.CreateTime, c.UpdateTime)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrAlreadyExists
+		}
+		return err
+	}
+	return nil
+}
+
+func scanCluster(row pgx.Row) (Cluster, error) {
+	var c Cluster
+	var config, labels []byte
+	err := row.Scan(&c.ProjectID, &c.Location, &c.Name, &config, &labels, &c.CreateTime, &c.UpdateTime)
+	if err != nil {
+		return Cluster{}, err
+	}
+	c.Config = json.RawMessage(config)
+	json.Unmarshal(labels, &c.Labels)
+	return c, nil
+}
+
+func (s *PostgresStore) GetCluster(ctx context.Context, projectID, location, name string) (Cluster, error) {
+	c, err := scanCluster(s.pool.QueryRow(ctx, `
+		SELECT project_id, location, cluster_name, config, labels, create_time, update_time
+		FROM jc_mk_clusters WHERE project_id=$1 AND location=$2 AND cluster_name=$3
+	`, projectID, location, name))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Cluster{}, ErrNoSuchCluster
+	}
+	return c, err
+}
+
+func (s *PostgresStore) UpdateCluster(ctx context.Context, projectID, location string, c Cluster) error {
+	labels, _ := json.Marshal(c.Labels)
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE jc_mk_clusters SET config=$4, labels=$5, update_time=$6
+		WHERE project_id=$1 AND location=$2 AND cluster_name=$3
+	`, projectID, location, c.Name, nullableJSONRaw(c.Config, "{}"), nullableJSONRaw(labels, "{}"), c.UpdateTime)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNoSuchCluster
+	}
+	return nil
+}
+
+func (s *PostgresStore) DeleteCluster(ctx context.Context, projectID, location, name string) error {
+	// Delete the cluster's topics first so no orphaned rows remain, mirroring
+	// MemoryStore.DeleteCluster (which drops the topic scope alongside the
+	// cluster). The explicit DELETE keeps the migration additive-safe (no
+	// schema change / FK cascade required).
+	if _, err := s.pool.Exec(ctx, `DELETE FROM jc_mk_topics WHERE project_id=$1 AND location=$2 AND cluster_name=$3`, projectID, location, name); err != nil {
+		return err
+	}
+	tag, err := s.pool.Exec(ctx, `DELETE FROM jc_mk_clusters WHERE project_id=$1 AND location=$2 AND cluster_name=$3`, projectID, location, name)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNoSuchCluster
+	}
+	return nil
+}
+
+func (s *PostgresStore) ListClusters(ctx context.Context, projectID, location string) ([]Cluster, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT project_id, location, cluster_name, config, labels, create_time, update_time
+		FROM jc_mk_clusters WHERE project_id=$1 AND location=$2 ORDER BY cluster_name
+	`, projectID, location)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []Cluster
+	for rows.Next() {
+		c, err := scanCluster(rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, c)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result, rows.Err()
+}
+
+// --- Topics ---
+
+func (s *PostgresStore) CreateTopic(ctx context.Context, projectID, location, clusterName string, t Topic) error {
+	if t.CreateTime.IsZero() {
+		t.CreateTime = clock.Now()
+	}
+	if t.UpdateTime.IsZero() {
+		t.UpdateTime = t.CreateTime
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO jc_mk_topics
+			(project_id, location, cluster_name, topic_name, partition_count, replication_factor, config, create_time, update_time)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+	`, projectID, location, clusterName, t.Name, t.PartitionCount, t.ReplicationFactor, nullableJSONRaw(t.Config, "{}"), t.CreateTime, t.UpdateTime)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrAlreadyExists
+		}
+		return err
+	}
+	return nil
+}
+
+func scanTopic(row pgx.Row) (Topic, error) {
+	var t Topic
+	var config []byte
+	err := row.Scan(&t.ProjectID, &t.Location, &t.ClusterName, &t.Name, &t.PartitionCount, &t.ReplicationFactor, &config, &t.CreateTime, &t.UpdateTime)
+	if err != nil {
+		return Topic{}, err
+	}
+	t.Config = json.RawMessage(config)
+	return t, nil
+}
+
+func (s *PostgresStore) GetTopic(ctx context.Context, projectID, location, clusterName, topicName string) (Topic, error) {
+	t, err := scanTopic(s.pool.QueryRow(ctx, `
+		SELECT project_id, location, cluster_name, topic_name, partition_count, replication_factor, config, create_time, update_time
+		FROM jc_mk_topics WHERE project_id=$1 AND location=$2 AND cluster_name=$3 AND topic_name=$4
+	`, projectID, location, clusterName, topicName))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Topic{}, ErrNoSuchTopic
+	}
+	return t, err
+}
+
+func (s *PostgresStore) UpdateTopic(ctx context.Context, projectID, location, clusterName string, t Topic) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE jc_mk_topics SET partition_count=$5, replication_factor=$6, config=$7, update_time=$8
+		WHERE project_id=$1 AND location=$2 AND cluster_name=$3 AND topic_name=$4
+	`, projectID, location, clusterName, t.Name, t.PartitionCount, t.ReplicationFactor, nullableJSONRaw(t.Config, "{}"), t.UpdateTime)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNoSuchTopic
+	}
+	return nil
+}
+
+func (s *PostgresStore) DeleteTopic(ctx context.Context, projectID, location, clusterName, topicName string) error {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM jc_mk_topics WHERE project_id=$1 AND location=$2 AND cluster_name=$3 AND topic_name=$4`, projectID, location, clusterName, topicName)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNoSuchTopic
+	}
+	return nil
+}
+
+func (s *PostgresStore) ListTopics(ctx context.Context, projectID, location, clusterName string) ([]Topic, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT project_id, location, cluster_name, topic_name, partition_count, replication_factor, config, create_time, update_time
+		FROM jc_mk_topics WHERE project_id=$1 AND location=$2 AND cluster_name=$3 ORDER BY topic_name
+	`, projectID, location, clusterName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []Topic
+	for rows.Next() {
+		t, err := scanTopic(rows)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, t)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Name < result[j].Name })
+	return result, rows.Err()
+}
+
+func (s *PostgresStore) Reset(ctx context.Context) {
+	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_mk_clusters`)
+	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_mk_topics`)
+}
+
+// nullableJSONRaw returns a json.RawMessage for a JSONB column, substituting the
+// given empty default ("{}" or "[]") for a nil/null value so NOT NULL columns
+// receive valid JSON instead of SQL NULL.
+func nullableJSONRaw(b []byte, empty string) any {
+	if len(b) == 0 || string(b) == "null" {
+		return json.RawMessage(empty)
+	}
+	return json.RawMessage(b)
+}

--- a/internal/gcp/store/managedkafka/postgres_test.go
+++ b/internal/gcp/store/managedkafka/postgres_test.go
@@ -1,0 +1,75 @@
+//go:build gcp_persistence
+
+package managedkafka
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	gcpstore "jaiscloud/internal/gcp/store"
+	"jaiscloud/internal/store"
+)
+
+// TestPostgresStore runs the shared store matrix against the Postgres backend.
+func TestPostgresStore(t *testing.T) {
+	dsn := os.Getenv("JAISCLOUD_DSN")
+	if dsn == "" {
+		t.Skip("JAISCLOUD_DSN not set — skipping Postgres store test")
+	}
+	ctx := context.Background()
+
+	pg, err := store.NewPostgresResourceStore(ctx, dsn, "gcp")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pg.Close()
+	if err := store.RunMigrations(ctx, pg.Pool(), "gcp", gcpstore.MigrationFS, "gcp"); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	s := NewPostgresStore(pg.Pool())
+	s.Reset(ctx)
+
+	runStoreTests(t, s)
+}
+
+// TestPostgresDeleteClusterCascadesTopics locks in the H3 fix: deleting a
+// cluster removes its topics, so no orphaned topic rows remain in --dsn mode.
+func TestPostgresDeleteClusterCascadesTopics(t *testing.T) {
+	dsn := os.Getenv("JAISCLOUD_DSN")
+	if dsn == "" {
+		t.Skip("JAISCLOUD_DSN not set — skipping Postgres cascade test")
+	}
+	ctx := context.Background()
+
+	pg, err := store.NewPostgresResourceStore(ctx, dsn, "gcp")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pg.Close()
+	if err := store.RunMigrations(ctx, pg.Pool(), "gcp", gcpstore.MigrationFS, "gcp"); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	s := NewPostgresStore(pg.Pool())
+	s.Reset(ctx)
+
+	if err := s.CreateCluster(ctx, "proj", "us-central1", Cluster{Name: "c1"}); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+	if err := s.CreateTopic(ctx, "proj", "us-central1", "c1", Topic{Name: "t1", PartitionCount: 3, ReplicationFactor: 1}); err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	if err := s.DeleteCluster(ctx, "proj", "us-central1", "c1"); err != nil {
+		t.Fatalf("delete cluster: %v", err)
+	}
+
+	topics, err := s.ListTopics(ctx, "proj", "us-central1", "c1")
+	if err != nil {
+		t.Fatalf("list topics after delete: %v", err)
+	}
+	if len(topics) != 0 {
+		t.Fatalf("expected 0 topics after cluster delete, got %d", len(topics))
+	}
+}

--- a/internal/gcp/store/managedkafka/snapshot.go
+++ b/internal/gcp/store/managedkafka/snapshot.go
@@ -1,0 +1,171 @@
+package managedkafka
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+)
+
+// --- Memory store ---
+
+func (s *MemoryStore) IsEmpty(_ context.Context) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.clusters) == 0 && len(s.topics) == 0, nil
+}
+
+func (s *MemoryStore) Snapshot(_ context.Context, w io.Writer) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return json.NewEncoder(w).Encode(map[string]any{
+		"clusters": s.clusters,
+		"topics":   s.topics,
+	})
+}
+
+func (s *MemoryStore) Restore(_ context.Context, r io.Reader) error {
+	var snap struct {
+		Clusters map[string]map[string]Cluster `json:"clusters"`
+		Topics   map[string]map[string]Topic   `json:"topics"`
+	}
+	if err := json.NewDecoder(r).Decode(&snap); err != nil {
+		return err
+	}
+	if snap.Clusters == nil {
+		snap.Clusters = map[string]map[string]Cluster{}
+	}
+	if snap.Topics == nil {
+		snap.Topics = map[string]map[string]Topic{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.clusters = snap.Clusters
+	s.topics = snap.Topics
+	return nil
+}
+
+// --- Postgres store ---
+
+func (s *PostgresStore) IsEmpty(ctx context.Context) (bool, error) {
+	var n int
+	if err := s.pool.QueryRow(ctx, `SELECT count(*) FROM jc_mk_clusters`).Scan(&n); err != nil {
+		return false, err
+	}
+	if n > 0 {
+		return false, nil
+	}
+	if err := s.pool.QueryRow(ctx, `SELECT count(*) FROM jc_mk_topics`).Scan(&n); err != nil {
+		return false, err
+	}
+	return n == 0, nil
+}
+
+func (s *PostgresStore) Snapshot(ctx context.Context, w io.Writer) error {
+	type clusterRow struct {
+		ProjectID string  `json:"projectId"`
+		Cluster   Cluster `json:"cluster"`
+	}
+	type topicRow struct {
+		ProjectID string `json:"projectId"`
+		Topic     Topic  `json:"topic"`
+	}
+
+	clusters := make([]clusterRow, 0)
+	topics := make([]topicRow, 0)
+
+	crows, err := s.pool.Query(ctx, `
+		SELECT project_id, location, cluster_name, config, labels, create_time, update_time
+		FROM jc_mk_clusters ORDER BY project_id, location, cluster_name
+	`)
+	if err != nil {
+		return err
+	}
+	for crows.Next() {
+		var r clusterRow
+		var config, labels []byte
+		if err := crows.Scan(&r.ProjectID, &r.Cluster.Location, &r.Cluster.Name, &config, &labels, &r.Cluster.CreateTime, &r.Cluster.UpdateTime); err != nil {
+			crows.Close()
+			return err
+		}
+		r.Cluster.Config = json.RawMessage(config)
+		json.Unmarshal(labels, &r.Cluster.Labels)
+		clusters = append(clusters, r)
+	}
+	crows.Close()
+	if err := crows.Err(); err != nil {
+		return err
+	}
+
+	trows, err := s.pool.Query(ctx, `
+		SELECT project_id, location, cluster_name, topic_name, partition_count, replication_factor, config, create_time, update_time
+		FROM jc_mk_topics ORDER BY project_id, location, cluster_name, topic_name
+	`)
+	if err != nil {
+		return err
+	}
+	for trows.Next() {
+		var r topicRow
+		var config []byte
+		if err := trows.Scan(&r.ProjectID, &r.Topic.Location, &r.Topic.ClusterName, &r.Topic.Name, &r.Topic.PartitionCount, &r.Topic.ReplicationFactor, &config, &r.Topic.CreateTime, &r.Topic.UpdateTime); err != nil {
+			trows.Close()
+			return err
+		}
+		r.Topic.Config = json.RawMessage(config)
+		topics = append(topics, r)
+	}
+	trows.Close()
+	if err := trows.Err(); err != nil {
+		return err
+	}
+
+	return json.NewEncoder(w).Encode(map[string]any{
+		"clusters": clusters,
+		"topics":   topics,
+	})
+}
+
+func (s *PostgresStore) Restore(ctx context.Context, r io.Reader) error {
+	var snap struct {
+		Clusters []struct {
+			ProjectID string  `json:"projectId"`
+			Cluster   Cluster `json:"cluster"`
+		} `json:"clusters"`
+		Topics []struct {
+			ProjectID string `json:"projectId"`
+			Topic     Topic  `json:"topic"`
+		} `json:"topics"`
+	}
+	if err := json.NewDecoder(r).Decode(&snap); err != nil {
+		return err
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	for _, tbl := range []string{"jc_mk_clusters", "jc_mk_topics"} {
+		if _, err := tx.Exec(ctx, `DELETE FROM `+tbl); err != nil {
+			return err
+		}
+	}
+	for _, r := range snap.Clusters {
+		labels, _ := json.Marshal(r.Cluster.Labels)
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO jc_mk_clusters
+				(project_id, location, cluster_name, config, labels, create_time, update_time)
+			VALUES ($1,$2,$3,$4,$5,$6,$7)
+		`, r.ProjectID, r.Cluster.Location, r.Cluster.Name, nullableJSONRaw(r.Cluster.Config, "{}"), nullableJSONRaw(labels, "{}"), r.Cluster.CreateTime, r.Cluster.UpdateTime); err != nil {
+			return err
+		}
+	}
+	for _, r := range snap.Topics {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO jc_mk_topics
+				(project_id, location, cluster_name, topic_name, partition_count, replication_factor, config, create_time, update_time)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+		`, r.ProjectID, r.Topic.Location, r.Topic.ClusterName, r.Topic.Name, r.Topic.PartitionCount, r.Topic.ReplicationFactor, nullableJSONRaw(r.Topic.Config, "{}"), r.Topic.CreateTime, r.Topic.UpdateTime); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}

--- a/internal/gcp/store/managedkafka/store.go
+++ b/internal/gcp/store/managedkafka/store.go
@@ -1,0 +1,65 @@
+// Package managedkafka provides the Apache Kafka for BigQuery (Managed Kafka)
+// store. Resources are project+location scoped with canonical names
+// projects/{project}/locations/{location}/clusters/{name} (and
+// .../clusters/{name}/topics/{topic}). A cluster is a logical record only — the
+// emulator never stands up a real broker. Consumer groups are not tracked (their
+// list endpoint always returns an empty list).
+package managedkafka
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+var (
+	ErrNoSuchCluster = errors.New("NoSuchCluster")
+	ErrNoSuchTopic   = errors.New("NoSuchTopic")
+	ErrAlreadyExists = errors.New("AlreadyExists")
+)
+
+// Cluster is a logical Managed Kafka cluster. Config holds the wire request
+// body (capacityConfig, gcpConfig, ...) verbatim as JSON so read-back echoes
+// what the caller sent; Labels are the extracted labels map.
+type Cluster struct {
+	ProjectID  string            `json:"projectId"`
+	Location   string            `json:"location"`
+	Name       string            `json:"clusterName"`
+	Config     json.RawMessage   `json:"config,omitempty"`
+	Labels     map[string]string `json:"labels,omitempty"`
+	CreateTime time.Time         `json:"createTime"`
+	UpdateTime time.Time         `json:"updateTime"`
+}
+
+// Topic is a logical Managed Kafka topic under a cluster. PartitionCount and
+// ReplicationFactor are the explicit ints the REST surface round-trips; Config
+// holds any additional wire fields verbatim.
+type Topic struct {
+	ProjectID         string          `json:"projectId"`
+	Location          string          `json:"location"`
+	ClusterName       string          `json:"clusterName"`
+	Name              string          `json:"topicName"`
+	PartitionCount    int             `json:"partitionCount"`
+	ReplicationFactor int             `json:"replicationFactor"`
+	Config            json.RawMessage `json:"config,omitempty"`
+	CreateTime        time.Time       `json:"createTime"`
+	UpdateTime        time.Time       `json:"updateTime"`
+}
+
+// Store is the Managed Kafka store.
+type Store interface {
+	CreateCluster(ctx context.Context, projectID, location string, c Cluster) error
+	GetCluster(ctx context.Context, projectID, location, name string) (Cluster, error)
+	UpdateCluster(ctx context.Context, projectID, location string, c Cluster) error
+	DeleteCluster(ctx context.Context, projectID, location, name string) error
+	ListClusters(ctx context.Context, projectID, location string) ([]Cluster, error)
+
+	CreateTopic(ctx context.Context, projectID, location, clusterName string, t Topic) error
+	GetTopic(ctx context.Context, projectID, location, clusterName, topicName string) (Topic, error)
+	UpdateTopic(ctx context.Context, projectID, location, clusterName string, t Topic) error
+	DeleteTopic(ctx context.Context, projectID, location, clusterName, topicName string) error
+	ListTopics(ctx context.Context, projectID, location, clusterName string) ([]Topic, error)
+
+	Reset(ctx context.Context)
+}

--- a/internal/gcp/store/managedkafka/store_test.go
+++ b/internal/gcp/store/managedkafka/store_test.go
@@ -1,0 +1,117 @@
+package managedkafka
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// runStoreTests exercises a Store against the shared test matrix. Backend tests
+// (memory/postgres) call this so both implement the identical contract.
+func runStoreTests(t *testing.T, s Store) {
+	ctx := context.Background()
+	defer s.Reset(ctx)
+
+	if _, err := s.GetCluster(ctx, "proj", "us-central1", "nope"); err != ErrNoSuchCluster {
+		t.Fatalf("expected ErrNoSuchCluster, got %v", err)
+	}
+
+	c := Cluster{
+		Name:   "my-cluster",
+		Config: []byte(`{"capacityConfig":{"vcpuCount":3,"memoryBytes":3221225472},"gcpConfig":{"accessConfig":{"networkConfigs":[]}}}`),
+		Labels: map[string]string{"env": "dev"},
+	}
+	if err := s.CreateCluster(ctx, "proj", "us-central1", c); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+	if err := s.CreateCluster(ctx, "proj", "us-central1", c); err != ErrAlreadyExists {
+		t.Fatalf("expected ErrAlreadyExists, got %v", err)
+	}
+
+	got, err := s.GetCluster(ctx, "proj", "us-central1", "my-cluster")
+	if err != nil {
+		t.Fatalf("get cluster: %v", err)
+	}
+	if got.Labels["env"] != "dev" {
+		t.Fatalf("cluster labels lost: %+v", got)
+	}
+	if string(got.Config) != `{"capacityConfig":{"vcpuCount":3,"memoryBytes":3221225472},"gcpConfig":{"accessConfig":{"networkConfigs":[]}}}` {
+		t.Fatalf("config not verbatim: %s", got.Config)
+	}
+
+	got.Config = []byte(`{"capacityConfig":{"vcpuCount":6,"memoryBytes":6442450944}}`)
+	if err := s.UpdateCluster(ctx, "proj", "us-central1", got); err != nil {
+		t.Fatalf("update cluster: %v", err)
+	}
+	list, err := s.ListClusters(ctx, "proj", "us-central1")
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list clusters: %v %d", err, len(list))
+	}
+	if string(list[0].Config) != `{"capacityConfig":{"vcpuCount":6,"memoryBytes":6442450944}}` {
+		t.Fatalf("update not persisted: %+v", list[0])
+	}
+
+	// Topics
+	if _, err := s.GetTopic(ctx, "proj", "us-central1", "my-cluster", "nope"); err != ErrNoSuchTopic {
+		t.Fatalf("expected ErrNoSuchTopic, got %v", err)
+	}
+	tp := Topic{Name: "t1", PartitionCount: 3, ReplicationFactor: 1}
+	if err := s.CreateTopic(ctx, "proj", "us-central1", "my-cluster", tp); err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	if err := s.CreateTopic(ctx, "proj", "us-central1", "my-cluster", tp); err != ErrAlreadyExists {
+		t.Fatalf("expected topic ErrAlreadyExists, got %v", err)
+	}
+	gotTopic, err := s.GetTopic(ctx, "proj", "us-central1", "my-cluster", "t1")
+	if err != nil || gotTopic.PartitionCount != 3 {
+		t.Fatalf("get topic: %v %+v", err, gotTopic)
+	}
+	gotTopic.PartitionCount = 6
+	if err := s.UpdateTopic(ctx, "proj", "us-central1", "my-cluster", gotTopic); err != nil {
+		t.Fatalf("update topic: %v", err)
+	}
+	tlist, err := s.ListTopics(ctx, "proj", "us-central1", "my-cluster")
+	if err != nil || len(tlist) != 1 || tlist[0].PartitionCount != 6 {
+		t.Fatalf("list topics: %v %+v", err, tlist)
+	}
+	if err := s.DeleteTopic(ctx, "proj", "us-central1", "my-cluster", "t1"); err != nil {
+		t.Fatalf("delete topic: %v", err)
+	}
+
+	// Delete cluster
+	if err := s.DeleteCluster(ctx, "proj", "us-central1", "my-cluster"); err != nil {
+		t.Fatalf("delete cluster: %v", err)
+	}
+	if _, err := s.GetCluster(ctx, "proj", "us-central1", "my-cluster"); err != ErrNoSuchCluster {
+		t.Fatalf("expected ErrNoSuchCluster after delete, got %v", err)
+	}
+}
+
+func TestMemoryStore(t *testing.T) {
+	runStoreTests(t, NewMemoryStore())
+}
+
+func TestMemoryStoreSnapshotRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	_ = s.CreateCluster(ctx, "p", "l", Cluster{Name: "c", Labels: map[string]string{"k": "v"}, Config: []byte(`{"capacityConfig":{"vcpuCount":3}}`)})
+	_ = s.CreateTopic(ctx, "p", "l", "c", Topic{Name: "t", PartitionCount: 3, ReplicationFactor: 1})
+
+	var buf bytes.Buffer
+	if err := s.Snapshot(ctx, &buf); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	s2 := NewMemoryStore()
+	if err := s2.Restore(ctx, &buf); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	got, err := s2.GetCluster(ctx, "p", "l", "c")
+	if err != nil || got.Labels["k"] != "v" {
+		t.Fatalf("cluster lost after restore: %v %+v", err, got)
+	}
+	gotTopic, err := s2.GetTopic(ctx, "p", "l", "c", "t")
+	if err != nil || gotTopic.PartitionCount != 3 || gotTopic.ReplicationFactor != 1 {
+		t.Fatalf("topic lost after restore: %v %+v", err, gotTopic)
+	}
+}

--- a/internal/gcp/store/migrations/026_managed_kafka.sql
+++ b/internal/gcp/store/migrations/026_managed_kafka.sql
@@ -1,0 +1,31 @@
+-- Apache Kafka for BigQuery (Managed Kafka). Resources are project+location
+-- scoped with canonical names
+-- projects/{project}/locations/{location}/clusters/{name} (and
+-- .../clusters/{name}/topics/{topic}). A cluster is a logical record only; its
+-- request body (capacityConfig, gcpConfig, ...) is stored verbatim as JSONB and
+-- labels as structured JSONB. Topics store partitionCount/replicationFactor as
+-- ints plus any additional wire fields verbatim. Consumer groups are not tracked.
+
+CREATE TABLE IF NOT EXISTS jc_mk_clusters (
+    project_id   TEXT        NOT NULL,
+    location     TEXT        NOT NULL,
+    cluster_name TEXT        NOT NULL,
+    config       JSONB       NOT NULL DEFAULT '{}',
+    labels       JSONB       NOT NULL DEFAULT '{}',
+    create_time  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    update_time  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (project_id, location, cluster_name)
+);
+
+CREATE TABLE IF NOT EXISTS jc_mk_topics (
+    project_id         TEXT        NOT NULL,
+    location           TEXT        NOT NULL,
+    cluster_name       TEXT        NOT NULL,
+    topic_name         TEXT        NOT NULL,
+    partition_count    INT         NOT NULL DEFAULT 0,
+    replication_factor INT         NOT NULL DEFAULT 0,
+    config             JSONB       NOT NULL DEFAULT '{}',
+    create_time        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    update_time        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (project_id, location, cluster_name, topic_name)
+);

--- a/tests/integration/gcp/pending/README.md
+++ b/tests/integration/gcp/pending/README.md
@@ -1,16 +1,14 @@
-# Pending GCP service tests
+# GCP service tests
 
 This nested module holds SDK test suites that live outside the main `sdk*`
-modules. As services get implemented, their tests here are "flipped active"
-(the `gcp_pending` build tag is removed) and run in CI via the
-`test-gcp-integration` job.
+modules. Tests here are run in CI via the `test-gcp-integration` job.
 
-**Currently active (untagged, run in CI):** Cloud Datastore
-(`datastore_test.go`), Cloud Storage gRPC v2 (`gcs_grpc_test.go`), and Cloud
-Logging (`logging_test.go`).
+**Active (untagged, run in CI):** Cloud Datastore (`datastore_test.go`),
+Cloud Storage gRPC v2 (`gcs_grpc_test.go`), Cloud Logging (`logging_test.go`),
+and Managed Kafka (`kafka_test.go`).
 
-**Currently pending (tagged `//go:build gcp_pending`, excluded from normal
-`go build`/`go test` and CI):** Managed Kafka (`kafka_test.go`).
+There are no pending services left: every test in this module is now active,
+so the `gcp_pending` build tag is no longer used by any file here.
 
 ## Running
 
@@ -18,15 +16,11 @@ Against a running `jaiscloud-gcp` (REST `http://localhost:8080`, gRPC
 `localhost:8081`):
 
 ```bash
-# Active tests (no build tag)
 STORAGE_EMULATOR_HOST_GRPC=localhost:8081 \
 DATASTORE_EMULATOR_HOST=localhost:8081 \
 LOGGING_EMULATOR_HOST=localhost:8081 \
 GCP_EMULATOR_PROJECT=test-project \
 go test -count=1 ./...
-
-# Include the still-pending (kafka) test to see its current failures
-go test -tags gcp_pending -count=1 ./...
 ```
 
 Client factories live in `internal/testutil/fixtures.go`. Env-var contract:
@@ -35,6 +29,4 @@ Client factories live in `internal/testutil/fixtures.go`. Env-var contract:
 - `DATASTORE_EMULATOR_HOST` — Datastore gRPC endpoint (native SDK var)
 - `LOGGING_EMULATOR_HOST` — Logging v2 gRPC endpoint (default `localhost:8081`)
 - `GCP_EMULATOR_PROJECT` — project id (default `test-project`)
-
-When the pending service is implemented, drop its `gcp_pending` build tag (and
-optionally move the file alongside the other `sdk*` modules).
+- `GCP_EMULATOR_ENDPOINT` — REST endpoint (default `http://localhost:8080`)

--- a/tests/integration/gcp/pending/kafka_test.go
+++ b/tests/integration/gcp/pending/kafka_test.go
@@ -1,5 +1,3 @@
-//go:build gcp_pending
-
 package tests
 
 import (
@@ -62,6 +60,39 @@ func kafkaGet(t *testing.T, url string) map[string]interface{} {
 	return result
 }
 
+// kafkaGetStatus performs a GET and returns the raw HTTP status code (used by
+// negative cases that expect a non-200).
+func kafkaGetStatus(t *testing.T, url string) int {
+	t.Helper()
+	resp, err := http.Get(url) //nolint:noctx
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// kafkaPostStatus performs a POST and returns the raw HTTP status code (used by
+// negative cases that expect a non-200).
+func kafkaPostStatus(t *testing.T, url string, body interface{}) int {
+	t.Helper()
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(data)) //nolint:noctx
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// kafkaDeleteStatus performs a DELETE and returns the raw HTTP status code.
+func kafkaDeleteStatus(t *testing.T, url string) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodDelete, url, nil) //nolint:noctx
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
 func kafkaDelete(url string) {
 	req, _ := http.NewRequest(http.MethodDelete, url, nil) //nolint:noctx
 	resp, err := http.DefaultClient.Do(req)
@@ -115,7 +146,18 @@ func TestManagedKafka(t *testing.T) {
 		name, _ := resp["name"].(string)
 		assert.Contains(t, name, clusterID)
 		assert.Equal(t, "ACTIVE", resp["state"])
-		assert.NotEmpty(t, resp["bootstrapAddress"])
+	})
+
+	t.Run("CreateDuplicateCluster", func(t *testing.T) {
+		status := kafkaPostStatus(t, base+"/clusters?clusterId="+clusterID, map[string]interface{}{
+			"capacityConfig": map[string]interface{}{"vcpuCount": 3, "memoryBytes": 3221225472},
+		})
+		assert.Equal(t, 409, status)
+	})
+
+	t.Run("DeleteMissingCluster", func(t *testing.T) {
+		status := kafkaDeleteStatus(t, base+"/clusters/does-not-exist")
+		assert.Equal(t, 404, status)
 	})
 
 	t.Run("ListClusters", func(t *testing.T) {
@@ -141,7 +183,9 @@ func TestManagedKafka(t *testing.T) {
 		})
 		assert.Equal(t, true, resp["done"])
 		response, _ := resp["response"].(map[string]interface{})
-		assert.Equal(t, float64(6), response["vcpuCount"])
+		capacity, _ := response["capacityConfig"].(map[string]interface{})
+		require.NotNil(t, capacity)
+		assert.Equal(t, float64(6), capacity["vcpuCount"])
 	})
 
 	t.Run("CreateTopic", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements **Managed Kafka** (`managedkafka.googleapis.com/v1`) — the last remaining `gcp_pending` GCP service — as a metadata-only management-plane CRUD, and flips its pending SDK test active.

## Scope

- **Provider** `internal/gcp/provider/managedkafka/` — `Cluster` (create/get/list/patch/delete), `Topic` (create/get/list/patch/delete), `ConsumerGroup` (list; get/update/delete → `Unimplemented`). Logical records only — no real broker.
- **Codec** `internal/gcp/adapter/managedkafka.go` — decodes `locations/{location}/clusters[/{id}][/topics[/{topicId}]|/consumerGroups[/{id}]]`; sub-resource derived from the path segment (not hardcoded), so `consumerGroups/{id}` routes to a distinct `Unimplemented` action rather than colliding with topics.
- **Store** `internal/gcp/store/managedkafka/` — memory + Postgres + Snapshotter, migration `026_managed_kafka.sql`. `DeleteCluster` cascades to its topics in both backends.
- **Wiring** — provider + codec + route detection + resource formatters registered in the GCP binary; `DetectService` gained a safe leading-slash normalization (handles clients that set a trailing-slash endpoint).
- **Test flip** — `tests/integration/gcp/pending/kafka_test.go` now runs active (no `gcp_pending` tag); the `pending/` module is fully active.

## Fidelity fixes (from the architect review)

- Removed non-standard wire fields the test (incorrectly) asserted: top-level `vcpuCount`/`memoryBytes` (now nested under `capacityConfig`), fabricated `bootstrapAddress`, and Topic `createTime`/`updateTime` — matching the proto.
- `rebalanceConfig`/`tlsConfig` now echoed verbatim when present.
- Postgres `DeleteCluster` deletes the cluster's topics (memory/postgres parity).
- Added a `gcp_persistence` Postgres store test (incl. a delete-cascades-topics case) and negative acceptance cases (duplicate-create → 409, delete-missing → 404).

## Deferred (documented)

- Cluster create/update/delete return a synchronous `{"done":true,"response":{…}}` operation envelope (no stored/pollable `Operation`, no `name`/`metadata`/`@type`) — a deliberate emulator simplification vs the proto's LRO.
- List pagination (`pageSize`/`pageToken`) ignored.
- No real broker; `bootstrapAddress` not exposed (matches proto).

## Verification

`go build` / `go vet` / `gofmt` clean; `go test -race ./internal/gcp/...` green; `TestManagedKafka` (13 subtests) + the full `pending/` module pass against a live emulator.
