### PR TITLE
fix(gcp/bigquery): Query never reports jobComplete without storing the job

### DIFF
--- a/internal/gcp/provider/bigquery/bigquery.go
+++ b/internal/gcp/provider/bigquery/bigquery.go
@@ -663,11 +663,16 @@ func (p *Provider) Query(ctx context.Context, nr *model.NormalizedRequest) (*mod
 	if loc := strValue(body, "location"); loc != "" {
 		jobCfg["jobReference"].(map[string]any)["location"] = loc
 	}
-	if data, err := json.Marshal(jobCfg); err == nil {
-		j := bqstore.Job{JobID: jobID, Config: data, CreateTime: now}
-		if err := p.store.CreateJob(ctx, projectOf(nr), j); err != nil {
-			return nil, mapErr(err)
-		}
+	data, err := json.Marshal(jobCfg)
+	if err != nil {
+		// Never report jobComplete=true for a job that wasn't actually stored —
+		// a subsequent GetJob/GetQueryResults for this jobId would otherwise
+		// 404 despite this call having just reported success.
+		return nil, model.NewProviderError("Internal", "failed to encode job configuration", 500)
+	}
+	j := bqstore.Job{JobID: jobID, Config: data, CreateTime: now}
+	if err := p.store.CreateJob(ctx, projectOf(nr), j); err != nil {
+		return nil, mapErr(err)
 	}
 	ref := map[string]any{"projectId": projectOf(nr), "jobId": jobID}
 	if loc := strValue(body, "location"); loc != "" {

--- a/internal/gcp/provider/bigquery/bigquery_test.go
+++ b/internal/gcp/provider/bigquery/bigquery_test.go
@@ -2,6 +2,7 @@ package bigquery
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	bqstore "jaiscloud/internal/gcp/store/bigquery"
@@ -278,6 +279,43 @@ func TestJobAndQueryEmptyResults(t *testing.T) {
 	}
 	if _, err := p.GetJob(ctx, newNR(map[string]any{"jobId": "j1"})); err == nil {
 		t.Fatalf("expected NotFound after job delete")
+	}
+}
+
+// TestQuery_RejectsUnencodableConfig verifies that Query never reports
+// jobComplete=true without actually storing the job. A json.Marshal failure
+// while building the stored job config used to be silently swallowed (the
+// store.CreateJob call sat inside "if data, err := json.Marshal(...); err ==
+// nil { ... }", so a marshal failure just skipped job creation entirely) while
+// the handler still returned a success response — a later GetJob/
+// GetQueryResults for that jobId would then 404 despite Query having reported
+// success. A real request body can't itself contain a value json.Marshal
+// rejects (it's always already-decoded JSON), so this forces the failure
+// directly with a math.Inf value to exercise the handler's own error path.
+func TestQuery_RejectsUnencodableConfig(t *testing.T) {
+	ctx := context.Background()
+	p := New(bqstore.NewMemoryStore())
+
+	_, err := p.Query(ctx, newNR(map[string]any{"body": map[string]any{
+		"query":        "SELECT * FROM t",
+		"useLegacySql": false,
+		"unencodable":  math.Inf(1),
+	}}))
+	if err == nil {
+		t.Fatal("expected an error for an unencodable job configuration, got nil")
+	}
+	perr, ok := err.(*model.ProviderError)
+	if !ok || perr.Code != "Internal" || perr.HTTPStatus != 500 {
+		t.Fatalf("expected Internal/500, got %v", err)
+	}
+
+	// No job should have been created.
+	list, err := p.ListJobs(ctx, newNR(map[string]any{}))
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	if jobs, _ := list.Data["jobs"].([]any); len(jobs) != 0 {
+		t.Fatalf("expected no jobs stored, got %d: %+v", len(jobs), jobs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Split out from the #39 review-fixes PR at the user's request, since this one is narrower in scope and unrelated to the rest of that PR's isolation/persistence/encryption findings.

`BigQuery.Query`'s `json.Marshal(jobCfg)` call was wrapped in `if data, err := json.Marshal(jobCfg); err == nil { ... }`, so a marshal failure silently skipped `store.CreateJob` entirely — while the handler still returned `jobComplete: true` with a `jobReference` for a job that was never stored. A subsequent `GetJob`/`GetQueryResults` for that `jobId` would then 404 despite `Query` having just reported success moments earlier.

The marshal input (`jobCfg`) is built entirely from already-JSON-decoded request-body values plus strings, so `json.Marshal` failing on it isn't realistically reachable via the wire codec path (a real HTTP request body can't itself contain a Go value `encoding/json` can't re-encode, like `+Inf`). Even so, a handler shouldn't silently downgrade a real internal failure into an apparent success — it should fail loudly, matching the `Internal`/500 convention already used elsewhere in this codebase (`internal/gcp/grpc/kms/service.go`, `internal/gcp/provider/kms/kms.go`, `internal/gcp/provider/iam/keys.go`) for this class of unexpected-serialization-failure.

## Change

`internal/gcp/provider/bigquery/bigquery.go`: `Query` now returns `model.NewProviderError("Internal", "failed to encode job configuration", 500)` on a marshal failure instead of silently proceeding to a success response with nothing stored.

## Test plan

- [x] Added `TestQuery_RejectsUnencodableConfig`, which forces the marshal failure directly with a `math.Inf` value embedded in the query body (since no real request body can produce this) to exercise the handler's own error path, and confirms no job is left stored afterward.
- [x] `go build ./internal/gcp/...` — clean
- [x] `go test ./internal/gcp/provider/bigquery/...` — all pass, including the existing `TestJobAndQueryEmptyResults` happy-path Query test (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)