### PR TITLE
fix(gcp/firestore): close the lost-update race on concurrent document writes

### DIFF
--- a/internal/gcp/provider/firestore/race_test.go
+++ b/internal/gcp/provider/firestore/race_test.go
@@ -1,0 +1,167 @@
+package firestore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	firestorestore "jaiscloud/internal/gcp/store/firestore"
+)
+
+// conflictInjectingStore wraps a real FirestoreStore and, on the Nth call to
+// GetDocument for a chosen document name, performs an out-of-band conflicting
+// write (via the wrapped store, bypassing the caller entirely) before
+// returning the caller its (now-stale) read. This deterministically
+// simulates the race window between PatchDocument/buildUpdate's base read and
+// its eventual Commit — the same window a real concurrent second writer would
+// exploit — without relying on real goroutine timing.
+type conflictInjectingStore struct {
+	firestorestore.FirestoreStore
+	targetName string
+	triggerNth int // inject before the Nth GetDocument(targetName) call
+	getCalls   int
+	inject     func()
+	injected   bool
+}
+
+func (s *conflictInjectingStore) GetDocument(ctx context.Context, name string) (firestorestore.Document, error) {
+	// Capture the result BEFORE injecting the conflicting write, so the
+	// caller gets the stale (pre-conflict) snapshot — exactly what a real
+	// concurrent reader would have seen — while the store's live state moves
+	// on underneath it.
+	doc, err := s.FirestoreStore.GetDocument(ctx, name)
+	if name == s.targetName {
+		s.getCalls++
+		if s.getCalls == s.triggerNth && !s.injected {
+			s.injected = true
+			s.inject()
+		}
+	}
+	return doc, err
+}
+
+// TestPatchDocument_ConcurrentWriteDetected verifies the lost-update race fix:
+// a write that lands between PatchDocument's base read and its Commit call is
+// detected (ABORTED) instead of silently overwritten. Before the fix,
+// PatchDocument did GetDocument -> compute merge -> UpdateDocument as two
+// separate, unprotected store calls; a conflicting write in between was
+// clobbered with no error.
+func TestPatchDocument_ConcurrentWriteDetected(t *testing.T) {
+	ctx := context.Background()
+	name := "projects/proj/databases/(default)/documents/cities/SF"
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Second)
+	real := firestorestore.NewMemoryStore()
+	if err := real.CreateDocument(ctx, firestorestore.Document{
+		Name:       name,
+		Fields:     map[string]*firestorestore.Value{"population": intField(1)},
+		CreateTime: t0,
+		UpdateTime: t0,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	wrapped := &conflictInjectingStore{FirestoreStore: real, targetName: name, triggerNth: 1}
+	p := New(wrapped, nil)
+
+	// "Writer B" races in and updates the document AFTER PatchDocument's base
+	// read but BEFORE its Commit call. Explicit, distinct UpdateTime values
+	// (rather than relying on real-clock timestamping, which two calls this
+	// close together could collide on) make the conflict unambiguous.
+	wrapped.inject = func() {
+		if err := real.UpdateDocument(ctx, firestorestore.Document{
+			Name:       name,
+			Fields:     map[string]*firestorestore.Value{"population": intField(2)},
+			CreateTime: t0,
+			UpdateTime: t1,
+		}); err != nil {
+			t.Fatalf("injected concurrent write: %v", err)
+		}
+	}
+
+	// "Writer A": patches a DIFFERENT field. Before the fix this would
+	// silently overwrite writer B's population=2 with population=1 (the
+	// stale base it read), losing the concurrent update with no error.
+	_, err := p.PatchDocument(ctx, "proj", "(default)", "cities/SF",
+		map[string]*firestorestore.Value{"name": firestorestore.StringVal("San Francisco")},
+		[]string{"name"}, nil)
+	if err == nil {
+		t.Fatal("expected the concurrent write to be detected (ABORTED), got nil error")
+	}
+	assertProviderError(t, err, 409, "ABORTED")
+
+	// Writer B's update must survive untouched — no lost update.
+	got, err := real.GetDocument(ctx, name)
+	if err != nil {
+		t.Fatalf("get after conflict: %v", err)
+	}
+	if v, ok := got.Fields["population"].AsInt64(); !ok || v != 2 {
+		t.Fatalf("population = %v, want 2 (writer B's update must not be lost)", got.Fields["population"])
+	}
+	if _, ok := got.Fields["name"]; ok {
+		t.Fatalf("writer A's write must not have applied, got fields %+v", got.Fields)
+	}
+}
+
+// TestCommit_ConcurrentTransformDetected is the same scenario via the
+// Commit/BatchWrite path (buildUpdate/buildTransform), which non-transactional
+// documents:commit and batchWrite requests use.
+func TestCommit_ConcurrentTransformDetected(t *testing.T) {
+	ctx := context.Background()
+	name := "projects/proj/databases/(default)/documents/cities/SF"
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Second)
+	real := firestorestore.NewMemoryStore()
+	if err := real.CreateDocument(ctx, firestorestore.Document{
+		Name:       name,
+		Fields:     map[string]*firestorestore.Value{"n": intField(10)},
+		CreateTime: t0,
+		UpdateTime: t0,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	wrapped := &conflictInjectingStore{FirestoreStore: real, targetName: name, triggerNth: 1}
+	p := New(wrapped, nil)
+	wrapped.inject = func() {
+		if err := real.UpdateDocument(ctx, firestorestore.Document{
+			Name:       name,
+			Fields:     map[string]*firestorestore.Value{"n": intField(20)},
+			CreateTime: t0,
+			UpdateTime: t1,
+		}); err != nil {
+			t.Fatalf("injected concurrent write: %v", err)
+		}
+	}
+
+	// A non-transactional Commit with an increment transform: the merge base
+	// (n=10) is read, then writer B races in and changes n to 20, then this
+	// commit tries to apply increment(5) on top of the STALE base (would
+	// silently produce n=15, discarding writer B's n=20 entirely).
+	nr := testNR()
+	nr.Params["body"] = map[string]any{
+		"writes": []any{
+			map[string]any{
+				"transform": map[string]any{
+					"document": name,
+					"fieldTransforms": []any{
+						map[string]any{"fieldPath": "n", "increment": map[string]any{"integerValue": "5"}},
+					},
+				},
+			},
+		},
+	}
+	_, err := p.Commit(ctx, nr)
+	if err == nil {
+		t.Fatal("expected the concurrent write to be detected (ABORTED), got nil error")
+	}
+	assertProviderError(t, err, 409, "ABORTED")
+
+	got, err := real.GetDocument(ctx, name)
+	if err != nil {
+		t.Fatalf("get after conflict: %v", err)
+	}
+	if v, ok := got.Fields["n"].AsInt64(); !ok || v != 20 {
+		t.Fatalf("n = %v, want 20 (writer B's update must not be lost, and the transform must not have applied to a stale base)", got.Fields["n"])
+	}
+}

--- a/internal/gcp/provider/firestore/service.go
+++ b/internal/gcp/provider/firestore/service.go
@@ -276,14 +276,20 @@ func (s *Service) PatchDocument(ctx context.Context, project, database, path str
 		CreateTime: createTime,
 		UpdateTime: now,
 	}
-	if exists {
-		if err := s.store.UpdateDocument(ctx, doc); err != nil {
-			return firestorestore.Document{}, mapStoreError(err)
-		}
-	} else {
-		if err := s.store.CreateDocument(ctx, doc); err != nil {
-			return firestorestore.Document{}, mapStoreError(err)
-		}
+	// Route through store.Commit (the same atomic check-and-apply primitive
+	// transactions use) instead of a separate Get-then-Update/Create, so a
+	// write that landed between our read above and this call is detected
+	// instead of silently overwritten: the implicit ReadRef re-validates
+	// (exists, updateTime) — Firestore's own optimistic-concurrency token,
+	// the ETag/If-Match equivalent — against the live document under the
+	// store's lock, atomically with applying the write. The lock is only
+	// held for that fast in-memory check-and-apply, not across this
+	// function's merge computation.
+	implicitRead := firestorestore.ReadRef{Name: name, Exists: exists, UpdateTime: existing.UpdateTime}
+	if err := s.store.Commit(ctx, []firestorestore.ReadRef{implicitRead}, []firestorestore.Write{
+		{Name: name, Document: &doc, Precondition: pre},
+	}); err != nil {
+		return firestorestore.Document{}, mapCommitError(err)
 	}
 	d := doc
 	s.publishChange(ChangeEvent{Name: d.Name, Doc: &d})
@@ -468,11 +474,11 @@ func (s *Service) Commit(ctx context.Context, transaction []byte, writes []*writ
 	}
 
 	commitTime := clock.Now()
-	ws, results, err := s.buildWrites(ctx, writes, commitTime)
+	ws, results, implicitReads, err := s.buildWrites(ctx, writes, commitTime)
 	if err != nil {
 		return time.Time{}, nil, err
 	}
-	reads := s.readSetFor(transaction)
+	reads := append(s.readSetFor(transaction), implicitReads...)
 	if err := s.store.Commit(ctx, reads, ws); err != nil {
 		return time.Time{}, nil, mapCommitError(err)
 	}
@@ -498,13 +504,13 @@ func (s *Service) BatchWrite(ctx context.Context, writes []*writeWire) ([]any, [
 	statuses := make([]any, 0, len(writes))
 	writeResults := make([]any, 0, len(writes))
 	for _, w := range writes {
-		ws, results, err := s.buildWrites(ctx, []*writeWire{w}, now)
+		ws, results, implicitReads, err := s.buildWrites(ctx, []*writeWire{w}, now)
 		if err != nil {
 			statuses = append(statuses, statusWire(3, errMsg(err)))
 			writeResults = append(writeResults, map[string]any{})
 			continue
 		}
-		if err := s.store.Commit(ctx, nil, ws); err != nil {
+		if err := s.store.Commit(ctx, implicitReads, ws); err != nil {
 			statuses = append(statuses, statusWireForError(err))
 			writeResults = append(writeResults, map[string]any{})
 			continue
@@ -550,14 +556,21 @@ func (s *Service) BatchGet(ctx context.Context, documents []string, transaction 
 // ─── write resolution ────────────────────────────────────────────────────────
 
 // buildWrites translates wire writes into store writes + write-results,
-// resolving masks and transforms against the current document state.
-func (s *Service) buildWrites(ctx context.Context, wire []*writeWire, now time.Time) ([]firestorestore.Write, []map[string]any, error) {
+// resolving masks and transforms against the current document state. The
+// returned reads are the implicit ReadRefs buildUpdate/buildTransform used as
+// their merge base — the caller must fold these into the read-set passed to
+// store.Commit (see buildUpdate's doc comment). Delete writes need no
+// implicit ReadRef: an unconditional delete is idempotent by design (real
+// Firestore's DeleteDocument doesn't error without an explicit precondition),
+// so there's no "lost update" for a concurrent delete to cause.
+func (s *Service) buildWrites(ctx context.Context, wire []*writeWire, now time.Time) ([]firestorestore.Write, []map[string]any, []firestorestore.ReadRef, error) {
 	writes := make([]firestorestore.Write, 0, len(wire))
 	results := make([]map[string]any, 0, len(wire))
+	reads := make([]firestorestore.ReadRef, 0, len(wire))
 	for _, w := range wire {
 		pre, err := toPrecondition(w.CurrentDocument)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		switch {
@@ -566,46 +579,53 @@ func (s *Service) buildWrites(ctx context.Context, wire []*writeWire, now time.T
 			results = append(results, map[string]any{}) // no updateTime after delete
 
 		case w.Transform != nil:
-			doc, res, err := s.buildTransform(ctx, w.Transform, pre, now)
+			doc, res, readRef, err := s.buildTransform(ctx, w.Transform, pre, now)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			writes = append(writes, firestorestore.Write{Name: doc.Name, Document: &doc, Precondition: pre})
 			results = append(results, res)
+			reads = append(reads, readRef)
 
 		case w.Update != nil:
-			doc, res, err := s.buildUpdate(ctx, w.Update, w.UpdateMask, w.UpdateTransforms, pre, now)
+			doc, res, readRef, err := s.buildUpdate(ctx, w.Update, w.UpdateMask, w.UpdateTransforms, pre, now)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			writes = append(writes, firestorestore.Write{Name: doc.Name, Document: &doc, Precondition: pre})
 			results = append(results, res)
+			reads = append(reads, readRef)
 
 		default:
-			return nil, nil, model.NewProviderError("InvalidArgument", "write must specify update, delete, or transform", 400)
+			return nil, nil, nil, model.NewProviderError("InvalidArgument", "write must specify update, delete, or transform", 400)
 		}
 	}
-	return writes, results, nil
+	return writes, results, reads, nil
 }
 
 // buildUpdate resolves an update (with optional mask + transforms) against the
-// current document.
-func (s *Service) buildUpdate(ctx context.Context, dw *documentWire, mask *documentMaskWire, transforms []fieldTransformWire, pre *firestorestore.Precondition, now time.Time) (firestorestore.Document, map[string]any, error) {
+// current document. The returned ReadRef is the document state this merge was
+// computed from — the caller must fold it into the read-set passed to
+// store.Commit so a write that lands between this read and the eventual
+// Commit call is detected (ErrAborted) instead of silently overwritten by the
+// merge this function computed from a now-stale base.
+func (s *Service) buildUpdate(ctx context.Context, dw *documentWire, mask *documentMaskWire, transforms []fieldTransformWire, pre *firestorestore.Precondition, now time.Time) (firestorestore.Document, map[string]any, firestorestore.ReadRef, error) {
 	if dw.Name == "" {
-		return firestorestore.Document{}, nil, model.NewProviderError("InvalidArgument", "update document name is required", 400)
+		return firestorestore.Document{}, nil, firestorestore.ReadRef{}, model.NewProviderError("InvalidArgument", "update document name is required", 400)
 	}
 	if err := validateFields(dw.Fields); err != nil {
-		return firestorestore.Document{}, nil, err
+		return firestorestore.Document{}, nil, firestorestore.ReadRef{}, err
 	}
 	if err := checkSize(dw.Fields); err != nil {
-		return firestorestore.Document{}, nil, err
+		return firestorestore.Document{}, nil, firestorestore.ReadRef{}, err
 	}
 
 	existing, err := s.store.GetDocument(ctx, dw.Name)
 	exists := err == nil
 	if err != nil && !errors.Is(err, firestorestore.ErrDocumentNotFound) {
-		return firestorestore.Document{}, nil, err
+		return firestorestore.Document{}, nil, firestorestore.ReadRef{}, err
 	}
+	readRef := firestorestore.ReadRef{Name: dw.Name, Exists: exists, UpdateTime: existing.UpdateTime}
 
 	base := map[string]*firestorestore.Value{}
 	if exists {
@@ -635,12 +655,12 @@ func (s *Service) buildUpdate(ctx context.Context, dw *documentWire, mask *docum
 		var res []*firestorestore.Value
 		merged, res, err = applyFieldTransforms(merged, transforms, now)
 		if err != nil {
-			return firestorestore.Document{}, nil, err
+			return firestorestore.Document{}, nil, firestorestore.ReadRef{}, err
 		}
 		transformResults = res
 	}
 	if err := checkSize(merged); err != nil {
-		return firestorestore.Document{}, nil, err
+		return firestorestore.Document{}, nil, firestorestore.ReadRef{}, err
 	}
 
 	createTime := now
@@ -656,19 +676,23 @@ func (s *Service) buildUpdate(ctx context.Context, dw *documentWire, mask *docum
 		}
 		res["transformResults"] = tr
 	}
-	return doc, res, nil
+	return doc, res, readRef, nil
 }
 
 // buildTransform resolves a document transform against the current document.
-func (s *Service) buildTransform(ctx context.Context, tw *documentTransformWire, pre *firestorestore.Precondition, now time.Time) (firestorestore.Document, map[string]any, error) {
+// The returned ReadRef is the document state the transform was computed from
+// — see buildUpdate's doc comment for why the caller must fold it into the
+// read-set passed to store.Commit.
+func (s *Service) buildTransform(ctx context.Context, tw *documentTransformWire, pre *firestorestore.Precondition, now time.Time) (firestorestore.Document, map[string]any, firestorestore.ReadRef, error) {
 	if tw.Document == "" {
-		return firestorestore.Document{}, nil, model.NewProviderError("InvalidArgument", "transform document name is required", 400)
+		return firestorestore.Document{}, nil, firestorestore.ReadRef{}, model.NewProviderError("InvalidArgument", "transform document name is required", 400)
 	}
 	existing, err := s.store.GetDocument(ctx, tw.Document)
 	exists := err == nil
 	if err != nil && !errors.Is(err, firestorestore.ErrDocumentNotFound) {
-		return firestorestore.Document{}, nil, err
+		return firestorestore.Document{}, nil, firestorestore.ReadRef{}, err
 	}
+	readRef := firestorestore.ReadRef{Name: tw.Document, Exists: exists, UpdateTime: existing.UpdateTime}
 
 	base := map[string]*firestorestore.Value{}
 	createTime := now
@@ -678,10 +702,10 @@ func (s *Service) buildTransform(ctx context.Context, tw *documentTransformWire,
 	}
 	fields, transformResults, err := applyFieldTransforms(base, tw.FieldTransforms, now)
 	if err != nil {
-		return firestorestore.Document{}, nil, err
+		return firestorestore.Document{}, nil, firestorestore.ReadRef{}, err
 	}
 	if err := checkSize(fields); err != nil {
-		return firestorestore.Document{}, nil, err
+		return firestorestore.Document{}, nil, firestorestore.ReadRef{}, err
 	}
 
 	doc := firestorestore.Document{Name: tw.Document, Fields: fields, CreateTime: createTime, UpdateTime: now}
@@ -689,7 +713,7 @@ func (s *Service) buildTransform(ctx context.Context, tw *documentTransformWire,
 	for _, r := range transformResults {
 		tr = append(tr, valueWire(r))
 	}
-	return doc, map[string]any{"updateTime": now.Format(time.RFC3339Nano), "transformResults": tr}, nil
+	return doc, map[string]any{"updateTime": now.Format(time.RFC3339Nano), "transformResults": tr}, readRef, nil
 }
 
 // ─── index management ────────────────────────────────────────────────────────

--- a/internal/gcp/provider/firestore/transform_update_test.go
+++ b/internal/gcp/provider/firestore/transform_update_test.go
@@ -35,7 +35,7 @@ func TestBuildUpdateThreeMaskStates(t *testing.T) {
 	seedTransformDoc(t, p, name)
 
 	// 1. nil mask → replace-all: unrelated field keep is dropped.
-	doc, _, err := p.buildUpdate(ctx, &documentWire{
+	doc, _, _, err := p.buildUpdate(ctx, &documentWire{
 		Name:   name,
 		Fields: map[string]*firestorestore.Value{"n": firestorestore.IntVal(1)},
 	}, nil, nil, nil, now)
@@ -47,7 +47,7 @@ func TestBuildUpdateThreeMaskStates(t *testing.T) {
 	}
 
 	// 2. non-empty mask → patch: only n is replaced, keep preserved.
-	doc, _, err = p.buildUpdate(ctx, &documentWire{
+	doc, _, _, err = p.buildUpdate(ctx, &documentWire{
 		Name:   name,
 		Fields: map[string]*firestorestore.Value{"n": firestorestore.IntVal(2)},
 	}, &documentMaskWire{FieldPaths: []string{"n"}}, nil, nil, now)
@@ -62,7 +62,7 @@ func TestBuildUpdateThreeMaskStates(t *testing.T) {
 	}
 
 	// 3. empty (present) mask + transform → transforms only on existing base.
-	doc, _, err = p.buildUpdate(ctx, &documentWire{Name: name},
+	doc, _, _, err = p.buildUpdate(ctx, &documentWire{Name: name},
 		&documentMaskWire{}, []fieldTransformWire{{FieldPath: "n", Increment: firestorestore.IntVal(5)}}, nil, now)
 	if err != nil {
 		t.Fatalf("transform-only buildUpdate: %v", err)


### PR DESCRIPTION
## Summary

One of two deferred findings from the earlier architect/senior-dev review (#39), split into its own PR since it's an unrelated, self-contained concern (the other, datastore key encoding, is a separate PR).

**Mechanism:** `PatchDocument` (`documents.patch`) and `buildUpdate`/`buildTransform` (used by `Commit`/`BatchWrite` for update-with-mask and field-transform writes) each read the current document, computed a merge/transform in application code, then wrote the result back as a separate, later store call. A write that landed in between was silently overwritten — neither the read nor the write was protected against a concurrent writer doing the same thing. This specifically broke `increment`'s atomicity guarantee: two concurrent increments on the same field could result in only one of them taking effect, with no error.

## Fix

Reuses the store's existing optimistic-concurrency primitive — `store.Commit`'s read-set/`ReadRef` validation, already proven correct by the `BeginTransaction`/`Commit` transaction path — rather than inventing a new locking scheme:

- `PatchDocument` now routes its write through `store.Commit` with an implicit `ReadRef` for the document state it read, instead of a separate `CreateDocument`/`UpdateDocument` call.
- `buildUpdate`/`buildTransform` now return the `ReadRef` for the document state their merge/transform was computed from; `buildWrites` collects these; `Commit` folds them into the transaction's read-set, and `BatchWrite` passes them directly (it has no transaction of its own).

A conflicting write between the read and the eventual `Commit` now surfaces as `409 ABORTED` — a retryable error, matching real Firestore's own optimistic-concurrency contract — instead of silently losing data.

**On lock duration** (this came up during review): the store's lock is only held for the fast, in-memory initial read, and separately for the fast, in-memory check-and-apply at commit time — never across the merge computation in between. This is optimistic concurrency control (check a version token, reject on conflict), the same shape as DynamoDB/S3's conditional-write pattern already used on the AWS side of this codebase and conceptually identical to an ETag/If-Match check — not a pessimistic lock held across an entire request.

**What real GCP Firestore actually does**, for context: transactional writes use exactly this optimistic-concurrency-with-retry model (a conflicting write aborts the transaction). Non-transactional single-document writes are actually atomic server-side in real Firestore (no separate client-visible read step at all) — matching that exactly would mean moving the merge computation inside the store's lock, a larger change. Converting the silent lost-update into a detected, retryable conflict (this PR) gets the correctness property that matters (no silent data loss) while reusing already-tested code, which is the tradeoff explicitly discussed and agreed on before implementing.

Delete writes intentionally get no implicit `ReadRef`: an unconditional delete is idempotent by design (real Firestore's `DeleteDocument` doesn't error without an explicit precondition), so there's no lost-update concern for a concurrent delete to cause.

## Test plan

- [x] Added `race_test.go`: two deterministic regression tests using a store wrapper that injects a conflicting write between the base read and the commit — exercising the exact race window without relying on real goroutine timing — covering both the `PatchDocument` path and the `Commit`/transform path. Both confirm the conflict is detected (`409 ABORTED`) and the concurrent write is not lost.
- [x] Ran the new tests 10x with `-race`: stable, no flakiness.
- [x] Full `internal/gcp/provider/firestore` and `internal/gcp/grpc/firestore` suites pass with `-race`, no regressions.
- [x] `go build ./...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)