### PR TITLE
fix(gcp/datastore): length-prefix the kind in canonical key encoding

### DIFF
--- a/internal/gcp/store/datastore/memory_test.go
+++ b/internal/gcp/store/datastore/memory_test.go
@@ -175,13 +175,13 @@ func TestMemoryStoreAdvanceIDs(t *testing.T) {
 }
 
 func TestKeyHelpers(t *testing.T) {
-	if KeyOfID("Task", 42) != "Task/id:42" {
+	if KeyOfID("Task", 42) != "4:Task/id:42" {
 		t.Fatalf("KeyOfID = %q", KeyOfID("Task", 42))
 	}
-	if KeyOfName("Task", "foo") != "Task/name:foo" {
+	if KeyOfName("Task", "foo") != "4:Task/name:foo" {
 		t.Fatalf("KeyOfName = %q", KeyOfName("Task", "foo"))
 	}
-	kind, idOrName, ok := SplitKey("Task/name:foo")
+	kind, idOrName, ok := SplitKey("4:Task/name:foo")
 	if !ok || kind != "Task" || idOrName != "name:foo" {
 		t.Fatalf("SplitKey = %q %q %v", kind, idOrName, ok)
 	}
@@ -192,5 +192,50 @@ func TestKeyHelpers(t *testing.T) {
 	id, name, isID = ParseIDOrName("name:foo")
 	if isID || id != 0 || name != "foo" {
 		t.Fatalf("ParseIDOrName name = %d %q %v", id, name, isID)
+	}
+}
+
+// TestKeyHelpers_KindContainingSlash verifies the bug the length-prefixed
+// encoding fixes: a kind containing "/" used to corrupt SplitKey's parse
+// (it split on the first "/", which could land inside the kind instead of
+// at the kind/id-or-name boundary). Length-prefixing the kind makes the
+// boundary explicit regardless of what characters the kind contains.
+func TestKeyHelpers_KindContainingSlash(t *testing.T) {
+	key := KeyOfID("my/kind", 7)
+	kind, idOrName, ok := SplitKey(key)
+	if !ok || kind != "my/kind" || idOrName != "id:7" {
+		t.Fatalf("SplitKey(%q) = %q %q %v, want \"my/kind\" \"id:7\" true", key, kind, idOrName, ok)
+	}
+	id, _, isID := ParseIDOrName(idOrName)
+	if !isID || id != 7 {
+		t.Fatalf("ParseIDOrName(%q) = %d _ %v", idOrName, id, isID)
+	}
+
+	// A name containing both "/" and ":" must also still round-trip.
+	key = KeyOfName("k/i:nd", "a/b:c")
+	kind, idOrName, ok = SplitKey(key)
+	if !ok || kind != "k/i:nd" || idOrName != "name:a/b:c" {
+		t.Fatalf("SplitKey(%q) = %q %q %v", key, kind, idOrName, ok)
+	}
+	_, name, isID := ParseIDOrName(idOrName)
+	if isID || name != "a/b:c" {
+		t.Fatalf("ParseIDOrName(%q) = _ %q %v", idOrName, name, isID)
+	}
+}
+
+func TestSplitKey_Malformed(t *testing.T) {
+	for _, bad := range []string{
+		"",
+		"no-length-prefix",
+		"abc:Task/id:1", // non-numeric length
+		"-1:Task/id:1",  // negative length
+		"100:Task/id:1", // length longer than remaining string
+		"4:Task|id:1",   // missing "/" at the length boundary
+		"0:/id:1",       // empty kind
+		"4:Task/",       // empty id-or-name
+	} {
+		if _, _, ok := SplitKey(bad); ok {
+			t.Errorf("SplitKey(%q): expected ok=false", bad)
+		}
 	}
 }

--- a/internal/gcp/store/datastore/store.go
+++ b/internal/gcp/store/datastore/store.go
@@ -85,21 +85,50 @@ type Store interface {
 	Reset(ctx context.Context)
 }
 
-// KeyOfID returns the canonical key string for a numeric-ID key: "kind/id:<id>".
+// KeyOfID returns the canonical key string for a numeric-ID key:
+// "<len(kind)>:<kind>/id:<id>". The kind is length-prefixed — rather than
+// relying on "/" as an unambiguous separator — so a kind containing "/" (or
+// any other character) still round-trips correctly through SplitKey. This
+// mirrors the structural principle real Datastore/Firestore key encoding
+// uses: a Key is a protobuf message with explicit length-delimited fields,
+// never a delimiter-joined string, so a kind or name can never corrupt the
+// parse regardless of its contents. See
+// https://cloud.google.com/php/docs/reference/cloud-datastore/latest/V1.Key
+// (Key.PathElement: kind + (id xor name), not a joined string).
 func KeyOfID(kind string, id int64) string {
-	return kind + "/" + "id:" + strconv.FormatInt(id, 10)
+	return encodeKind(kind) + "id:" + strconv.FormatInt(id, 10)
 }
 
-// KeyOfName returns the canonical key string for a name key: "kind/name:<name>".
+// KeyOfName returns the canonical key string for a name key:
+// "<len(kind)>:<kind>/name:<name>". See KeyOfID for why kind is
+// length-prefixed. name is not: ParseIDOrName splits it off by the fixed
+// "id:"/"name:" tag prefix (a single Cut on the first ":"), so name may
+// itself contain "/" or ":" without ambiguity.
 func KeyOfName(kind, name string) string {
-	return kind + "/" + "name:" + name
+	return encodeKind(kind) + "name:" + name
 }
 
-// SplitKey parses "kind/id-or-name" into its kind and tagged id-or-name. ok is
-// false when the key is malformed.
+func encodeKind(kind string) string {
+	return strconv.Itoa(len(kind)) + ":" + kind + "/"
+}
+
+// SplitKey parses "<len(kind)>:<kind>/id-or-name" into its kind and tagged
+// id-or-name. ok is false when the key is malformed.
 func SplitKey(key string) (kind, idOrName string, ok bool) {
-	kind, idOrName, ok = strings.Cut(key, "/")
-	if !ok || kind == "" || idOrName == "" {
+	lenStr, rest, found := strings.Cut(key, ":")
+	if !found {
+		return "", "", false
+	}
+	n, err := strconv.Atoi(lenStr)
+	if err != nil || n < 0 || n > len(rest) {
+		return "", "", false
+	}
+	kind = rest[:n]
+	if kind == "" || len(rest) == n || rest[n] != '/' {
+		return "", "", false
+	}
+	idOrName = rest[n+1:]
+	if idOrName == "" {
 		return "", "", false
 	}
 	return kind, idOrName, true


### PR DESCRIPTION
## Summary

The other deferred finding from the earlier review (#39), split into its own PR (the firestore concurrency fix is #41).

**Mechanism:** `KeyOfID`/`KeyOfName` built the internal canonical entity key as a naive delimiter-joined string: `kind + "/" + "id:"|"name:" + idOrName`. `SplitKey` parsed it back by cutting on the *first* `/`. A kind containing `/` (e.g. `"my/kind"`) corrupted the split — `KeyOfID("my/kind", 5)` produced `"my/kind/id:5"`, which `SplitKey` misparsed as `kind="my"`, `idOrName="kind/id:5"`, silently breaking the key round-trip.

Real GCP client libraries don't produce kinds containing `/` in practice, so the practical trigger was always low — but it's a real gap, not a hypothetical one.

## How real GCP avoids this class of bug

Researched it rather than guessing: a Datastore/Firestore `Key` is a structured protobuf message (`partition_id` + a path of `PathElement{kind, id xor name}`), never a delimiter-joined string. Protobuf's length-delimited field encoding makes the kind/id-or-name boundary unambiguous regardless of what characters the kind contains — there's no `/`-scanning involved in the real format at all.

([Source](https://cloud.google.com/php/docs/reference/cloud-datastore/latest/V1.Key))

## Fix

Mirrors that structural principle for our internal string-based key (implementing actual protobuf encoding would be unnecessary complexity for what's purely an internal map/DB-column key, never a wire format): `kind` is now length-prefixed (`"<len>:<kind>/..."`), so `SplitKey` reads exactly that many bytes as the kind rather than scanning for a delimiter that could appear inside it.

`name` was already safe and is unchanged — `ParseIDOrName`'s tag-prefix cut (`strings.Cut(s, ":")` against the fixed `"id:"`/`"name:"` prefix) only ever splits once, so a name containing `/` or `:` already round-tripped correctly.

No other code depends on the key string's format directly — `ListKind` filters by each `Entity`'s separate `Kind` field (and, in Postgres, a dedicated `kind` column), not by parsing the composite key — so the change is fully contained to `KeyOfID`/`KeyOfName`/`SplitKey`.

## Test plan

- [x] Updated the existing format-specific test (`TestKeyHelpers`) to the new encoding.
- [x] Added `TestKeyHelpers_KindContainingSlash` — proves the actual bug is fixed: a kind containing `/` (and a name containing both `/` and `:`) now round-trips correctly.
- [x] Added `TestSplitKey_Malformed` — rejects non-numeric/negative/overlong length prefixes, a missing `/` at the computed boundary, and empty kind/id-or-name.
- [x] `go build ./internal/gcp/...` — clean.
- [x] `go test ./internal/gcp/store/datastore/... ./internal/gcp/grpc/datastore/...` — all pass, including every existing test (confirms the format change doesn't break anything else that touches keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)