### PR TITLE
feat(gcp): shared atomic read-modify-write primitive for store Update/Patch

### DIFF
--- a/internal/gcp/storeutil/atomic.go
+++ b/internal/gcp/storeutil/atomic.go
@@ -1,0 +1,54 @@
+// Package storeutil provides the shared atomic read-modify-write primitive
+// GCP memory stores use for their Update/Patch-style methods.
+//
+// An adversarial review across the GCP providers (storage, secretmanager,
+// datastore, functions, workflows, dataproc, bigquery, managedkafka,
+// monitoring, and the shared IAM-policy helper) found the same bug shape
+// repeated in nearly every Update/Patch handler: Get() the current value,
+// merge request fields into it in Go, then a SEPARATE, later Update() call
+// writes the result — with no atomicity between the two. A second writer
+// racing in between is silently overwritten (a lost update), and in at
+// least one case (Secret Manager) this corrupted an internally-managed
+// counter, not just a client-visible field. This mirrors the Firestore
+// lost-update race fixed earlier by routing PatchDocument/buildUpdate
+// through store.Commit's atomic read-set validation — this package
+// generalizes that fix into one reusable primitive instead of hand-rolling
+// it per store.
+//
+// AtomicUpdate is for in-memory stores (sync.RWMutex-guarded maps). Postgres
+// stores need the equivalent guarantee too, but SQL specifics (table/column
+// names) don't generalize into shared Go code the same way; the convention
+// there is a Serializable-isolation transaction with `SELECT ... FOR UPDATE`
+// on every row the mutation reads or writes, mirroring
+// internal/gcp/store/firestore/postgres.go's Commit — see that file for the
+// reference shape when adding this to a Postgres store.
+package storeutil
+
+import "sync"
+
+// AtomicUpdate holds mu for the entire read-mutate-write sequence: get()
+// reads the current value (and whether it exists), mutate computes the new
+// value from it (or returns an error to abort without writing — a
+// validation failure, a not-found condition, or a client-supplied
+// precondition mismatch), and set() persists the result. Holding one lock
+// across all three closes the race the Get-then-separate-Update pattern
+// leaves open: no other Get/Create/Update/Delete guarded by the same mu can
+// be observed or applied in the middle of this sequence.
+//
+// Keep get, mutate, and set fast and allocation-light — no I/O, no
+// acquiring any other lock — since mu is held for their combined duration.
+// On a mutate error, set is never called and the zero value of T is
+// returned alongside the error.
+func AtomicUpdate[T any](mu *sync.RWMutex, get func() (T, bool), mutate func(current T, exists bool) (T, error), set func(T)) (T, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	current, exists := get()
+	next, err := mutate(current, exists)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	set(next)
+	return next, nil
+}

--- a/internal/gcp/storeutil/atomic_test.go
+++ b/internal/gcp/storeutil/atomic_test.go
@@ -1,0 +1,109 @@
+package storeutil
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestAtomicUpdate_CreatesWhenAbsent(t *testing.T) {
+	var mu sync.RWMutex
+	store := map[string]int{}
+
+	got, err := AtomicUpdate(&mu,
+		func() (int, bool) { v, ok := store["k"]; return v, ok },
+		func(current int, exists bool) (int, error) {
+			if exists {
+				t.Fatalf("expected exists=false for a fresh key")
+			}
+			return 1, nil
+		},
+		func(v int) { store["k"] = v },
+	)
+	if err != nil {
+		t.Fatalf("AtomicUpdate: %v", err)
+	}
+	if got != 1 || store["k"] != 1 {
+		t.Fatalf("got=%d store=%d, want 1/1", got, store["k"])
+	}
+}
+
+func TestAtomicUpdate_MergesExisting(t *testing.T) {
+	var mu sync.RWMutex
+	store := map[string]int{"k": 10}
+
+	got, err := AtomicUpdate(&mu,
+		func() (int, bool) { v, ok := store["k"]; return v, ok },
+		func(current int, exists bool) (int, error) {
+			if !exists || current != 10 {
+				t.Fatalf("expected exists=true current=10, got exists=%v current=%d", exists, current)
+			}
+			return current + 5, nil
+		},
+		func(v int) { store["k"] = v },
+	)
+	if err != nil {
+		t.Fatalf("AtomicUpdate: %v", err)
+	}
+	if got != 15 || store["k"] != 15 {
+		t.Fatalf("got=%d store=%d, want 15/15", got, store["k"])
+	}
+}
+
+func TestAtomicUpdate_MutateErrorDoesNotWrite(t *testing.T) {
+	var mu sync.RWMutex
+	store := map[string]int{"k": 10}
+	sentinel := errors.New("nope")
+	setCalled := false
+
+	_, err := AtomicUpdate(&mu,
+		func() (int, bool) { v, ok := store["k"]; return v, ok },
+		func(current int, exists bool) (int, error) { return 0, sentinel },
+		func(v int) { setCalled = true; store["k"] = v },
+	)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+	if setCalled {
+		t.Fatal("set must not be called when mutate returns an error")
+	}
+	if store["k"] != 10 {
+		t.Fatalf("store must be untouched on error, got %d", store["k"])
+	}
+}
+
+// TestAtomicUpdate_NoLostUpdatesUnderConcurrency is the actual regression
+// this primitive exists to fix: many goroutines each doing a
+// read-then-increment-then-write on the SAME key must never lose an update.
+// Run with -race; a data race here would also indicate the lock isn't doing
+// its job.
+func TestAtomicUpdate_NoLostUpdatesUnderConcurrency(t *testing.T) {
+	var mu sync.RWMutex
+	store := map[string]int{"k": 0}
+
+	const goroutines = 50
+	const incrementsEach = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < incrementsEach; j++ {
+				if _, err := AtomicUpdate(&mu,
+					func() (int, bool) { v, ok := store["k"]; return v, ok },
+					func(current int, exists bool) (int, error) { return current + 1, nil },
+					func(v int) { store["k"] = v },
+				); err != nil {
+					t.Errorf("AtomicUpdate: %v", err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	want := goroutines * incrementsEach
+	if store["k"] != want {
+		t.Fatalf("final count = %d, want %d (a mismatch means a lost update slipped through)", store["k"], want)
+	}
+}


### PR DESCRIPTION
## Summary

Foundational PR for a series fixing a systemic bug found by an adversarial OCC (optimistic-concurrency) review across the GCP providers: nearly every `Update`/`Patch` handler does `Get()` → merge request fields in Go → a **separate**, later `Update()` call, with no atomicity between the two. A concurrent writer racing in between is silently overwritten — a lost update. In at least one case (Secret Manager) this corrupts an internally-managed counter (`NextVer`), not just a client-visible field.

This is the same root cause as the Firestore lost-update race fixed in #41, generalized into one reusable primitive instead of being hand-rolled per store.

## What this PR adds

`internal/gcp/storeutil.AtomicUpdate(mu, get, mutate, set)` — holds the store's mutex for the entire read→mutate→write sequence, so no other `Get`/`Create`/`Update`/`Delete` guarded by the same mutex can be observed or applied in the middle of it. `mutate` can also reject the write (return an error) — this is the vehicle every follow-up fix in the series uses to validate a client-supplied precondition (GCS's `ifGenerationMatch`, Datastore's `base_version`/`update_time`, `policy.Set`'s `etag`) atomically with applying the write, rather than checking it up front and racing against a concurrent writer anyway.

Postgres stores need the equivalent guarantee but SQL specifics (table/column names) don't generalize into shared Go code the same way — documented in the package comment as a convention (`Serializable` transaction + `SELECT ... FOR UPDATE`) referencing `store/firestore/postgres.go`'s `Commit` as the reference shape, for each follow-up PR to mirror.

This PR is intentionally just the primitive — no service is wired to it yet.

## Follow-up PRs (in priority order)

1. Secret Manager — `Update`/`UpdateSecret` corrupting the version counter (real data loss)
2. Datastore — `Mutation.base_version`/`update_time` conflict-detection fields decoded off the wire and never read
3. Cloud Storage (GCS) — `ifGenerationMatch`/`ifMetagenerationMatch` reach `nr.Params` but are never read anywhere
4. The shared `policy.Set` IAM-policy CAS helper (used by Pub/Sub, Secret Manager, IAM, KMS-gRPC) — implements an etag check, but `Load`+`Upsert` aren't atomic, so the check itself has the same race
5. Functions, Workflows, Dataproc, BigQuery, Managed Kafka, Monitoring — the same Get-then-separate-Update race on their respective `Update`/`Patch` handlers (no known client-facing precondition being ignored in most of these, so lower severity than 1–4, but still a real lost-update window)

## Test plan

- [x] `TestAtomicUpdate_CreatesWhenAbsent` / `_MergesExisting` — correctness of the get/mutate/set wiring
- [x] `TestAtomicUpdate_MutateErrorDoesNotWrite` — an error from `mutate` aborts without calling `set`
- [x] `TestAtomicUpdate_NoLostUpdatesUnderConcurrency` — 50 goroutines × 100 increments each on one shared key, asserting the final count is exactly 5000; a mismatch would mean a lost update slipped through. Run under `-race`.
- [x] 100% statement coverage on the new package.
- [x] `go build ./...` — clean.
- [x] Isolation boundary re-verified (`internal/gcp/storeutil` imports nothing from `internal/aws`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)