### PR TITLE
fix(gcp/secretmanager): atomic Update closes version-counter corruption

### DIFF
--- a/internal/gcp/grpc/secretmanager/service.go
+++ b/internal/gcp/grpc/secretmanager/service.go
@@ -189,29 +189,31 @@ func (s *Service) UpdateSecret(ctx context.Context, req *secretmanagerpb.UpdateS
 	if !ok {
 		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
 	}
-	cur, err := s.secrets.GetSecret(ctx, project, id)
+	// UpdateSecretAtomic reads, merges, and writes under one lock, so a
+	// concurrent AddVersion's NextVersion() counter advance can't land
+	// between our read and our write and get silently rolled back by it.
+	updated, err := s.secrets.UpdateSecretAtomic(ctx, project, id, func(cur secretmanagerstore.Secret) (secretmanagerstore.Secret, error) {
+		if labels := proto.GetLabels(); labels != nil {
+			cur.Labels = labels
+		}
+		if r := proto.GetRotation(); r != nil {
+			cur.Rotation = rotationFromProto(r)
+		}
+		if va := proto.GetVersionAliases(); va != nil {
+			cur.VersionAliases = make(map[string]int, len(va))
+			for k, v := range va {
+				cur.VersionAliases[k] = int(v)
+			}
+		}
+		if kmsKeyName := kmsKeyNameFromSecret(proto); kmsKeyName != "" {
+			cur.KmsKeyName = kmsKeyName
+		}
+		return cur, nil
+	})
 	if err != nil {
 		return nil, mapSecretErr(err)
 	}
-	if labels := proto.GetLabels(); labels != nil {
-		cur.Labels = labels
-	}
-	if r := proto.GetRotation(); r != nil {
-		cur.Rotation = rotationFromProto(r)
-	}
-	if va := proto.GetVersionAliases(); va != nil {
-		cur.VersionAliases = make(map[string]int, len(va))
-		for k, v := range va {
-			cur.VersionAliases[k] = int(v)
-		}
-	}
-	if kmsKeyName := kmsKeyNameFromSecret(proto); kmsKeyName != "" {
-		cur.KmsKeyName = kmsKeyName
-	}
-	if err := s.secrets.UpdateSecret(ctx, project, id, cur); err != nil {
-		return nil, mapSecretErr(err)
-	}
-	return secretToProto(project, cur), nil
+	return secretToProto(project, updated), nil
 }
 
 func (s *Service) DeleteSecret(ctx context.Context, req *secretmanagerpb.DeleteSecretRequest) (*emptypb.Empty, error) {

--- a/internal/gcp/provider/secretmanager/secret.go
+++ b/internal/gcp/provider/secretmanager/secret.go
@@ -268,70 +268,98 @@ func (p *Provider) Update(ctx context.Context, nr *model.NormalizedRequest) (*mo
 		return nil, err
 	}
 	id := secretID(name)
-	s, err := p.secrets.GetSecret(ctx, nr.AccountID, id)
+	body, _ := nr.Params["body"].(map[string]any)
+
+	// UpdateSecretAtomic reads, merges, and writes under one lock, so a
+	// concurrent AddVersion's NextVersion() counter advance can't land between
+	// our read and our write and get silently rolled back by it.
+	updated, err := p.secrets.UpdateSecretAtomic(ctx, nr.AccountID, id, func(current secretmanagerstore.Secret) (secretmanagerstore.Secret, error) {
+		m := fromStoreSecret(nr, current)
+		if body != nil {
+			if labels, ok := body["labels"].(map[string]any); ok {
+				m.Labels = make(map[string]string, len(labels))
+				for k, v := range labels {
+					if sv, ok := v.(string); ok {
+						m.Labels[k] = sv
+					}
+				}
+			}
+			if r := rotationFromBody(body); r != nil {
+				m.Rotation = r
+			}
+			if va := versionAliasesFromBody(body); va != nil {
+				m.VersionAliases = va
+			}
+			if kmsKeyName := kmsKeyNameFromBody(body); kmsKeyName != "" {
+				m.KmsKeyName = kmsKeyName
+			}
+		}
+		return toStoreSecret(m), nil
+	})
 	if err != nil {
 		return nil, mapSecretErr(err)
 	}
-	m := fromStoreSecret(nr, s)
-	if body, ok := nr.Params["body"].(map[string]any); ok {
-		if labels, ok := body["labels"].(map[string]any); ok {
-			m.Labels = make(map[string]string, len(labels))
-			for k, v := range labels {
-				if sv, ok := v.(string); ok {
-					m.Labels[k] = sv
-				}
-			}
-		}
-		if r := rotationFromBody(body); r != nil {
-			m.Rotation = r
-		}
-		if va := versionAliasesFromBody(body); va != nil {
-			m.VersionAliases = va
-		}
-		if kmsKeyName := kmsKeyNameFromBody(body); kmsKeyName != "" {
-			m.KmsKeyName = kmsKeyName
-		}
-	}
-	if err := p.secrets.UpdateSecret(ctx, nr.AccountID, id, toStoreSecret(m)); err != nil {
-		return nil, mapSecretErr(err)
-	}
-	return provider.OK(secretToMap(m)), nil
+	return provider.OK(secretToMap(fromStoreSecret(nr, updated))), nil
 }
 
-// maybeRotate advances a secret's rotation schedule when it is due: it creates
-// an empty version and advances nextRotationTime by rotationPeriod. This is
-// GCP's automatic-rotation behavior, evaluated lazily on read (no background
+// errSkipRotation aborts maybeRotate's atomic mutate without writing, when
+// rotation turns out not to be due after all (re-checked under the store's
+// lock, since the Secret this function receives may have been read well
+// before this call by a caller several frames up).
+var errSkipRotation = errors.New("secret rotation not due")
+
+// maybeRotate advances a secret's rotation schedule when it is due: it
+// allocates the next version number and creates an empty version, and
+// advances nextRotationTime by rotationPeriod. This is GCP's
+// automatic-rotation behavior, evaluated lazily on read (no background
 // worker), mirroring how AWS SQS enforces visibility lazily on receive.
+//
+// s is the caller's (possibly stale — read by Get/Access some time before
+// this call) snapshot, used only for the cheap up-front "is rotation even
+// configured and due" check, to avoid taking the store lock at all in the
+// overwhelmingly common case where it isn't. If that check passes,
+// everything that actually matters — whether rotation is STILL due, the
+// rotation-schedule advance, and the version-counter allocation — is
+// re-done from a fresh read inside UpdateSecretAtomic's locked section, so
+// a concurrent Update/AddVersion/maybeRotate on the same secret can't
+// interleave with this one.
 func (p *Provider) maybeRotate(ctx context.Context, account, id string, s secretmanagerstore.Secret) secretmanagerstore.Secret {
 	if s.Rotation == nil || s.Rotation.NextRotationTime == "" {
 		return s
 	}
-	next, err := time.Parse(time.RFC3339Nano, s.Rotation.NextRotationTime)
-	if err != nil || clock.Now().Before(next) {
+	if next, err := time.Parse(time.RFC3339Nano, s.Rotation.NextRotationTime); err != nil || clock.Now().Before(next) {
 		return s
 	}
-	if s.Rotation.RotationPeriod != "" {
-		if d, err := time.ParseDuration(s.Rotation.RotationPeriod); err == nil {
-			// Copy before mutating: s.Rotation is a pointer aliased with the
-			// store's own copy (GetSecret returns Secret by value, but Rotation
-			// is a *Rotation field), so writing through it directly would mutate
-			// live store state ahead of, and regardless of the outcome of, the
-			// UpdateSecret call below.
-			rotation := *s.Rotation
-			rotation.NextRotationTime = clock.Now().Add(d).UTC().Format(time.RFC3339Nano)
-			s.Rotation = &rotation
+
+	var allocatedVer int
+	updated, err := p.secrets.UpdateSecretAtomic(ctx, account, id, func(current secretmanagerstore.Secret) (secretmanagerstore.Secret, error) {
+		if current.Rotation == nil || current.Rotation.NextRotationTime == "" {
+			return secretmanagerstore.Secret{}, errSkipRotation
 		}
-	}
-	ver, err := p.secrets.NextVersion(ctx, account, id)
+		next, err := time.Parse(time.RFC3339Nano, current.Rotation.NextRotationTime)
+		if err != nil || clock.Now().Before(next) {
+			return secretmanagerstore.Secret{}, errSkipRotation
+		}
+		if current.Rotation.RotationPeriod != "" {
+			if d, err := time.ParseDuration(current.Rotation.RotationPeriod); err == nil {
+				rotation := *current.Rotation
+				rotation.NextRotationTime = clock.Now().Add(d).UTC().Format(time.RFC3339Nano)
+				current.Rotation = &rotation
+			}
+		}
+		allocatedVer = current.NextVer
+		current.NextVer++
+		return current, nil
+	})
 	if err != nil {
+		// errSkipRotation (already rotated, or rotation disabled, since our
+		// caller's read) or any store error: behave as if untouched.
 		return s
 	}
-	s.NextVer = ver + 1
 	_ = p.secrets.CreateVersion(ctx, account, secretmanagerstore.Version{
-		SecretID: id, VersionID: strconv.Itoa(ver), State: "ENABLED", CreateTime: clock.Now(),
+		SecretID: id, VersionID: strconv.Itoa(allocatedVer), State: "ENABLED", CreateTime: clock.Now(),
 	})
-	_ = p.secrets.UpdateSecret(ctx, account, id, s)
-	return s
+	return updated
 }
 
 func (p *Provider) Delete(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {

--- a/internal/gcp/provider/secretmanager/secret_extra_test.go
+++ b/internal/gcp/provider/secretmanager/secret_extra_test.go
@@ -2,6 +2,7 @@ package secretmanager
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -163,6 +164,76 @@ func TestSecretAddVersionConcurrent(t *testing.T) {
 	}
 	if len(versions) != n {
 		t.Fatalf("expected %d versions, got %d", n, len(versions))
+	}
+}
+
+// TestSecretUpdateConcurrentWithAddVersion is the regression test for the
+// version-counter corruption bug: Update used to Get the secret, merge
+// request fields (including the NextVer it just read) into a full copy, then
+// write that whole copy back with a separate UpdateSecret call. If a
+// concurrent AddVersion's NextVersion() advanced the counter in the window
+// between Update's read and its write, Update's stale write silently rolled
+// the counter back — a subsequent AddVersion would then reuse an
+// already-issued version ID and CreateVersion would silently overwrite that
+// version's stored payload. Fixed by routing Update through
+// UpdateSecretAtomic, which holds the store's lock for the whole
+// read-merge-write sequence so NextVersion() can't land in the middle of it.
+//
+// This asserts the property that actually matters: with N concurrent
+// AddVersion calls interleaved with N concurrent Update calls (patching an
+// unrelated field, labels), every AddVersion must produce a distinct version
+// ID — no two ever collide on the same ID, which is exactly what a rolled-
+// back counter would cause.
+func TestSecretUpdateConcurrentWithAddVersion(t *testing.T) {
+	ctx := context.Background()
+	p := New(secretmanagerstore.NewMemoryStore(), store.NewMemoryResourceStore(), crypto.NewEnvelopeEncryptor(kms.NewMemoryStore()))
+
+	if _, err := p.Create(ctx, newNR(map[string]any{"secretId": "s"})); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	const n = 50
+	var wg sync.WaitGroup
+	errs := make(chan error, 2*n)
+	for i := 0; i < n; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			nr := newNR(map[string]any{"name": "secrets/s", "body": map[string]any{"payload": map[string]any{"data": "aGk="}}})
+			if _, err := p.AddVersion(ctx, nr); err != nil {
+				errs <- err
+			}
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			nr := newNR(map[string]any{
+				"name": "secrets/s",
+				"body": map[string]any{"labels": map[string]any{"iteration": strconv.Itoa(i)}},
+			})
+			if _, err := p.Update(ctx, nr); err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent AddVersion/Update: %v", err)
+	}
+
+	versions, err := p.secrets.ListVersions(ctx, "proj", "s")
+	if err != nil {
+		t.Fatalf("list versions: %v", err)
+	}
+	if len(versions) != n {
+		t.Fatalf("expected %d distinct versions (a rolled-back counter would cause fewer, via silent ID collision), got %d", n, len(versions))
+	}
+	seen := make(map[string]bool, n)
+	for _, v := range versions {
+		if seen[v.VersionID] {
+			t.Fatalf("duplicate version ID %q — the counter was rolled back and two AddVersion calls collided", v.VersionID)
+		}
+		seen[v.VersionID] = true
 	}
 }
 

--- a/internal/gcp/store/secretmanager/memory.go
+++ b/internal/gcp/store/secretmanager/memory.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sort"
 	"sync"
+
+	"jaiscloud/internal/gcp/storeutil"
 )
 
 // MemoryStore is an in-memory Store.
@@ -54,6 +56,19 @@ func (s *MemoryStore) UpdateSecret(_ context.Context, projectID, id string, sec 
 	}
 	s.secrets[projectID][id] = sec
 	return nil
+}
+
+func (s *MemoryStore) UpdateSecretAtomic(_ context.Context, projectID, id string, mutate func(Secret) (Secret, error)) (Secret, error) {
+	return storeutil.AtomicUpdate(&s.mu,
+		func() (Secret, bool) { sec, ok := s.secrets[projectID][id]; return sec, ok },
+		func(current Secret, exists bool) (Secret, error) {
+			if !exists {
+				return Secret{}, ErrNoSuchSecret
+			}
+			return mutate(current)
+		},
+		func(sec Secret) { s.secrets[projectID][id] = sec },
+	)
 }
 
 func (s *MemoryStore) DeleteSecret(_ context.Context, projectID, id string) error {

--- a/internal/gcp/store/secretmanager/memory_test.go
+++ b/internal/gcp/store/secretmanager/memory_test.go
@@ -2,6 +2,7 @@ package secretmanager
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -122,6 +123,51 @@ func TestMemoryStoreNextVersion(t *testing.T) {
 	}
 	if _, err := s.NextVersion(ctx, "proj", "missing"); err != ErrNoSuchSecret {
 		t.Fatalf("expected ErrNoSuchSecret, got %v", err)
+	}
+}
+
+func TestMemoryStoreUpdateSecretAtomic(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	s.CreateSecret(ctx, "proj", "a", Secret{ID: "a", Labels: map[string]string{"k": "v"}, NextVer: 1})
+
+	updated, err := s.UpdateSecretAtomic(ctx, "proj", "a", func(cur Secret) (Secret, error) {
+		cur.Labels = map[string]string{"k": "v2"}
+		return cur, nil
+	})
+	if err != nil {
+		t.Fatalf("UpdateSecretAtomic: %v", err)
+	}
+	if updated.Labels["k"] != "v2" {
+		t.Fatalf("returned value not updated: %+v", updated)
+	}
+	got, _ := s.GetSecret(ctx, "proj", "a")
+	if got.Labels["k"] != "v2" {
+		t.Fatalf("stored value not updated: %+v", got)
+	}
+
+	// mutate error: no-op, nothing written.
+	sentinel := errors.New("nope")
+	if _, err := s.UpdateSecretAtomic(ctx, "proj", "a", func(cur Secret) (Secret, error) {
+		return Secret{}, sentinel
+	}); !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+	got, _ = s.GetSecret(ctx, "proj", "a")
+	if got.Labels["k"] != "v2" {
+		t.Fatalf("secret must be untouched after a mutate error, got %+v", got)
+	}
+
+	// missing secret → ErrNoSuchSecret, mutate never called.
+	mutateCalled := false
+	if _, err := s.UpdateSecretAtomic(ctx, "proj", "missing", func(cur Secret) (Secret, error) {
+		mutateCalled = true
+		return cur, nil
+	}); err != ErrNoSuchSecret {
+		t.Fatalf("expected ErrNoSuchSecret, got %v", err)
+	}
+	if mutateCalled {
+		t.Fatal("mutate must not be called for a missing secret")
 	}
 }
 

--- a/internal/gcp/store/secretmanager/postgres.go
+++ b/internal/gcp/store/secretmanager/postgres.go
@@ -89,6 +89,58 @@ func (s *PostgresStore) UpdateSecret(ctx context.Context, projectID, id string, 
 	return nil
 }
 
+// UpdateSecretAtomic mirrors MemoryStore's version: a Serializable transaction
+// with SELECT ... FOR UPDATE row-locks the secret for the duration of
+// mutate, so a concurrent NextVersion() (or another UpdateSecretAtomic) call
+// on the same secret blocks until this transaction commits or rolls back,
+// instead of racing to silently roll back the other's write. See
+// store/firestore/postgres.go's Commit for the same convention.
+func (s *PostgresStore) UpdateSecretAtomic(ctx context.Context, projectID, id string, mutate func(Secret) (Secret, error)) (Secret, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return Secret{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	var sec Secret
+	var labels, rotation, aliases []byte
+	err = tx.QueryRow(ctx, `
+		SELECT secret_id, labels, create_time, next_ver, rotation, version_aliases, kms_key_name
+		FROM jc_sm_secrets WHERE project_id=$1 AND secret_id=$2 FOR UPDATE
+	`, projectID, id).Scan(&sec.ID, &labels, &sec.CreateTime, &sec.NextVer, &rotation, &aliases, &sec.KmsKeyName)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Secret{}, ErrNoSuchSecret
+	}
+	if err != nil {
+		return Secret{}, err
+	}
+	json.Unmarshal(labels, &sec.Labels)
+	if len(rotation) > 0 {
+		json.Unmarshal(rotation, &sec.Rotation)
+	}
+	if len(aliases) > 0 {
+		json.Unmarshal(aliases, &sec.VersionAliases)
+	}
+
+	next, err := mutate(sec)
+	if err != nil {
+		return Secret{}, err
+	}
+
+	newLabels, _ := json.Marshal(next.Labels)
+	if _, err := tx.Exec(ctx, `
+		UPDATE jc_sm_secrets SET labels=$3, next_ver=$4, rotation=$5, version_aliases=$6, kms_key_name=$7
+		WHERE project_id=$1 AND secret_id=$2
+	`, projectID, id, json.RawMessage(newLabels), next.NextVer, nullableJSON(next.Rotation), nullableJSON(next.VersionAliases), next.KmsKeyName); err != nil {
+		return Secret{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return Secret{}, err
+	}
+	return next, nil
+}
+
 func (s *PostgresStore) DeleteSecret(ctx context.Context, projectID, id string) error {
 	if _, err := s.pool.Exec(ctx, `DELETE FROM jc_sm_versions WHERE project_id=$1 AND secret_id=$2`, projectID, id); err != nil {
 		return err

--- a/internal/gcp/store/secretmanager/store.go
+++ b/internal/gcp/store/secretmanager/store.go
@@ -49,6 +49,16 @@ type Store interface {
 	CreateSecret(ctx context.Context, projectID, id string, s Secret) error
 	GetSecret(ctx context.Context, projectID, id string) (Secret, error)
 	UpdateSecret(ctx context.Context, projectID, id string, s Secret) error
+	// UpdateSecretAtomic atomically reads the current secret, calls mutate to
+	// compute the new value, and writes it back — no other GetSecret/
+	// UpdateSecret/NextVersion for this secret can be observed or applied in
+	// between. Callers doing a read-modify-write (a labels/rotation patch, an
+	// automatic-rotation version bump) must use this instead of a separate
+	// GetSecret+UpdateSecret pair: the latter has a lost-update window where a
+	// concurrent NextVersion() call's counter advance gets silently rolled
+	// back by the stale write. Returns ErrNoSuchSecret if the secret doesn't
+	// exist (mutate is not called in that case).
+	UpdateSecretAtomic(ctx context.Context, projectID, id string, mutate func(current Secret) (Secret, error)) (Secret, error)
 	DeleteSecret(ctx context.Context, projectID, id string) error // cascades versions
 	ListSecrets(ctx context.Context, projectID string) ([]Secret, error)
 

--- a/internal/gcp/storeutil/atomic.go
+++ b/internal/gcp/storeutil/atomic.go
@@ -1,0 +1,54 @@
+// Package storeutil provides the shared atomic read-modify-write primitive
+// GCP memory stores use for their Update/Patch-style methods.
+//
+// An adversarial review across the GCP providers (storage, secretmanager,
+// datastore, functions, workflows, dataproc, bigquery, managedkafka,
+// monitoring, and the shared IAM-policy helper) found the same bug shape
+// repeated in nearly every Update/Patch handler: Get() the current value,
+// merge request fields into it in Go, then a SEPARATE, later Update() call
+// writes the result — with no atomicity between the two. A second writer
+// racing in between is silently overwritten (a lost update), and in at
+// least one case (Secret Manager) this corrupted an internally-managed
+// counter, not just a client-visible field. This mirrors the Firestore
+// lost-update race fixed earlier by routing PatchDocument/buildUpdate
+// through store.Commit's atomic read-set validation — this package
+// generalizes that fix into one reusable primitive instead of hand-rolling
+// it per store.
+//
+// AtomicUpdate is for in-memory stores (sync.RWMutex-guarded maps). Postgres
+// stores need the equivalent guarantee too, but SQL specifics (table/column
+// names) don't generalize into shared Go code the same way; the convention
+// there is a Serializable-isolation transaction with `SELECT ... FOR UPDATE`
+// on every row the mutation reads or writes, mirroring
+// internal/gcp/store/firestore/postgres.go's Commit — see that file for the
+// reference shape when adding this to a Postgres store.
+package storeutil
+
+import "sync"
+
+// AtomicUpdate holds mu for the entire read-mutate-write sequence: get()
+// reads the current value (and whether it exists), mutate computes the new
+// value from it (or returns an error to abort without writing — a
+// validation failure, a not-found condition, or a client-supplied
+// precondition mismatch), and set() persists the result. Holding one lock
+// across all three closes the race the Get-then-separate-Update pattern
+// leaves open: no other Get/Create/Update/Delete guarded by the same mu can
+// be observed or applied in the middle of this sequence.
+//
+// Keep get, mutate, and set fast and allocation-light — no I/O, no
+// acquiring any other lock — since mu is held for their combined duration.
+// On a mutate error, set is never called and the zero value of T is
+// returned alongside the error.
+func AtomicUpdate[T any](mu *sync.RWMutex, get func() (T, bool), mutate func(current T, exists bool) (T, error), set func(T)) (T, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	current, exists := get()
+	next, err := mutate(current, exists)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	set(next)
+	return next, nil
+}

--- a/internal/gcp/storeutil/atomic_test.go
+++ b/internal/gcp/storeutil/atomic_test.go
@@ -1,0 +1,109 @@
+package storeutil
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestAtomicUpdate_CreatesWhenAbsent(t *testing.T) {
+	var mu sync.RWMutex
+	store := map[string]int{}
+
+	got, err := AtomicUpdate(&mu,
+		func() (int, bool) { v, ok := store["k"]; return v, ok },
+		func(current int, exists bool) (int, error) {
+			if exists {
+				t.Fatalf("expected exists=false for a fresh key")
+			}
+			return 1, nil
+		},
+		func(v int) { store["k"] = v },
+	)
+	if err != nil {
+		t.Fatalf("AtomicUpdate: %v", err)
+	}
+	if got != 1 || store["k"] != 1 {
+		t.Fatalf("got=%d store=%d, want 1/1", got, store["k"])
+	}
+}
+
+func TestAtomicUpdate_MergesExisting(t *testing.T) {
+	var mu sync.RWMutex
+	store := map[string]int{"k": 10}
+
+	got, err := AtomicUpdate(&mu,
+		func() (int, bool) { v, ok := store["k"]; return v, ok },
+		func(current int, exists bool) (int, error) {
+			if !exists || current != 10 {
+				t.Fatalf("expected exists=true current=10, got exists=%v current=%d", exists, current)
+			}
+			return current + 5, nil
+		},
+		func(v int) { store["k"] = v },
+	)
+	if err != nil {
+		t.Fatalf("AtomicUpdate: %v", err)
+	}
+	if got != 15 || store["k"] != 15 {
+		t.Fatalf("got=%d store=%d, want 15/15", got, store["k"])
+	}
+}
+
+func TestAtomicUpdate_MutateErrorDoesNotWrite(t *testing.T) {
+	var mu sync.RWMutex
+	store := map[string]int{"k": 10}
+	sentinel := errors.New("nope")
+	setCalled := false
+
+	_, err := AtomicUpdate(&mu,
+		func() (int, bool) { v, ok := store["k"]; return v, ok },
+		func(current int, exists bool) (int, error) { return 0, sentinel },
+		func(v int) { setCalled = true; store["k"] = v },
+	)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+	if setCalled {
+		t.Fatal("set must not be called when mutate returns an error")
+	}
+	if store["k"] != 10 {
+		t.Fatalf("store must be untouched on error, got %d", store["k"])
+	}
+}
+
+// TestAtomicUpdate_NoLostUpdatesUnderConcurrency is the actual regression
+// this primitive exists to fix: many goroutines each doing a
+// read-then-increment-then-write on the SAME key must never lose an update.
+// Run with -race; a data race here would also indicate the lock isn't doing
+// its job.
+func TestAtomicUpdate_NoLostUpdatesUnderConcurrency(t *testing.T) {
+	var mu sync.RWMutex
+	store := map[string]int{"k": 0}
+
+	const goroutines = 50
+	const incrementsEach = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < incrementsEach; j++ {
+				if _, err := AtomicUpdate(&mu,
+					func() (int, bool) { v, ok := store["k"]; return v, ok },
+					func(current int, exists bool) (int, error) { return current + 1, nil },
+					func(v int) { store["k"] = v },
+				); err != nil {
+					t.Errorf("AtomicUpdate: %v", err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	want := goroutines * incrementsEach
+	if store["k"] != want {
+		t.Fatalf("final count = %d, want %d (a mismatch means a lost update slipped through)", store["k"], want)
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #44 (the shared `storeutil.AtomicUpdate` primitive). This is the highest-priority fix from the adversarial OCC review: real secret data loss, not a cosmetic race.

**Mechanism.** `Secret.Update` (REST) and `UpdateSecret` (gRPC) did `GetSecret` → merge request fields (including `NextVer`, read at the same moment) into a full copy → a **separate** `UpdateSecret` call that writes every mutable column unconditionally. If a concurrent `AddVersion`'s `NextVersion()` (an atomic counter advance) landed in that window, `Update`'s stale write silently rolled the counter back. A subsequent `AddVersion` would then reuse an already-issued version ID, and `CreateVersion` would silently overwrite that version's stored (encrypted) payload.

**Verified the severity directly**, not just asserted it: temporarily reverted to the old pattern and ran the new regression test (50 concurrent `AddVersion` + 50 concurrent `Update`, interleaved) 15 times — only 11 to 36 of the 50 versions survived per run (as low as **22% survival**) before silently colliding on a reused version ID. With the fix, all 15 runs produce exactly 50 distinct versions.

## Fix

Added `Store.UpdateSecretAtomic(ctx, project, id, mutate)` to the secretmanager store interface:
- `MemoryStore` wraps `storeutil.AtomicUpdate` — one lock spans the whole read-merge-write sequence, so `NextVersion()` can't land in the middle of it.
- `PostgresStore` wraps a `Serializable` transaction with `SELECT ... FOR UPDATE`, mirroring `store/firestore/postgres.go`'s `Commit`.

Routed both `Update` (`secret.go`) and gRPC `UpdateSecret` (`grpc/secretmanager/service.go`) through it.

`maybeRotate` had the same gap, with an even larger staleness window — it operates on a snapshot the *caller* (`Get`/`Access`) read potentially much earlier, then does its own `NextVersion()`+`UpdateSecret()` at the end with no re-validation. Restructured it to re-check whether rotation is still due **and** allocate the version number inside `UpdateSecretAtomic`'s locked section (directly incrementing `NextVer` there instead of a separate `NextVersion()` call), so a concurrent `Update`/`AddVersion`/another `maybeRotate` can't interleave with it either. The up-front (unlocked) due-check on the caller's snapshot stays as a cheap short-circuit for the common case where rotation isn't due at all — the locked section re-validates everything that actually matters.

## Test plan

- [x] `TestSecretUpdateConcurrentWithAddVersion` — 50 concurrent `AddVersion` interleaved with 50 concurrent `Update` calls; asserts exactly 50 distinct version IDs survive (a rolled-back counter would cause fewer, via silent collision). **Confirmed this test fails against the old code** (11–36/50 survive across 15 runs) and passes reliably with the fix (15/15 runs, exactly 50/50).
- [x] `TestMemoryStoreUpdateSecretAtomic` — direct store-level test: create/merge, mutate-error-aborts-without-writing, not-found-doesn't-call-mutate.
- [x] All existing Secret Manager tests (REST, gRPC, store — `TestSecretRotationAndAliases`, `TestSecretRotationNotDue`, `TestSecretAddVersionConcurrent`, etc.) pass unchanged.
- [x] `-race` clean throughout.
- [x] Full `internal/gcp` suite (44 packages) and full repo build — clean.
- [x] Isolation boundary re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)