### PR TITLE
fix(gcp/datastore): enforce Mutation base_version/update_time preconditions

### DIFF
--- a/internal/gcp/grpc/datastore/occ_test.go
+++ b/internal/gcp/grpc/datastore/occ_test.go
@@ -1,0 +1,217 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	datastorepb "cloud.google.com/go/datastore/apiv1/datastorepb"
+)
+
+// TestLookupReturnsRealVersion verifies EntityResult.Version reflects the
+// entity's actual write history (1 after insert, 2 after update) instead of
+// being hardcoded to 1 — the field a real client reads to determine the
+// base_version for a subsequent conditional write.
+func TestLookupReturnsRealVersion(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+	key := nameKey("Task", "a")
+
+	if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Insert{Insert: entity(key, map[string]*datastorepb.Value{"n": intVal(1)})},
+		}},
+	}); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	lookup := func() int64 {
+		t.Helper()
+		resp, err := client.Lookup(ctx, &datastorepb.LookupRequest{ProjectId: "test", Keys: []*datastorepb.Key{key}})
+		if err != nil {
+			t.Fatalf("lookup: %v", err)
+		}
+		if len(resp.GetFound()) != 1 {
+			t.Fatalf("expected 1 found entity, got %d", len(resp.GetFound()))
+		}
+		return resp.GetFound()[0].GetVersion()
+	}
+
+	if v := lookup(); v != 1 {
+		t.Fatalf("version after insert = %d, want 1", v)
+	}
+
+	if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Update{Update: entity(key, map[string]*datastorepb.Value{"n": intVal(2)})},
+		}},
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if v := lookup(); v != 2 {
+		t.Fatalf("version after update = %d, want 2", v)
+	}
+}
+
+// TestCommitBaseVersionConflictRejected is the core regression test: a
+// Mutation carrying base_version (real Datastore's per-mutation
+// optimistic-concurrency precondition) that no longer matches the entity's
+// current version must be rejected (ConflictDetected=true, not applied) —
+// not silently applied unconditionally, which was the bug (the proto field
+// was decoded and never read).
+func TestCommitBaseVersionConflictRejected(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+	key := nameKey("Task", "a")
+
+	insertResp, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Insert{Insert: entity(key, map[string]*datastorepb.Value{"n": intVal(1)})},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	insertedVersion := insertResp.GetMutationResults()[0].GetVersion()
+	if insertedVersion != 1 {
+		t.Fatalf("inserted version = %d, want 1", insertedVersion)
+	}
+
+	// A concurrent writer updates the entity, advancing its version.
+	if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Update{Update: entity(key, map[string]*datastorepb.Value{"n": intVal(2)})},
+		}},
+	}); err != nil {
+		t.Fatalf("concurrent update: %v", err)
+	}
+
+	// A stale writer, still holding the version from the original insert,
+	// attempts a conditional update. This must be rejected, not silently
+	// applied on top of the newer state.
+	staleResp, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation:                 &datastorepb.Mutation_Update{Update: entity(key, map[string]*datastorepb.Value{"n": intVal(999)})},
+			ConflictDetectionStrategy: &datastorepb.Mutation_BaseVersion{BaseVersion: insertedVersion},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("stale commit should not error at the RPC level, got: %v", err)
+	}
+	results := staleResp.GetMutationResults()
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if !results[0].GetConflictDetected() {
+		t.Fatal("expected ConflictDetected=true for a stale base_version, got false")
+	}
+
+	// The stale write must NOT have applied: n must still be 2, not 999.
+	lookupResp, err := client.Lookup(ctx, &datastorepb.LookupRequest{ProjectId: "test", Keys: []*datastorepb.Key{key}})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	got := lookupResp.GetFound()[0].GetEntity().GetProperties()["n"].GetIntegerValue()
+	if got != 2 {
+		t.Fatalf("n = %d after a rejected conditional write, want 2 (the stale write must not have applied)", got)
+	}
+}
+
+// TestCommitBaseVersionMatchSucceeds is the positive case: a Mutation whose
+// base_version DOES match the entity's current version must apply normally.
+func TestCommitBaseVersionMatchSucceeds(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+	key := nameKey("Task", "a")
+
+	insertResp, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Insert{Insert: entity(key, map[string]*datastorepb.Value{"n": intVal(1)})},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	v := insertResp.GetMutationResults()[0].GetVersion()
+
+	resp, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation:                 &datastorepb.Mutation_Update{Update: entity(key, map[string]*datastorepb.Value{"n": intVal(2)})},
+			ConflictDetectionStrategy: &datastorepb.Mutation_BaseVersion{BaseVersion: v},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if resp.GetMutationResults()[0].GetConflictDetected() {
+		t.Fatal("expected no conflict for a matching base_version")
+	}
+	if got := resp.GetMutationResults()[0].GetVersion(); got != v+1 {
+		t.Fatalf("version after update = %d, want %d", got, v+1)
+	}
+}
+
+// TestCommitPartialConflictDoesNotAbortOtherMutations verifies real
+// Datastore's per-mutation (not per-Commit) conflict semantics: a
+// conflicting mutation in a batch does not prevent OTHER, non-conflicting
+// mutations in the same Commit call from applying.
+func TestCommitPartialConflictDoesNotAbortOtherMutations(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+	keyA := nameKey("Task", "a")
+	keyB := nameKey("Task", "b")
+
+	if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{
+			{Operation: &datastorepb.Mutation_Insert{Insert: entity(keyA, map[string]*datastorepb.Value{"n": intVal(1)})}},
+		},
+	}); err != nil {
+		t.Fatalf("seed a: %v", err)
+	}
+
+	resp, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{
+			// Conflicting: wrong base_version for an existing entity.
+			{
+				Operation:                 &datastorepb.Mutation_Update{Update: entity(keyA, map[string]*datastorepb.Value{"n": intVal(999)})},
+				ConflictDetectionStrategy: &datastorepb.Mutation_BaseVersion{BaseVersion: 12345},
+			},
+			// Non-conflicting: a plain insert of a different entity, no precondition.
+			{Operation: &datastorepb.Mutation_Insert{Insert: entity(keyB, map[string]*datastorepb.Value{"n": intVal(7)})}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	results := resp.GetMutationResults()
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if !results[0].GetConflictDetected() {
+		t.Fatal("expected mutation 0 (stale base_version) to conflict")
+	}
+	if results[1].GetConflictDetected() {
+		t.Fatal("mutation 1 (plain insert) must not be marked as conflicting")
+	}
+
+	// b must have been inserted despite a's conflict in the same Commit.
+	lookupResp, err := client.Lookup(ctx, &datastorepb.LookupRequest{ProjectId: "test", Keys: []*datastorepb.Key{keyB}})
+	if err != nil {
+		t.Fatalf("lookup b: %v", err)
+	}
+	if len(lookupResp.GetFound()) != 1 {
+		t.Fatal("entity b must exist — its non-conflicting insert must not have been aborted by a's conflict")
+	}
+}

--- a/internal/gcp/grpc/datastore/service.go
+++ b/internal/gcp/grpc/datastore/service.go
@@ -79,6 +79,7 @@ func (s *Service) Commit(ctx context.Context, req *datastorepb.CommitRequest) (*
 	project := s.project(ctx, req.GetProjectId())
 	results := make([]*datastorepb.MutationResult, 0, len(req.GetMutations()))
 	for _, m := range req.GetMutations() {
+		pre := mutationPrecondition(m)
 		mr := &datastorepb.MutationResult{Version: 1}
 		switch op := m.GetOperation().(type) {
 		case *datastorepb.Mutation_Insert:
@@ -86,25 +87,38 @@ func (s *Service) Commit(ctx context.Context, req *datastorepb.CommitRequest) (*
 			if err != nil {
 				return nil, mapError(err)
 			}
-			if err := s.store.Insert(ctx, project, e); err != nil {
-				if errors.Is(err, datastorestore.ErrEntityExists) {
-					return nil, mapError(model.NewProviderError("AlreadyExists", "entity already exists", 409))
-				}
+			applied, err := s.store.ApplyMutation(ctx, project, datastorestore.MutationInsert, e, pre)
+			switch {
+			case errors.Is(err, datastorestore.ErrConflict):
+				mr.ConflictDetected = true
+				mr.Version = applied.Version
+			case errors.Is(err, datastorestore.ErrEntityExists):
+				return nil, mapError(model.NewProviderError("AlreadyExists", "entity already exists", 409))
+			case err != nil:
 				return nil, mapError(err)
-			}
-			if allocated {
-				mr.Key = keyProto(e.Key, project)
+			default:
+				mr.Version = applied.Version
+				if allocated {
+					mr.Key = keyProto(e.Key, project)
+				}
 			}
 		case *datastorepb.Mutation_Upsert:
 			e, allocated, err := s.resolveEntity(ctx, project, op.Upsert)
 			if err != nil {
 				return nil, mapError(err)
 			}
-			if err := s.store.Upsert(ctx, project, e); err != nil {
+			applied, err := s.store.ApplyMutation(ctx, project, datastorestore.MutationUpsert, e, pre)
+			switch {
+			case errors.Is(err, datastorestore.ErrConflict):
+				mr.ConflictDetected = true
+				mr.Version = applied.Version
+			case err != nil:
 				return nil, mapError(err)
-			}
-			if allocated {
-				mr.Key = keyProto(e.Key, project)
+			default:
+				mr.Version = applied.Version
+				if allocated {
+					mr.Key = keyProto(e.Key, project)
+				}
 			}
 		case *datastorepb.Mutation_Update:
 			e, err := entityFromProto(op.Update)
@@ -114,19 +128,29 @@ func (s *Service) Commit(ctx context.Context, req *datastorepb.CommitRequest) (*
 			if e.Key == "" {
 				return nil, mapError(model.NewProviderError("InvalidArgument", "update key is incomplete", 400))
 			}
-			if err := s.store.Update(ctx, project, e); err != nil {
-				if errors.Is(err, datastorestore.ErrEntityNotFound) {
-					return nil, mapError(model.NewProviderError("FailedPrecondition", "entity not found", 404))
-				}
+			applied, err := s.store.ApplyMutation(ctx, project, datastorestore.MutationUpdate, e, pre)
+			switch {
+			case errors.Is(err, datastorestore.ErrConflict):
+				mr.ConflictDetected = true
+				mr.Version = applied.Version
+			case errors.Is(err, datastorestore.ErrEntityNotFound):
+				return nil, mapError(model.NewProviderError("FailedPrecondition", "entity not found", 404))
+			case err != nil:
 				return nil, mapError(err)
+			default:
+				mr.Version = applied.Version
 			}
 		case *datastorepb.Mutation_Delete:
 			key, err := deleteKey(op.Delete)
 			if err != nil {
 				return nil, mapError(err)
 			}
-			if err := s.store.Delete(ctx, project, key); err != nil {
-				return nil, mapError(err)
+			if err := s.store.DeleteConflictChecked(ctx, project, key, pre); err != nil {
+				if errors.Is(err, datastorestore.ErrConflict) {
+					mr.ConflictDetected = true
+				} else {
+					return nil, mapError(err)
+				}
 			}
 		default:
 			return nil, mapError(model.NewProviderError("InvalidArgument", "mutation has no operation", 400))
@@ -137,6 +161,23 @@ func (s *Service) Commit(ctx context.Context, req *datastorepb.CommitRequest) (*
 		MutationResults: results,
 		// CommitTime is not set for non-transactional commits (see the proto).
 	}, nil
+}
+
+// mutationPrecondition translates a Mutation's conflict_detection_strategy
+// oneof (base_version or update_time — real Datastore's per-mutation
+// optimistic-concurrency precondition) into a store Precondition. Returns nil
+// when the mutation carries neither (the common case — no precondition).
+func mutationPrecondition(m *datastorepb.Mutation) *datastorestore.Precondition {
+	switch v := m.GetConflictDetectionStrategy().(type) {
+	case *datastorepb.Mutation_BaseVersion:
+		bv := v.BaseVersion
+		return &datastorestore.Precondition{BaseVersion: &bv}
+	case *datastorepb.Mutation_UpdateTime:
+		ut := v.UpdateTime.AsTime()
+		return &datastorestore.Precondition{UpdateTime: &ut}
+	default:
+		return nil
+	}
 }
 
 func (s *Service) Lookup(ctx context.Context, req *datastorepb.LookupRequest) (*datastorepb.LookupResponse, error) {
@@ -162,8 +203,11 @@ func (s *Service) Lookup(ctx context.Context, req *datastorepb.LookupRequest) (*
 		default:
 			_ = kind
 			resp.Found = append(resp.Found, &datastorepb.EntityResult{
-				Entity:  entityToProto(e, project),
-				Version: 1,
+				Entity: entityToProto(e, project),
+				// Real, per-entity version — clients read this and pass it
+				// back as a Mutation's base_version for a conditional write;
+				// a hardcoded 1 would make that OCC contract meaningless.
+				Version: e.Version,
 			})
 		}
 	}
@@ -207,7 +251,7 @@ func (s *Service) RunQuery(ctx context.Context, req *datastorepb.RunQueryRequest
 		}
 		batch.EntityResults = append(batch.EntityResults, &datastorepb.EntityResult{
 			Entity:  entityToProto(e, project),
-			Version: 1,
+			Version: e.Version,
 		})
 	}
 	return &datastorepb.RunQueryResponse{Batch: batch}, nil

--- a/internal/gcp/store/datastore/memory.go
+++ b/internal/gcp/store/datastore/memory.go
@@ -2,8 +2,12 @@ package datastore
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"sync"
+
+	"jaiscloud/internal/clock"
+	"jaiscloud/internal/gcp/storeutil"
 )
 
 // MemoryStore is an in-memory Store. Entities are keyed by (project, key).
@@ -67,6 +71,61 @@ func (s *MemoryStore) Update(_ context.Context, project string, e Entity) error 
 func (s *MemoryStore) Delete(_ context.Context, project, key string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	delete(s.entities[project], key)
+	return nil
+}
+
+func (s *MemoryStore) ApplyMutation(_ context.Context, project string, kind MutationKind, e Entity, precondition *Precondition) (Entity, error) {
+	var observed Entity
+	result, err := storeutil.AtomicUpdate(&s.mu,
+		func() (Entity, bool) { ent, ok := s.entities[project][e.Key]; return ent, ok },
+		func(current Entity, exists bool) (Entity, error) {
+			observed = current
+			if !preconditionMatches(current, exists, precondition) {
+				return Entity{}, ErrConflict
+			}
+			switch kind {
+			case MutationInsert:
+				if exists {
+					return Entity{}, ErrEntityExists
+				}
+				e.Version = 1
+			case MutationUpdate:
+				if !exists {
+					return Entity{}, ErrEntityNotFound
+				}
+				e.Version = current.Version + 1
+			case MutationUpsert:
+				e.Version = current.Version + 1
+			}
+			e.UpdateTime = clock.Now()
+			return e, nil
+		},
+		func(ent Entity) {
+			if s.entities[project] == nil {
+				s.entities[project] = make(map[string]Entity)
+			}
+			s.entities[project][e.Key] = ent
+		},
+	)
+	if errors.Is(err, ErrConflict) {
+		// Report the entity's actual current (unchanged) state, not the zero
+		// value AtomicUpdate discards on error — real Datastore's
+		// MutationResult.version is "the version on the server after
+		// processing," which for a rejected mutation is the version that
+		// caused the rejection, useful for a client's retry.
+		return observed, ErrConflict
+	}
+	return result, err
+}
+
+func (s *MemoryStore) DeleteConflictChecked(_ context.Context, project, key string, precondition *Precondition) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, exists := s.entities[project][key]
+	if !preconditionMatches(current, exists, precondition) {
+		return ErrConflict
+	}
 	delete(s.entities[project], key)
 	return nil
 }

--- a/internal/gcp/store/datastore/memory_test.go
+++ b/internal/gcp/store/datastore/memory_test.go
@@ -79,6 +79,90 @@ func TestMemoryStoreCRUD(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreApplyMutation(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	e := testEntity("Task", "a", map[string]Value{"n": num(1)})
+
+	// Insert: no precondition, version stamped to 1.
+	inserted, err := s.ApplyMutation(ctx, "p1", MutationInsert, e, nil)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if inserted.Version != 1 {
+		t.Fatalf("inserted version = %d, want 1", inserted.Version)
+	}
+
+	// Insert again: ErrEntityExists regardless of precondition.
+	if _, err := s.ApplyMutation(ctx, "p1", MutationInsert, e, nil); !errors.Is(err, ErrEntityExists) {
+		t.Fatalf("duplicate insert = %v, want ErrEntityExists", err)
+	}
+
+	// Update with a stale base_version: ErrConflict, not applied. A fresh
+	// Entity (its own Properties map, not aliased with the stored one) —
+	// mutating e.Properties in place would corrupt the already-stored
+	// entity's data via the shared map reference, since Go doesn't copy maps
+	// on struct assignment.
+	stale := int64(0)
+	staleUpdate := testEntity("Task", "a", map[string]Value{"n": num(999)})
+	got, err := s.ApplyMutation(ctx, "p1", MutationUpdate, staleUpdate, &Precondition{BaseVersion: &stale})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("stale update = %v, want ErrConflict", err)
+	}
+	if got.Version != 1 {
+		t.Fatalf("conflict result version = %d, want 1 (the current, unchanged version)", got.Version)
+	}
+	current, _ := s.Get(ctx, "p1", e.Key)
+	n := current.Properties["n"].IntegerValue
+	if n == nil || *n != 1 {
+		t.Fatalf("entity must be unchanged after a rejected conditional update, got %+v", current.Properties["n"])
+	}
+
+	// Update with the correct base_version: applies, version advances.
+	correct := int64(1)
+	goodUpdate := testEntity("Task", "a", map[string]Value{"n": num(2)})
+	updated, err := s.ApplyMutation(ctx, "p1", MutationUpdate, goodUpdate, &Precondition{BaseVersion: &correct})
+	if err != nil {
+		t.Fatalf("correct update: %v", err)
+	}
+	if updated.Version != 2 {
+		t.Fatalf("updated version = %d, want 2", updated.Version)
+	}
+
+	// Update on a missing entity: ErrEntityNotFound.
+	missing := testEntity("Task", "missing", nil)
+	if _, err := s.ApplyMutation(ctx, "p1", MutationUpdate, missing, nil); !errors.Is(err, ErrEntityNotFound) {
+		t.Fatalf("update missing = %v, want ErrEntityNotFound", err)
+	}
+}
+
+func TestMemoryStoreDeleteConflictChecked(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	e := testEntity("Task", "a", map[string]Value{"n": num(1)})
+	if _, err := s.ApplyMutation(ctx, "p1", MutationInsert, e, nil); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Stale precondition: ErrConflict, entity not deleted.
+	stale := int64(0)
+	if err := s.DeleteConflictChecked(ctx, "p1", e.Key, &Precondition{BaseVersion: &stale}); !errors.Is(err, ErrConflict) {
+		t.Fatalf("stale delete = %v, want ErrConflict", err)
+	}
+	if _, err := s.Get(ctx, "p1", e.Key); err != nil {
+		t.Fatalf("entity must still exist after a rejected conditional delete, got %v", err)
+	}
+
+	// Correct precondition: deletes.
+	correct := int64(1)
+	if err := s.DeleteConflictChecked(ctx, "p1", e.Key, &Precondition{BaseVersion: &correct}); err != nil {
+		t.Fatalf("correct delete: %v", err)
+	}
+	if _, err := s.Get(ctx, "p1", e.Key); !errors.Is(err, ErrEntityNotFound) {
+		t.Fatalf("get after delete = %v, want ErrEntityNotFound", err)
+	}
+}
+
 func TestMemoryStoreAllocateIDs(t *testing.T) {
 	ctx := context.Background()
 	s := NewMemoryStore()

--- a/internal/gcp/store/datastore/postgres.go
+++ b/internal/gcp/store/datastore/postgres.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 
+	"jaiscloud/internal/clock"
+
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -25,13 +27,13 @@ func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore {
 
 // entityCols is the SELECT column list for jc_datastore_entities (the project
 // and name_or_id columns are re-derivable from Key and scanned but discarded).
-const entityCols = "project, kind, name_or_id, properties"
+const entityCols = "project, kind, name_or_id, properties, version, update_time"
 
 func scanEntity(scan func(...any) error) (Entity, error) {
 	var e Entity
 	var project, nameOrID string
 	var props []byte
-	if err := scan(&project, &e.Kind, &nameOrID, &props); err != nil {
+	if err := scan(&project, &e.Kind, &nameOrID, &props, &e.Version, &e.UpdateTime); err != nil {
 		return Entity{}, err
 	}
 	if len(props) > 0 {
@@ -138,6 +140,105 @@ func (s *PostgresStore) Delete(ctx context.Context, project, key string) error {
 	}
 	_, err := s.pool.Exec(ctx, `DELETE FROM jc_datastore_entities WHERE project=$1 AND kind=$2 AND name_or_id=$3`, project, kind, nameOrID)
 	return err
+}
+
+// ApplyMutation mirrors MemoryStore's: a Serializable transaction with
+// SELECT ... FOR UPDATE row-locks the entity (or its absence — a locked scan
+// of zero rows still participates in the transaction's serialization) for
+// the duration of the precondition check and apply, so a concurrent mutation
+// on the same entity can't land in between. See
+// store/firestore/postgres.go's Commit for the same convention.
+func (s *PostgresStore) ApplyMutation(ctx context.Context, project string, kind MutationKind, e Entity, precondition *Precondition) (Entity, error) {
+	entKind, nameOrID, err := splitKeyCols(e)
+	if err != nil {
+		return Entity{}, err
+	}
+
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return Entity{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	row := tx.QueryRow(ctx, `
+		SELECT `+entityCols+` FROM jc_datastore_entities
+		WHERE project=$1 AND kind=$2 AND name_or_id=$3 FOR UPDATE
+	`, project, entKind, nameOrID)
+	current, err := scanEntity(row.Scan)
+	exists := true
+	if errors.Is(err, pgx.ErrNoRows) {
+		exists = false
+	} else if err != nil {
+		return Entity{}, err
+	}
+
+	if !preconditionMatches(current, exists, precondition) {
+		// Report the entity's actual current (unchanged) state — see
+		// MemoryStore.ApplyMutation's doc comment on this same return.
+		return current, ErrConflict
+	}
+	switch kind {
+	case MutationInsert:
+		if exists {
+			return Entity{}, ErrEntityExists
+		}
+		e.Version = 1
+	case MutationUpdate:
+		if !exists {
+			return Entity{}, ErrEntityNotFound
+		}
+		e.Version = current.Version + 1
+	case MutationUpsert:
+		e.Version = current.Version + 1
+	}
+	e.UpdateTime = clock.Now()
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO jc_datastore_entities (project, kind, name_or_id, properties, version, update_time)
+		VALUES ($1,$2,$3,$4,$5,$6)
+		ON CONFLICT (project, kind, name_or_id) DO UPDATE
+			SET properties=EXCLUDED.properties, version=EXCLUDED.version, update_time=EXCLUDED.update_time
+	`, project, entKind, nameOrID, propertiesJSON(e.Properties), e.Version, e.UpdateTime); err != nil {
+		return Entity{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Entity{}, err
+	}
+	return e, nil
+}
+
+// DeleteConflictChecked mirrors ApplyMutation's locking convention.
+func (s *PostgresStore) DeleteConflictChecked(ctx context.Context, project, key string, precondition *Precondition) error {
+	kind, nameOrID, ok := SplitKey(key)
+	if !ok {
+		return ErrInvalidKey
+	}
+
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	row := tx.QueryRow(ctx, `
+		SELECT `+entityCols+` FROM jc_datastore_entities
+		WHERE project=$1 AND kind=$2 AND name_or_id=$3 FOR UPDATE
+	`, project, kind, nameOrID)
+	current, err := scanEntity(row.Scan)
+	exists := true
+	if errors.Is(err, pgx.ErrNoRows) {
+		exists = false
+	} else if err != nil {
+		return err
+	}
+
+	if !preconditionMatches(current, exists, precondition) {
+		return ErrConflict
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM jc_datastore_entities WHERE project=$1 AND kind=$2 AND name_or_id=$3`, project, kind, nameOrID); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 func (s *PostgresStore) ListKind(ctx context.Context, project, kind string) ([]Entity, error) {

--- a/internal/gcp/store/datastore/store.go
+++ b/internal/gcp/store/datastore/store.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Sentinel errors returned by the store, mapped to gRPC status codes by the
@@ -17,6 +18,13 @@ var (
 	ErrEntityNotFound = errors.New("EntityNotFound")
 	ErrEntityExists   = errors.New("EntityExists")
 	ErrInvalidKey     = errors.New("InvalidKey")
+	// ErrConflict is returned by ApplyMutation/DeleteConflictChecked when a
+	// caller-supplied Precondition doesn't match the entity's current state.
+	// The mutation was NOT applied. This maps to a real Datastore Mutation's
+	// per-mutation conflict_detection_strategy outcome (MutationResult.
+	// conflict_detected=true) rather than aborting the whole Commit — see
+	// ApplyMutation's doc comment.
+	ErrConflict = errors.New("Conflict")
 )
 
 // GeoPoint is a Datastore geo_point_value ({latitude, longitude}).
@@ -53,10 +61,34 @@ type Value struct {
 // for kind-scoped queries). Key is the stable canonical key string
 // "kind/id-or-name" (see KeyOfID/KeyOfName); the store's primary key is
 // (project, Key). Properties is the property map keyed by property name.
+// Version and UpdateTime are server-managed bookkeeping used only by
+// ApplyMutation/DeleteConflictChecked's optimistic-concurrency check — a
+// caller constructing an Entity for Insert/Update/Upsert/ApplyMutation does
+// not set these; the store stamps them on write.
 type Entity struct {
 	Kind       string           `json:"kind"`
 	Key        string           `json:"key"`
 	Properties map[string]Value `json:"properties"`
+	Version    int64            `json:"version,omitempty"`
+	UpdateTime time.Time        `json:"updateTime,omitempty"`
+}
+
+// MutationKind identifies which Datastore mutation ApplyMutation applies.
+type MutationKind int
+
+const (
+	MutationInsert MutationKind = iota
+	MutationUpdate
+	MutationUpsert
+)
+
+// Precondition is the optional per-mutation conflict-detection condition from
+// Datastore's real Mutation.conflict_detection_strategy oneof. At most one of
+// BaseVersion/UpdateTime should be set; nil (no Precondition at all) always
+// matches.
+type Precondition struct {
+	BaseVersion *int64
+	UpdateTime  *time.Time
 }
 
 // Store is the Cloud Datastore entity data-plane store. Entities are
@@ -72,6 +104,38 @@ type Store interface {
 	Update(ctx context.Context, project string, e Entity) error
 	// Delete removes the entity at key. Idempotent.
 	Delete(ctx context.Context, project, key string) error
+
+	// ApplyMutation atomically checks precondition (if non-nil) against the
+	// entity currently stored at e.Key and, if it matches (or precondition is
+	// nil), applies the insert/update/upsert — all under one lock/transaction,
+	// so no concurrent mutation on the same entity can be observed or applied
+	// in between the check and the apply. Version and UpdateTime on e are
+	// ignored (server-managed) and stamped on the returned entity: 1 and
+	// clock.Now() for a successful Insert, current.Version+1 and clock.Now()
+	// for Update/Upsert.
+	//
+	// Returns ErrConflict — without applying the mutation — if precondition
+	// doesn't match. This must NOT be treated as fatal by the caller the way
+	// ErrEntityExists/ErrEntityNotFound are: real Datastore's
+	// conflict_detection_strategy is a per-mutation outcome (marked in that
+	// mutation's MutationResult.conflict_detected), not a reason to abort the
+	// rest of the Commit's other mutations.
+	//
+	// Returns ErrEntityExists for an Insert whose key already exists, or
+	// ErrEntityNotFound for an Update whose key doesn't — exactly as Insert/
+	// Update do — checked precondition-first, so a conflict takes priority
+	// over an existence mismatch when both would apply.
+	ApplyMutation(ctx context.Context, project string, kind MutationKind, e Entity, precondition *Precondition) (Entity, error)
+
+	// DeleteConflictChecked atomically checks precondition (if non-nil)
+	// against the entity currently stored at key and, if it matches (or
+	// precondition is nil), deletes it. Deleting an already-absent entity
+	// with a nil precondition is idempotent (matching Delete); with a
+	// non-nil precondition against an absent entity, only a
+	// Precondition{BaseVersion: &0} conceptually "matches" (real Datastore
+	// treats a missing entity as version 0) — anything else returns
+	// ErrConflict.
+	DeleteConflictChecked(ctx context.Context, project, key string, precondition *Precondition) error
 	// ListKind returns every entity of the given kind in the project, sorted by
 	// key. An empty kind returns every entity in the project.
 	ListKind(ctx context.Context, project, kind string) ([]Entity, error)
@@ -83,6 +147,29 @@ type Store interface {
 	// (numeric) entity.
 	AdvanceIDs(ctx context.Context, project string, max int64) error
 	Reset(ctx context.Context)
+}
+
+// preconditionMatches reports whether p is satisfied by the entity's current
+// state (current, exists). A nil p always matches. Shared by every Store
+// implementation's ApplyMutation/DeleteConflictChecked.
+func preconditionMatches(current Entity, exists bool, p *Precondition) bool {
+	if p == nil {
+		return true
+	}
+	if p.BaseVersion != nil {
+		if !exists {
+			// Real Datastore treats a nonexistent entity as version 0.
+			return *p.BaseVersion == 0
+		}
+		return current.Version == *p.BaseVersion
+	}
+	if p.UpdateTime != nil {
+		if !exists {
+			return false
+		}
+		return current.UpdateTime.Equal(*p.UpdateTime)
+	}
+	return true
 }
 
 // KeyOfID returns the canonical key string for a numeric-ID key:

--- a/internal/gcp/store/migrations/028_datastore_entity_version.sql
+++ b/internal/gcp/store/migrations/028_datastore_entity_version.sql
@@ -1,0 +1,8 @@
+-- 028_datastore_entity_version: entity version + update_time, backing
+-- Datastore's per-mutation optimistic-concurrency conflict detection
+-- (Mutation.conflict_detection_strategy: base_version / update_time). Was
+-- previously untracked entirely, so a client's conditional write was
+-- silently applied unconditionally regardless of whether it actually
+-- matched the server's current entity state.
+ALTER TABLE jc_datastore_entities ADD COLUMN IF NOT EXISTS version BIGINT NOT NULL DEFAULT 1;
+ALTER TABLE jc_datastore_entities ADD COLUMN IF NOT EXISTS update_time TIMESTAMPTZ NOT NULL DEFAULT now();

--- a/internal/gcp/storeutil/atomic.go
+++ b/internal/gcp/storeutil/atomic.go
@@ -1,0 +1,54 @@
+// Package storeutil provides the shared atomic read-modify-write primitive
+// GCP memory stores use for their Update/Patch-style methods.
+//
+// An adversarial review across the GCP providers (storage, secretmanager,
+// datastore, functions, workflows, dataproc, bigquery, managedkafka,
+// monitoring, and the shared IAM-policy helper) found the same bug shape
+// repeated in nearly every Update/Patch handler: Get() the current value,
+// merge request fields into it in Go, then a SEPARATE, later Update() call
+// writes the result — with no atomicity between the two. A second writer
+// racing in between is silently overwritten (a lost update), and in at
+// least one case (Secret Manager) this corrupted an internally-managed
+// counter, not just a client-visible field. This mirrors the Firestore
+// lost-update race fixed earlier by routing PatchDocument/buildUpdate
+// through store.Commit's atomic read-set validation — this package
+// generalizes that fix into one reusable primitive instead of hand-rolling
+// it per store.
+//
+// AtomicUpdate is for in-memory stores (sync.RWMutex-guarded maps). Postgres
+// stores need the equivalent guarantee too, but SQL specifics (table/column
+// names) don't generalize into shared Go code the same way; the convention
+// there is a Serializable-isolation transaction with `SELECT ... FOR UPDATE`
+// on every row the mutation reads or writes, mirroring
+// internal/gcp/store/firestore/postgres.go's Commit — see that file for the
+// reference shape when adding this to a Postgres store.
+package storeutil
+
+import "sync"
+
+// AtomicUpdate holds mu for the entire read-mutate-write sequence: get()
+// reads the current value (and whether it exists), mutate computes the new
+// value from it (or returns an error to abort without writing — a
+// validation failure, a not-found condition, or a client-supplied
+// precondition mismatch), and set() persists the result. Holding one lock
+// across all three closes the race the Get-then-separate-Update pattern
+// leaves open: no other Get/Create/Update/Delete guarded by the same mu can
+// be observed or applied in the middle of this sequence.
+//
+// Keep get, mutate, and set fast and allocation-light — no I/O, no
+// acquiring any other lock — since mu is held for their combined duration.
+// On a mutate error, set is never called and the zero value of T is
+// returned alongside the error.
+func AtomicUpdate[T any](mu *sync.RWMutex, get func() (T, bool), mutate func(current T, exists bool) (T, error), set func(T)) (T, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	current, exists := get()
+	next, err := mutate(current, exists)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	set(next)
+	return next, nil
+}

--- a/internal/gcp/storeutil/atomic_test.go
+++ b/internal/gcp/storeutil/atomic_test.go
@@ -1,0 +1,109 @@
+package storeutil
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestAtomicUpdate_CreatesWhenAbsent(t *testing.T) {
+	var mu sync.RWMutex
+	store := map[string]int{}
+
+	got, err := AtomicUpdate(&mu,
+		func() (int, bool) { v, ok := store["k"]; return v, ok },
+		func(current int, exists bool) (int, error) {
+			if exists {
+				t.Fatalf("expected exists=false for a fresh key")
+			}
+			return 1, nil
+		},
+		func(v int) { store["k"] = v },
+	)
+	if err != nil {
+		t.Fatalf("AtomicUpdate: %v", err)
+	}
+	if got != 1 || store["k"] != 1 {
+		t.Fatalf("got=%d store=%d, want 1/1", got, store["k"])
+	}
+}
+
+func TestAtomicUpdate_MergesExisting(t *testing.T) {
+	var mu sync.RWMutex
+	store := map[string]int{"k": 10}
+
+	got, err := AtomicUpdate(&mu,
+		func() (int, bool) { v, ok := store["k"]; return v, ok },
+		func(current int, exists bool) (int, error) {
+			if !exists || current != 10 {
+				t.Fatalf("expected exists=true current=10, got exists=%v current=%d", exists, current)
+			}
+			return current + 5, nil
+		},
+		func(v int) { store["k"] = v },
+	)
+	if err != nil {
+		t.Fatalf("AtomicUpdate: %v", err)
+	}
+	if got != 15 || store["k"] != 15 {
+		t.Fatalf("got=%d store=%d, want 15/15", got, store["k"])
+	}
+}
+
+func TestAtomicUpdate_MutateErrorDoesNotWrite(t *testing.T) {
+	var mu sync.RWMutex
+	store := map[string]int{"k": 10}
+	sentinel := errors.New("nope")
+	setCalled := false
+
+	_, err := AtomicUpdate(&mu,
+		func() (int, bool) { v, ok := store["k"]; return v, ok },
+		func(current int, exists bool) (int, error) { return 0, sentinel },
+		func(v int) { setCalled = true; store["k"] = v },
+	)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+	if setCalled {
+		t.Fatal("set must not be called when mutate returns an error")
+	}
+	if store["k"] != 10 {
+		t.Fatalf("store must be untouched on error, got %d", store["k"])
+	}
+}
+
+// TestAtomicUpdate_NoLostUpdatesUnderConcurrency is the actual regression
+// this primitive exists to fix: many goroutines each doing a
+// read-then-increment-then-write on the SAME key must never lose an update.
+// Run with -race; a data race here would also indicate the lock isn't doing
+// its job.
+func TestAtomicUpdate_NoLostUpdatesUnderConcurrency(t *testing.T) {
+	var mu sync.RWMutex
+	store := map[string]int{"k": 0}
+
+	const goroutines = 50
+	const incrementsEach = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < incrementsEach; j++ {
+				if _, err := AtomicUpdate(&mu,
+					func() (int, bool) { v, ok := store["k"]; return v, ok },
+					func(current int, exists bool) (int, error) { return current + 1, nil },
+					func(v int) { store["k"] = v },
+				); err != nil {
+					t.Errorf("AtomicUpdate: %v", err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	want := goroutines * incrementsEach
+	if store["k"] != want {
+		t.Fatalf("final count = %d, want %d (a mismatch means a lost update slipped through)", store["k"], want)
+	}
+}


### PR DESCRIPTION
## Summary

Third PR in the OCC-fix series (the shared `storeutil.AtomicUpdate` primitive is #44, Secret Manager's version-counter fix is #45 — both already merged into `gcp`; this PR now targets `gcp` directly). Second-highest-priority finding from the adversarial OCC review, and the cleanest one to identify: a real, documented Datastore v1 proto field, decoded off the wire and never read, not an inferred gap.

**Mechanism.** `Commit` hardcoded every `MutationResult.Version` to `1` and never called `Mutation.GetConflictDetectionStrategy()` (the `base_version`/`update_time` oneof — real Datastore's per-mutation optimistic-concurrency precondition). A client's conditional write — "apply this mutation only if the entity is still at the version I last read" — was silently applied unconditionally, with `MutationResult.conflict_detected` never set.

Unlike Firestore's atomic all-or-nothing `Commit`, real Datastore's conflict detection is **per-mutation**: *"Conflicting mutations are not applied, and are marked as such in MutationResult"* (the proto's own doc comment) — other mutations in the same `Commit` call are unaffected. The fix preserves that: a conflicting mutation sets `ConflictDetected=true` and is skipped; the rest of the batch still applies.

## Fix

Entities had no version or update-time tracking at all before this, so implementing the check required adding it:

- `Entity` gained `Version` (int64) and `UpdateTime` fields, stamped by the store on every successful write (1 on insert, `current+1` on update/upsert) — server-managed, not something a caller sets.
- New migration `028` adds the `version`/`update_time` columns to `jc_datastore_entities` (`DEFAULT 1` / `now()`, so existing rows are unaffected).
- New `Store` methods `ApplyMutation` and `DeleteConflictChecked` atomically check an optional `Precondition{BaseVersion, UpdateTime}` against the entity's current state and apply-or-reject as one operation — `MemoryStore` via `storeutil.AtomicUpdate`, `PostgresStore` via a `Serializable` transaction with `SELECT ... FOR UPDATE`, mirroring `store/firestore/postgres.go`'s `Commit`. Both return the entity's actual current state (not a zero value) on `ErrConflict`, since real Datastore's `MutationResult.version` after a rejected mutation is the version that caused the rejection — useful for a client's retry.
- `Lookup` and `RunQuery`'s `EntityResult.Version` now report the real tracked version instead of a hardcoded `1` — otherwise a client reading an entity to determine its `base_version` for a later conditional write would always get a lie.
- The old `Insert`/`Update`/`Upsert`/`Delete` methods are unchanged (still used by existing tests); `Commit` now calls `ApplyMutation`/`DeleteConflictChecked` exclusively, since it was already their only production caller.

## Test plan

- [x] **Verified the fix has teeth**: temporarily reverted `mutationPrecondition` to always return `nil` (simulating the original bug) and confirmed the new regression tests fail exactly as expected, then restored the fix and confirmed they pass.
- [x] `TestCommitBaseVersionConflictRejected` — a stale `base_version` is rejected (`ConflictDetected=true`), the entity is unchanged.
- [x] `TestCommitBaseVersionMatchSucceeds` — a matching `base_version` applies normally.
- [x] `TestCommitPartialConflictDoesNotAbortOtherMutations` — a conflicting mutation doesn't block other mutations in the same `Commit`.
- [x] `TestLookupReturnsRealVersion` — version increments correctly across insert→update.
- [x] `TestMemoryStoreApplyMutation` / `TestMemoryStoreDeleteConflictChecked` — direct store-level coverage.
- [x] All existing Datastore tests (REST/store/gRPC) pass unchanged.
- [x] `-race` clean throughout; all new tests run 5x stable.
- [x] Full `internal/gcp` suite (44 packages) and full repo build — clean.
- [x] Isolation boundary re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)