### PR TITLE
fix(gcp/storage): enforce ifGenerationMatch/ifMetagenerationMatch

### DIFF
--- a/internal/gcp/grpc/storage/service.go
+++ b/internal/gcp/grpc/storage/service.go
@@ -491,7 +491,13 @@ func (s *Service) DeleteObject(ctx context.Context, req *storagepb.DeleteObjectR
 		return nil, mapError(err)
 	}
 
-	if err := s.provider.DeleteObjectData(ctx, bucket, object); err != nil {
+	// precondition: nil — checkObjectPreconditions above already validated
+	// the request's preconditions against a separately-fetched read. That
+	// check-then-write isn't atomic the way the REST path's is (see
+	// storage.DeleteObjectData's *Checked call) — a real but narrower,
+	// pre-existing gap, left as a follow-up rather than duplicating the
+	// check here.
+	if err := s.provider.DeleteObjectData(ctx, bucket, object, nil); err != nil {
 		return nil, mapError(err)
 	}
 	return &emptypb.Empty{}, nil
@@ -621,7 +627,10 @@ func (s *Service) ComposeObject(ctx context.Context, req *storagepb.ComposeObjec
 	meta := protoResourceToMeta(dest, bucket, object, s.provider.NextGen(), now)
 	meta.ComponentCount = int64(len(sources))
 
-	finalMeta, err := s.provider.PutObjectData(ctx, project, meta, buf.Bytes(), versioned, priorBlobKey, false, meta.KmsKeyName, nil, "")
+	// precondition: nil — this gRPC path doesn't yet parse
+	// WriteObjectSpec.if_generation_match/if_metageneration_match; the REST
+	// ObjectsInsert/ObjectsRewrite path does (see storage.objectPrecondition).
+	finalMeta, err := s.provider.PutObjectData(ctx, project, meta, buf.Bytes(), versioned, priorBlobKey, false, meta.KmsKeyName, nil, "", nil)
 	if err != nil {
 		return nil, mapError(err)
 	}
@@ -728,7 +737,7 @@ func (s *Service) finalize(ctx context.Context, project string, sess *uploadSess
 	if meta.ContentType == "" {
 		meta.ContentType = "application/octet-stream"
 	}
-	finalMeta, err := s.provider.PutObjectData(ctx, project, meta, sess.buf, versioned, priorBlobKey, true, sess.kmsKeyName, sess.cseKey, sess.cseKeySHA256)
+	finalMeta, err := s.provider.PutObjectData(ctx, project, meta, sess.buf, versioned, priorBlobKey, true, sess.kmsKeyName, sess.cseKey, sess.cseKeySHA256, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gcp/provider/storage/precondition_test.go
+++ b/internal/gcp/provider/storage/precondition_test.go
@@ -1,0 +1,199 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"jaiscloud/internal/gcp/wire"
+	"jaiscloud/internal/model"
+)
+
+func assertPrecondition412(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a PreconditionFailed error, got nil")
+	}
+	perr, ok := err.(*model.ProviderError)
+	if !ok || perr.HTTPStatus != 412 {
+		t.Fatalf("expected HTTP 412, got %v", err)
+	}
+}
+
+// TestObjectsInsert_IfGenerationMatchZero_CreateOnlyIfAbsent verifies GCS's
+// most common conditional-write idiom: ifGenerationMatch=0 means "only
+// create if no live object currently exists at this name" — used for
+// GCS-based locks/idempotent-create. Before this fix, the codec decoded the
+// query param into nr.Params but the provider never read it, so this
+// precondition was silently ignored and every insert always "succeeded"
+// regardless of whether the object already existed.
+func TestObjectsInsert_IfGenerationMatchZero_CreateOnlyIfAbsent(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+
+	insert := func(data string) (*model.ProviderResponse, error) {
+		nr := bucketParamsWithObj("bkt", "obj.txt")
+		nr.Params[wire.MediaKey] = []byte(data)
+		nr.Params["ifGenerationMatch"] = "0"
+		return p.ObjectsInsert(ctx, nr)
+	}
+
+	// First insert: no live object exists, ifGenerationMatch=0 matches (0
+	// live generations) — must succeed.
+	first, err := insert("v1")
+	if err != nil {
+		t.Fatalf("first insert (should succeed, no live object yet): %v", err)
+	}
+	if first.Data["generation"] == "" {
+		t.Fatal("expected a non-empty generation on the created object")
+	}
+
+	// Second insert: a live object now exists, ifGenerationMatch=0 no longer
+	// matches — must be rejected with 412, and the original content must
+	// survive untouched.
+	if _, err := insert("v2-should-not-apply"); err == nil {
+		t.Fatal("expected the second create-only-if-absent insert to fail, got nil error")
+	} else {
+		assertPrecondition412(t, err)
+	}
+
+	getNR := bucketParamsWithObj("bkt", "obj.txt")
+	getResp, err := p.ObjectsGetMedia(ctx, getNR)
+	if err != nil {
+		t.Fatalf("get media: %v", err)
+	}
+	if got := streamBytes(t, getResp); string(got) != "v1" {
+		t.Fatalf("object content = %q, want %q (the rejected second insert must not have applied)", got, "v1")
+	}
+}
+
+// TestObjectsInsert_IfGenerationMatch_StaleGenerationRejected verifies the
+// general (not just =0) case: a client overwriting an object it expects to
+// still be at a specific generation must be rejected if that's no longer
+// true.
+func TestObjectsInsert_IfGenerationMatch_StaleGenerationRejected(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	resp := insertTestObject(t, p, "bkt", "obj.txt", "text/plain", nil)
+	staleGen, _ := resp.Data["generation"].(string)
+	if staleGen == "" {
+		t.Fatal("expected a generation on the inserted object")
+	}
+
+	// A concurrent writer overwrites the object (no precondition), advancing
+	// its generation.
+	overwrite := bucketParamsWithObj("bkt", "obj.txt")
+	overwrite.Params[wire.MediaKey] = []byte("concurrent-write")
+	if _, err := p.ObjectsInsert(ctx, overwrite); err != nil {
+		t.Fatalf("concurrent overwrite: %v", err)
+	}
+
+	// A stale writer, still holding the ORIGINAL generation, attempts a
+	// conditional overwrite. Must be rejected.
+	stale := bucketParamsWithObj("bkt", "obj.txt")
+	stale.Params[wire.MediaKey] = []byte("stale-write-should-not-apply")
+	stale.Params["ifGenerationMatch"] = staleGen
+	if _, err := p.ObjectsInsert(ctx, stale); err == nil {
+		t.Fatal("expected the stale-generation insert to fail, got nil error")
+	} else {
+		assertPrecondition412(t, err)
+	}
+
+	getResp, err := p.ObjectsGetMedia(ctx, bucketParamsWithObj("bkt", "obj.txt"))
+	if err != nil {
+		t.Fatalf("get media: %v", err)
+	}
+	if got := streamBytes(t, getResp); string(got) != "concurrent-write" {
+		t.Fatalf("object content = %q, want %q (the stale write must not have applied)", got, "concurrent-write")
+	}
+}
+
+// TestObjectsPatch_IfMetagenerationMatch verifies the metadata-mutation
+// precondition on objects.patch: a stale metageneration is rejected, a
+// matching one applies.
+func TestObjectsPatch_IfMetagenerationMatch(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	insertResp := insertTestObject(t, p, "bkt", "obj.txt", "text/plain", nil)
+	metagen, _ := insertResp.Data["metageneration"].(string)
+	if metagen == "" {
+		t.Fatal("expected a metageneration on the inserted object")
+	}
+
+	// Stale metageneration: rejected.
+	stale := bucketParamsWithObj("bkt", "obj.txt")
+	stale.Params["ifMetagenerationMatch"] = "999"
+	stale.Params["body"] = map[string]any{"contentType": "application/json"}
+	if _, err := p.ObjectsPatch(ctx, stale); err == nil {
+		t.Fatal("expected a stale metageneration patch to fail, got nil error")
+	} else {
+		assertPrecondition412(t, err)
+	}
+	unchanged, err := p.ObjectsGet(ctx, bucketParamsWithObj("bkt", "obj.txt"))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if unchanged.Data["contentType"] == "application/json" {
+		t.Fatal("the rejected patch must not have applied")
+	}
+
+	// Matching metageneration: applies.
+	match := bucketParamsWithObj("bkt", "obj.txt")
+	match.Params["ifMetagenerationMatch"] = metagen
+	match.Params["body"] = map[string]any{"contentType": "application/json"}
+	resp, err := p.ObjectsPatch(ctx, match)
+	if err != nil {
+		t.Fatalf("matching metageneration patch: %v", err)
+	}
+	if resp.Data["contentType"] != "application/json" {
+		t.Fatalf("expected contentType applied, got %v", resp.Data["contentType"])
+	}
+}
+
+// TestObjectsDelete_IfGenerationMatch verifies the "safe delete" idiom: a
+// delete conditioned on the generation the client last observed must be
+// rejected if the object has since changed, and the object must survive.
+func TestObjectsDelete_IfGenerationMatch(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	resp := insertTestObject(t, p, "bkt", "obj.txt", "text/plain", nil)
+	staleGen, _ := resp.Data["generation"].(string)
+
+	// Object changes underneath the client (overwrite advances generation).
+	overwrite := bucketParamsWithObj("bkt", "obj.txt")
+	overwrite.Params[wire.MediaKey] = []byte("new-content")
+	if _, err := p.ObjectsInsert(ctx, overwrite); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+
+	// Delete conditioned on the stale generation: rejected, object survives.
+	del := bucketParamsWithObj("bkt", "obj.txt")
+	del.Params["ifGenerationMatch"] = staleGen
+	if _, err := p.ObjectsDelete(ctx, del); err == nil {
+		t.Fatal("expected the stale-generation delete to fail, got nil error")
+	} else {
+		assertPrecondition412(t, err)
+	}
+	if _, err := p.ObjectsGet(ctx, bucketParamsWithObj("bkt", "obj.txt")); err != nil {
+		t.Fatalf("object must still exist after a rejected conditional delete, got %v", err)
+	}
+
+	// Delete conditioned on the CURRENT generation: succeeds.
+	current, err := p.ObjectsGet(ctx, bucketParamsWithObj("bkt", "obj.txt"))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	currentGen, _ := current.Data["generation"].(string)
+	del2 := bucketParamsWithObj("bkt", "obj.txt")
+	del2.Params["ifGenerationMatch"] = currentGen
+	if _, err := p.ObjectsDelete(ctx, del2); err != nil {
+		t.Fatalf("delete with correct generation: %v", err)
+	}
+	if _, err := p.ObjectsGet(ctx, bucketParamsWithObj("bkt", "obj.txt")); err == nil {
+		t.Fatal("expected the object to be gone after a matching conditional delete")
+	}
+}

--- a/internal/gcp/provider/storage/storage.go
+++ b/internal/gcp/provider/storage/storage.go
@@ -383,6 +383,50 @@ func BlobKey(bucket, object, generation string) string {
 	return blobKey(bucket, object, generation)
 }
 
+// objectPrecondition parses GCS's real ifGenerationMatch/ifGenerationNotMatch/
+// ifMetagenerationMatch/ifMetagenerationNotMatch query params — the codec's
+// generic queryToParams already copies these into nr.Params as strings, but
+// nothing previously read them, so a client's conditional write (most
+// commonly ifGenerationMatch=0 for "create only if this object doesn't
+// already exist") was silently applied unconditionally. Returns nil when the
+// request carries none of them (the overwhelmingly common case).
+func objectPrecondition(nr *model.NormalizedRequest) *gcs.Precondition {
+	var pre gcs.Precondition
+	set := false
+	if v, ok := parseInt64Param(nr, "ifGenerationMatch"); ok {
+		pre.GenerationMatch = &v
+		set = true
+	}
+	if v, ok := parseInt64Param(nr, "ifGenerationNotMatch"); ok {
+		pre.GenerationNotMatch = &v
+		set = true
+	}
+	if v, ok := parseInt64Param(nr, "ifMetagenerationMatch"); ok {
+		pre.MetagenerationMatch = &v
+		set = true
+	}
+	if v, ok := parseInt64Param(nr, "ifMetagenerationNotMatch"); ok {
+		pre.MetagenerationNotMatch = &v
+		set = true
+	}
+	if !set {
+		return nil
+	}
+	return &pre
+}
+
+func parseInt64Param(nr *model.NormalizedRequest, key string) (int64, bool) {
+	s, ok := nr.Params[key].(string)
+	if !ok || s == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
 // ─── buckets ──────────────────────────────────────────────────────────────────
 
 // bucketToMap converts a bucketMeta into the map stored by the ObjectStore.
@@ -834,8 +878,11 @@ func (p *Provider) writeObjectRaw(ctx context.Context, nr *model.NormalizedReque
 	if err != nil {
 		return o, err
 	}
-	finalMeta, err := p.PutObjectData(ctx, nr.AccountID, toStoreObject(o), raw, versioned, priorBlobKey, md5Enabled, kmsKeyName, cseKey, cseKeySHA256)
+	finalMeta, err := p.PutObjectData(ctx, nr.AccountID, toStoreObject(o), raw, versioned, priorBlobKey, md5Enabled, kmsKeyName, cseKey, cseKeySHA256, objectPrecondition(nr))
 	if err != nil {
+		if errors.Is(err, gcs.ErrPreconditionFailed) {
+			return o, model.NewProviderError("PreconditionFailed", "At least one of the pre-conditions you specified did not hold", 412)
+		}
 		return o, err
 	}
 	return fromStoreObject(finalMeta), nil
@@ -848,7 +895,11 @@ func (p *Provider) writeObjectRaw(ctx context.Context, nr *model.NormalizedReque
 // generation and metadata; checksums/size are computed here and stamped onto
 // the returned metadata. project is the owning project (account scope) used for
 // envelope DEK wrapping.
-func (p *Provider) PutObjectData(ctx context.Context, project string, meta gcs.ObjectMeta, raw []byte, versioned bool, priorBlobKey string, md5Enabled bool, kmsKeyName string, cseKey []byte, cseKeySHA256 string) (gcs.ObjectMeta, error) {
+// precondition is GCS's ifGenerationMatch/ifGenerationNotMatch/
+// ifMetagenerationMatch/ifMetagenerationNotMatch, checked atomically with the
+// metadata write (see gcs.ObjectStore's *Checked methods) — nil for a caller
+// (currently: the gRPC Storage service) that doesn't yet parse one.
+func (p *Provider) PutObjectData(ctx context.Context, project string, meta gcs.ObjectMeta, raw []byte, versioned bool, priorBlobKey string, md5Enabled bool, kmsKeyName string, cseKey []byte, cseKeySHA256 string, precondition *gcs.Precondition) (gcs.ObjectMeta, error) {
 	// Plaintext checksums/size (GCS reports the logical object, not the
 	// ciphertext).
 	if md5Enabled {
@@ -892,9 +943,9 @@ func (p *Provider) PutObjectData(ctx context.Context, project string, meta gcs.O
 	meta.WrappedDEK = wrappedDEK
 	var err error
 	if versioned {
-		err = p.objects.PutObjectGeneration(ctx, meta.Bucket, meta.Name, meta)
+		err = p.objects.PutObjectGenerationChecked(ctx, meta.Bucket, meta.Name, meta, precondition)
 	} else {
-		err = p.objects.PutObjectMeta(ctx, meta.Bucket, meta.Name, meta)
+		err = p.objects.PutObjectMetaChecked(ctx, meta.Bucket, meta.Name, meta, precondition)
 	}
 	if err != nil {
 		// Roll back the just-written blob so a failed metadata write does not
@@ -1410,9 +1461,12 @@ func (p *Provider) ObjectsUpdate(ctx context.Context, nr *model.NormalizedReques
 
 	o.Metageneration = bumpMeta(o.Metageneration)
 	o.Updated = clock.Now().Format(time.RFC3339Nano)
-	if err := p.objects.PutObjectMeta(ctx, bucket, object, toStoreObject(o)); err != nil {
+	if err := p.objects.PutObjectMetaChecked(ctx, bucket, object, toStoreObject(o), objectPrecondition(nr)); err != nil {
 		if errors.Is(err, gcs.ErrNoSuchBucket) {
 			return nil, model.NewProviderError("NotFound", "bucket not found", 404)
+		}
+		if errors.Is(err, gcs.ErrPreconditionFailed) {
+			return nil, model.NewProviderError("PreconditionFailed", "At least one of the pre-conditions you specified did not hold", 412)
 		}
 		return nil, err
 	}
@@ -1448,9 +1502,12 @@ func (p *Provider) ObjectsPatch(ctx context.Context, nr *model.NormalizedRequest
 	}
 	o.Metageneration = bumpMeta(o.Metageneration)
 	o.Updated = clock.Now().Format(time.RFC3339Nano)
-	if err := p.objects.PutObjectMeta(ctx, bucket, object, toStoreObject(o)); err != nil {
+	if err := p.objects.PutObjectMetaChecked(ctx, bucket, object, toStoreObject(o), objectPrecondition(nr)); err != nil {
 		if errors.Is(err, gcs.ErrNoSuchBucket) {
 			return nil, model.NewProviderError("NotFound", "bucket not found", 404)
+		}
+		if errors.Is(err, gcs.ErrPreconditionFailed) {
+			return nil, model.NewProviderError("PreconditionFailed", "At least one of the pre-conditions you specified did not hold", 412)
 		}
 		return nil, err
 	}
@@ -1499,7 +1556,7 @@ func bumpMeta(m string) string {
 func (p *Provider) ObjectsDelete(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
 	bucket, _ := nr.Params["bucket"].(string)
 	object, _ := nr.Params["object"].(string)
-	if err := p.DeleteObjectData(ctx, bucket, object); err != nil {
+	if err := p.DeleteObjectData(ctx, bucket, object, objectPrecondition(nr)); err != nil {
 		return nil, err
 	}
 	return &model.ProviderResponse{HTTPStatus: 204, Data: map[string]any{}}, nil
@@ -1508,10 +1565,17 @@ func (p *Provider) ObjectsDelete(ctx context.Context, nr *model.NormalizedReques
 // DeleteObjectData deletes an object, honoring retention holds and bucket
 // versioning (non-versioned: hard-delete every generation and its bytes;
 // versioned: tombstone the live generation and drop its bytes). Shared by the
-// REST ObjectsDelete and the gRPC DeleteObject.
-func (p *Provider) DeleteObjectData(ctx context.Context, bucket, object string) error {
+// REST ObjectsDelete and the gRPC DeleteObject. precondition is GCS's
+// ifGenerationMatch/ifGenerationNotMatch (the common "safe delete" idiom —
+// only delete if the object is still at the generation I last observed),
+// checked atomically with the delete; nil for a caller (currently: the gRPC
+// Storage service) that doesn't yet parse one.
+func (p *Provider) DeleteObjectData(ctx context.Context, bucket, object string, precondition *gcs.Precondition) error {
 	// Retention check first: a held or retention-active object cannot be
-	// deleted (GCS returns PERMISSION_DENIED).
+	// deleted (GCS returns PERMISSION_DENIED). Note this GetObjectMeta read is
+	// separate from the precondition check inside the *Checked delete call
+	// below — a hold added/removed in between is a pre-existing, narrower race
+	// unrelated to (and not widened by) the precondition fix here.
 	meta, err := p.objects.GetObjectMeta(ctx, bucket, object)
 	if err != nil {
 		if errors.Is(err, gcs.ErrNoSuchObject) {
@@ -1526,9 +1590,12 @@ func (p *Provider) DeleteObjectData(ctx context.Context, bucket, object string) 
 	if p.bucketVersioned(ctx, bucket) {
 		// Versioned bucket: delete only the live generation, leaving a
 		// non-live tombstone that appears in ?versions=true listings.
-		if _, err := p.objects.TombstoneObjectMeta(ctx, bucket, object); err != nil {
+		if _, err := p.objects.TombstoneObjectMetaChecked(ctx, bucket, object, precondition); err != nil {
 			if errors.Is(err, gcs.ErrNoSuchObject) {
 				return model.NewProviderError("NotFound", "object not found", 404)
+			}
+			if errors.Is(err, gcs.ErrPreconditionFailed) {
+				return model.NewProviderError("PreconditionFailed", "At least one of the pre-conditions you specified did not hold", 412)
 			}
 			return err
 		}
@@ -1546,9 +1613,12 @@ func (p *Provider) DeleteObjectData(ctx context.Context, bucket, object string) 
 			}
 		}
 	}
-	if err := p.objects.DeleteObjectMeta(ctx, bucket, object); err != nil {
+	if err := p.objects.DeleteObjectMetaChecked(ctx, bucket, object, precondition); err != nil {
 		if errors.Is(err, gcs.ErrNoSuchObject) {
 			return model.NewProviderError("NotFound", "object not found", 404)
+		}
+		if errors.Is(err, gcs.ErrPreconditionFailed) {
+			return model.NewProviderError("PreconditionFailed", "At least one of the pre-conditions you specified did not hold", 412)
 		}
 		return err
 	}

--- a/internal/gcp/store/gcs/memory.go
+++ b/internal/gcp/store/gcs/memory.go
@@ -154,6 +154,102 @@ func (s *MemoryObjectStore) PutObjectGeneration(_ context.Context, bucket, name 
 	return nil
 }
 
+func (s *MemoryObjectStore) PutObjectMetaChecked(_ context.Context, bucket, name string, meta ObjectMeta, precondition *Precondition) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.buckets[bucket]; !ok {
+		return ErrNoSuchBucket
+	}
+	current, exists := liveGeneration(s.objects[bucket][name])
+	if !objectPreconditionMatches(current, exists, precondition) {
+		return ErrPreconditionFailed
+	}
+	meta.Bucket = bucket
+	meta.Name = name
+	normalizeMeta(&meta)
+	if s.objects[bucket] == nil {
+		s.objects[bucket] = make(map[string][]ObjectMeta)
+	}
+	s.objects[bucket][name] = []ObjectMeta{meta}
+	return nil
+}
+
+func (s *MemoryObjectStore) PutObjectGenerationChecked(_ context.Context, bucket, name string, meta ObjectMeta, precondition *Precondition) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.buckets[bucket]; !ok {
+		return ErrNoSuchBucket
+	}
+	current, exists := liveGeneration(s.objects[bucket][name])
+	if !objectPreconditionMatches(current, exists, precondition) {
+		return ErrPreconditionFailed
+	}
+	meta.Bucket = bucket
+	meta.Name = name
+	normalizeMeta(&meta)
+	if s.objects[bucket] == nil {
+		s.objects[bucket] = make(map[string][]ObjectMeta)
+	}
+	gens := s.objects[bucket][name]
+	now := clock.Now()
+	for i := range gens {
+		if gens[i].TimeDeleted == nil {
+			t := now
+			gens[i].TimeDeleted = &t
+		}
+	}
+	s.objects[bucket][name] = append(gens, meta)
+	return nil
+}
+
+func (s *MemoryObjectStore) DeleteObjectMetaChecked(_ context.Context, bucket, name string, precondition *Precondition) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	objs, ok := s.objects[bucket]
+	if !ok {
+		return ErrNoSuchObject
+	}
+	gens, ok := objs[name]
+	if !ok {
+		return ErrNoSuchObject
+	}
+	current, exists := liveGeneration(gens)
+	if !objectPreconditionMatches(current, exists, precondition) {
+		return ErrPreconditionFailed
+	}
+	delete(objs, name)
+	return nil
+}
+
+func (s *MemoryObjectStore) TombstoneObjectMetaChecked(_ context.Context, bucket, name string, precondition *Precondition) (ObjectMeta, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	objs, ok := s.objects[bucket]
+	if !ok {
+		return ObjectMeta{}, ErrNoSuchObject
+	}
+	gens, ok := objs[name]
+	if !ok {
+		return ObjectMeta{}, ErrNoSuchObject
+	}
+	current, exists := liveGeneration(gens)
+	if !exists {
+		return ObjectMeta{}, ErrNoSuchObject
+	}
+	if !objectPreconditionMatches(current, exists, precondition) {
+		return ObjectMeta{}, ErrPreconditionFailed
+	}
+	for i := len(gens) - 1; i >= 0; i-- {
+		if gens[i].TimeDeleted == nil {
+			now := clock.Now()
+			gens[i].TimeDeleted = &now
+			objs[name] = gens
+			return gens[i], nil
+		}
+	}
+	return ObjectMeta{}, ErrNoSuchObject
+}
+
 func (s *MemoryObjectStore) GetObjectMeta(_ context.Context, bucket, name string) (ObjectMeta, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/gcp/store/gcs/memory_test.go
+++ b/internal/gcp/store/gcs/memory_test.go
@@ -97,3 +97,72 @@ func TestMemoryObjectStoreRoundTrip(t *testing.T) {
 		t.Fatalf("expected ErrNoSuchBucket after reset, got %v", err)
 	}
 }
+
+func TestMemoryObjectStorePutObjectMetaChecked(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryObjectStore()
+	if err := s.CreateBucket(ctx, "proj", "bkt", nil); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+
+	// ifGenerationMatch=0 ("create only if absent") succeeds when no live
+	// object exists yet.
+	zero := int64(0)
+	o1 := ObjectMeta{Generation: "1", ContentType: "text/plain", TimeCreated: time.Now(), Updated: time.Now()}
+	if err := s.PutObjectMetaChecked(ctx, "bkt", "a.txt", o1, &Precondition{GenerationMatch: &zero}); err != nil {
+		t.Fatalf("create-if-absent: %v", err)
+	}
+
+	// The same precondition now fails: a live object exists.
+	o2 := ObjectMeta{Generation: "2", ContentType: "text/plain", TimeCreated: time.Now(), Updated: time.Now()}
+	if err := s.PutObjectMetaChecked(ctx, "bkt", "a.txt", o2, &Precondition{GenerationMatch: &zero}); !errors.Is(err, ErrPreconditionFailed) {
+		t.Fatalf("expected ErrPreconditionFailed, got %v", err)
+	}
+	current, err := s.GetObjectMeta(ctx, "bkt", "a.txt")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if current.Generation != "1" {
+		t.Fatalf("generation = %q after a rejected write, want 1 (unchanged)", current.Generation)
+	}
+
+	// A matching generation precondition succeeds.
+	one := int64(1)
+	if err := s.PutObjectMetaChecked(ctx, "bkt", "a.txt", o2, &Precondition{GenerationMatch: &one}); err != nil {
+		t.Fatalf("matching generation write: %v", err)
+	}
+	current, _ = s.GetObjectMeta(ctx, "bkt", "a.txt")
+	if current.Generation != "2" {
+		t.Fatalf("generation = %q after a matching write, want 2", current.Generation)
+	}
+}
+
+func TestMemoryObjectStoreDeleteObjectMetaChecked(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryObjectStore()
+	if err := s.CreateBucket(ctx, "proj", "bkt", nil); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	o := ObjectMeta{Generation: "1", ContentType: "text/plain", TimeCreated: time.Now(), Updated: time.Now()}
+	if err := s.PutObjectMeta(ctx, "bkt", "a.txt", o); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	// Stale generation precondition: rejected, object survives.
+	stale := int64(999)
+	if err := s.DeleteObjectMetaChecked(ctx, "bkt", "a.txt", &Precondition{GenerationMatch: &stale}); !errors.Is(err, ErrPreconditionFailed) {
+		t.Fatalf("expected ErrPreconditionFailed, got %v", err)
+	}
+	if _, err := s.GetObjectMeta(ctx, "bkt", "a.txt"); err != nil {
+		t.Fatalf("object must still exist after a rejected conditional delete, got %v", err)
+	}
+
+	// Correct generation precondition: deletes.
+	correct := int64(1)
+	if err := s.DeleteObjectMetaChecked(ctx, "bkt", "a.txt", &Precondition{GenerationMatch: &correct}); err != nil {
+		t.Fatalf("delete with correct generation: %v", err)
+	}
+	if _, err := s.GetObjectMeta(ctx, "bkt", "a.txt"); !errors.Is(err, ErrNoSuchObject) {
+		t.Fatalf("expected ErrNoSuchObject after delete, got %v", err)
+	}
+}

--- a/internal/gcp/store/gcs/postgres.go
+++ b/internal/gcp/store/gcs/postgres.go
@@ -250,6 +250,142 @@ func nullableTimePtr(t *time.Time) pgtype.Timestamptz {
 	return nullableTime(t)
 }
 
+// lockLiveGeneration reads (and, via FOR UPDATE, row-locks) the object's
+// current live generation within tx, returning (ObjectMeta{}, false, nil)
+// when none exists. Shared by every *Checked method below so the
+// precondition check and the write happen inside one Serializable
+// transaction — mirroring store/firestore/postgres.go's Commit.
+func lockLiveGeneration(ctx context.Context, tx pgx.Tx, bucket, name string) (ObjectMeta, bool, error) {
+	row := tx.QueryRow(ctx, `
+		SELECT `+objectCols+`
+		FROM jc_gcs_objects WHERE bucket=$1 AND name=$2 AND time_deleted IS NULL
+		ORDER BY generation::bigint DESC LIMIT 1
+		FOR UPDATE
+	`, bucket, name)
+	m, err := scanObject(row.Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ObjectMeta{}, false, nil
+	}
+	if err != nil {
+		return ObjectMeta{}, false, err
+	}
+	return m, true, nil
+}
+
+func (s *PostgresObjectStore) PutObjectMetaChecked(ctx context.Context, bucket, name string, meta ObjectMeta, precondition *Precondition) error {
+	meta.Bucket = bucket
+	meta.Name = name
+	normalizeMeta(&meta)
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	if err := ensureBucketExists(ctx, tx, bucket); err != nil {
+		return err
+	}
+	current, exists, err := lockLiveGeneration(ctx, tx, bucket, name)
+	if err != nil {
+		return err
+	}
+	if !objectPreconditionMatches(current, exists, precondition) {
+		return ErrPreconditionFailed
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM jc_gcs_objects WHERE bucket=$1 AND name=$2`, bucket, name); err != nil {
+		return err
+	}
+	if err := insertObjectGeneration(ctx, tx, meta); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *PostgresObjectStore) PutObjectGenerationChecked(ctx context.Context, bucket, name string, meta ObjectMeta, precondition *Precondition) error {
+	meta.Bucket = bucket
+	meta.Name = name
+	normalizeMeta(&meta)
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	if err := ensureBucketExists(ctx, tx, bucket); err != nil {
+		return err
+	}
+	current, exists, err := lockLiveGeneration(ctx, tx, bucket, name)
+	if err != nil {
+		return err
+	}
+	if !objectPreconditionMatches(current, exists, precondition) {
+		return ErrPreconditionFailed
+	}
+	now := clock.Now()
+	if _, err := tx.Exec(ctx, `
+		UPDATE jc_gcs_objects SET time_deleted=$3 WHERE bucket=$1 AND name=$2 AND time_deleted IS NULL
+	`, bucket, name, now); err != nil {
+		return err
+	}
+	if err := insertObjectGeneration(ctx, tx, meta); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *PostgresObjectStore) DeleteObjectMetaChecked(ctx context.Context, bucket, name string, precondition *Precondition) error {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	current, exists, err := lockLiveGeneration(ctx, tx, bucket, name)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return ErrNoSuchObject
+	}
+	if !objectPreconditionMatches(current, exists, precondition) {
+		return ErrPreconditionFailed
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM jc_gcs_objects WHERE bucket=$1 AND name=$2`, bucket, name); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *PostgresObjectStore) TombstoneObjectMetaChecked(ctx context.Context, bucket, name string, precondition *Precondition) (ObjectMeta, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return ObjectMeta{}, err
+	}
+	defer tx.Rollback(ctx)
+	m, exists, err := lockLiveGeneration(ctx, tx, bucket, name)
+	if err != nil {
+		return ObjectMeta{}, err
+	}
+	if !exists {
+		return ObjectMeta{}, ErrNoSuchObject
+	}
+	if !objectPreconditionMatches(m, exists, precondition) {
+		return ObjectMeta{}, ErrPreconditionFailed
+	}
+	now := clock.Now()
+	tag, err := tx.Exec(ctx, `
+		UPDATE jc_gcs_objects SET time_deleted=$3 WHERE bucket=$1 AND name=$2 AND generation=$4
+	`, bucket, name, now, m.Generation)
+	if err != nil {
+		return ObjectMeta{}, err
+	}
+	if tag.RowsAffected() == 0 {
+		return ObjectMeta{}, ErrNoSuchObject
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ObjectMeta{}, err
+	}
+	m.TimeDeleted = &now
+	return m, nil
+}
+
 func (s *PostgresObjectStore) GetObjectMeta(ctx context.Context, bucket, name string) (ObjectMeta, error) {
 	row := s.pool.QueryRow(ctx, `
 		SELECT `+objectCols+`

--- a/internal/gcp/store/gcs/store.go
+++ b/internal/gcp/store/gcs/store.go
@@ -7,6 +7,7 @@ package gcs
 import (
 	"context"
 	"errors"
+	"strconv"
 	"time"
 
 	"jaiscloud/internal/clock"
@@ -20,7 +21,67 @@ var (
 	ErrNoSuchUpload   = errors.New("NoSuchUpload")
 	ErrBucketNotEmpty = errors.New("BucketNotEmpty")
 	ErrAlreadyExists  = errors.New("AlreadyExists")
+	// ErrPreconditionFailed is returned by the *Checked object-write methods
+	// when a Precondition doesn't match the object's current live-generation
+	// state. The write was NOT applied — real GCS's ifGenerationMatch/
+	// ifGenerationNotMatch/ifMetagenerationMatch/ifMetagenerationNotMatch
+	// query params, which the codec already decodes into request params but
+	// which nothing previously read or enforced.
+	ErrPreconditionFailed = errors.New("PreconditionFailed")
 )
+
+// Precondition is GCS's real per-request conditional-write precondition:
+// ifGenerationMatch / ifGenerationNotMatch / ifMetagenerationMatch /
+// ifMetagenerationNotMatch. A nil field means that condition wasn't
+// specified — nil Precondition entirely (or nil the *Checked call is given)
+// always matches, same as no precondition at all. A GenerationMatch of 0
+// means "no live generation currently exists" — GCS's standard
+// create-only-if-absent idiom.
+type Precondition struct {
+	GenerationMatch        *int64
+	GenerationNotMatch     *int64
+	MetagenerationMatch    *int64
+	MetagenerationNotMatch *int64
+}
+
+// objectPreconditionMatches reports whether p is satisfied by the object's
+// current live-generation state (current, exists). A nil p always matches.
+func objectPreconditionMatches(current ObjectMeta, exists bool, p *Precondition) bool {
+	if p == nil {
+		return true
+	}
+	var gen, metagen int64
+	if exists {
+		gen, _ = strconv.ParseInt(current.Generation, 10, 64)
+		metagen, _ = strconv.ParseInt(current.Metageneration, 10, 64)
+	}
+	if p.GenerationMatch != nil {
+		if !exists {
+			if *p.GenerationMatch != 0 {
+				return false
+			}
+		} else if gen != *p.GenerationMatch {
+			return false
+		}
+	}
+	if p.GenerationNotMatch != nil {
+		if !exists {
+			// NotMatch against 0 means "must already exist".
+			if *p.GenerationNotMatch == 0 {
+				return false
+			}
+		} else if gen == *p.GenerationNotMatch {
+			return false
+		}
+	}
+	if p.MetagenerationMatch != nil && (!exists || metagen != *p.MetagenerationMatch) {
+		return false
+	}
+	if p.MetagenerationNotMatch != nil && exists && metagen == *p.MetagenerationNotMatch {
+		return false
+	}
+	return true
+}
 
 // ObjectRetention is the GCS Object.retention object ({retainUntilTime, mode}).
 // mode is "Unlocked" or "Locked".
@@ -110,6 +171,17 @@ type ObjectStore interface {
 	// and returns it, leaving any prior non-live generations untouched. Used
 	// for versioned-object deletion so a non-live tombstone is retained.
 	TombstoneObjectMeta(ctx context.Context, bucket, name string) (ObjectMeta, error)
+
+	// PutObjectMetaChecked/PutObjectGenerationChecked/DeleteObjectMetaChecked/
+	// TombstoneObjectMetaChecked mirror their unchecked counterparts above,
+	// but atomically validate precondition (if non-nil) against the object's
+	// current live-generation state under the same lock/transaction as the
+	// write, instead of the write applying unconditionally. Returns
+	// ErrPreconditionFailed — without applying the write — on a mismatch.
+	PutObjectMetaChecked(ctx context.Context, bucket, name string, meta ObjectMeta, precondition *Precondition) error
+	PutObjectGenerationChecked(ctx context.Context, bucket, name string, meta ObjectMeta, precondition *Precondition) error
+	DeleteObjectMetaChecked(ctx context.Context, bucket, name string, precondition *Precondition) error
+	TombstoneObjectMetaChecked(ctx context.Context, bucket, name string, precondition *Precondition) (ObjectMeta, error)
 	// ListObjects returns the live generation of every object in the bucket,
 	// sorted by name. Prefix, delimiter, and pageToken pagination are applied
 	// by the provider.


### PR DESCRIPTION
## Summary

Fourth PR in the OCC-fix series (targets \`gcp\` directly — #44 shared primitive, #45 Secret Manager, and #47 Datastore are separate PRs in the same series). This is the finding that started the whole adversarial review: GCS's real \`ifGenerationMatch\`/\`ifGenerationNotMatch\`/\`ifMetagenerationMatch\`/\`ifMetagenerationNotMatch\` preconditions arrive on every request (the codec's generic \`queryToParams\` already copies them into \`nr.Params\`) but nothing in the provider ever read them.

**Impact.** A client's conditional write — most commonly \`ifGenerationMatch=0\`, the standard "create only if this object doesn't already exist" idiom used for GCS-based distributed locks — was silently applied unconditionally, regardless of whether the condition actually held.

## Scope

Scoped to the REST object-mutation surface where \`Generation\`/\`Metageneration\` are already tracked:
- \`ObjectsInsert\` (+ \`ObjectsRewrite\` and resumable-upload completion, which share the same \`writeObjectRaw\`/\`PutObjectData\` choke point) — generation precondition.
- \`ObjectsUpdate\`/\`ObjectsPatch\` — metageneration precondition.
- \`ObjectsDelete\` — generation precondition (the "safe delete" idiom).

**Explicitly deferred, not silently dropped:**
- \`BucketsUpdate\`'s metageneration precondition — bucket metadata has no metageneration counter tracked at all currently; that needs its own addition, not just wiring, so it's out of scope here.
- \`ObjectsCompose\`'s destination preconditions — more niche, multi-source semantics.
- The gRPC Storage v2 service's \`DeleteObject\`/\`UpdateObject\` **already have their own** precondition validation (\`checkObjectPreconditions\`) — discovered while doing this work — but it checks against a separately-fetched read, then a later separate write: the same non-atomic TOCTOU shape this PR closes for REST. Left as a smaller, separate follow-up (route it through the new \`*Checked\` store methods) rather than scope-creeping into this PR, which was about REST's *total absence* of any check.

## Fix

Added four new \`gcs.ObjectStore\` methods — \`PutObjectMetaChecked\`, \`PutObjectGenerationChecked\`, \`DeleteObjectMetaChecked\`, \`TombstoneObjectMetaChecked\` — that atomically validate an optional \`Precondition{GenerationMatch, GenerationNotMatch, MetagenerationMatch, MetagenerationNotMatch}\` against the object's current live-generation state under the same lock/transaction as the write:
- \`MemoryObjectStore\`: one mutex acquisition, reusing the existing \`liveGeneration\` helper.
- \`PostgresObjectStore\`: a \`Serializable\` transaction with \`SELECT ... FOR UPDATE\`, mirroring \`store/firestore/postgres.go\`'s \`Commit\`.

The old unchecked methods are unchanged (the gRPC Storage service's two remaining \`PutObjectData\` call sites — \`WriteObject\`, resumable-upload finalize — don't yet parse this precondition from their own request shape, so they pass \`nil\`).

## Test plan

- [x] **Verified the fix has teeth**: temporarily reverted \`objectPrecondition\` to always return \`nil\` (simulating the original bug) and confirmed all four new regression tests fail exactly as expected, then restored the fix and confirmed they pass.
- [x] \`TestObjectsInsert_IfGenerationMatchZero_CreateOnlyIfAbsent\` — the core \`ifGenerationMatch=0\` idiom: succeeds when absent, rejected (412) once a live object exists, original content survives.
- [x] \`TestObjectsInsert_IfGenerationMatch_StaleGenerationRejected\` — general stale-generation overwrite rejection.
- [x] \`TestObjectsPatch_IfMetagenerationMatch\` — stale metageneration rejected, matching one applies.
- [x] \`TestObjectsDelete_IfGenerationMatch\` — stale-generation delete rejected (object survives), matching-generation delete succeeds.
- [x] \`TestMemoryObjectStorePutObjectMetaChecked\` / \`TestMemoryObjectStoreDeleteObjectMetaChecked\` — direct store-level coverage.
- [x] All existing storage tests (REST/gRPC/store) pass unchanged.
- [x] \`-race\` clean throughout; new tests run 3x stable.
- [x] Full \`internal/gcp\` suite (44 packages) and full repo build — clean.
- [x] Isolation boundary re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)