### PR TITLE
fix(gcp): close lost-update race in shared IAM policy.Set etag OCC

### DIFF
--- a/internal/gcp/policy/policy.go
+++ b/internal/gcp/policy/policy.go
@@ -44,9 +44,18 @@ func Load(ctx context.Context, s store.ResourceStore, account, resourceType, id 
 	return p
 }
 
+// errEtagMismatch aborts Set's UpsertAtomic mutate callback without writing,
+// distinguishing an etag-precondition failure from a genuine storage error.
+var errEtagMismatch = model.NewProviderError("Conflict", "etag mismatch: optimistic concurrency control failed", 409)
+
 // Set stores a policy for a resource, enforcing etag OCC. body is the parsed
 // request JSON — either the Policy fields directly, or wrapped in a "policy"
 // field per SetIamPolicyRequest. Returns the stored policy.
+//
+// The etag check and the write happen inside a single UpsertAtomic call so
+// two concurrent SetIamPolicy requests that both read the same starting etag
+// can't both pass the check and race to overwrite each other — the second to
+// acquire the lock sees the first's already-updated etag and is rejected.
 func Set(ctx context.Context, s store.ResourceStore, account, resourceType, id string, body map[string]any) (Policy, error) {
 	policyBody := body
 	if p, ok := body["policy"].(map[string]any); ok {
@@ -56,16 +65,30 @@ func Set(ctx context.Context, s store.ResourceStore, account, resourceType, id s
 	if bs, ok := policyBody["bindings"].([]any); ok {
 		bindings = bs
 	}
-	existing := Load(ctx, s, account, resourceType, id)
-	if reqEtag, _ := policyBody["etag"].(string); reqEtag != "" && reqEtag != existing.Etag {
-		return Policy{}, model.NewProviderError("Conflict", "etag mismatch: optimistic concurrency control failed", 409)
-	}
+	reqEtag, _ := policyBody["etag"].(string)
+
 	pol := Policy{Version: 1, Etag: EtagFor(bindings), Bindings: bindings}
 	if v, ok := policyBody["version"].(float64); ok {
 		pol.Version = int(v)
 	}
-	data, _ := json.Marshal(pol)
-	_ = s.Upsert(ctx, account, store.GlobalRegion, store.ResourceEntry{Type: resourceType, ID: id, Data: data})
+
+	_, err := s.UpsertAtomic(ctx, account, store.GlobalRegion, resourceType, id, func(current store.ResourceEntry, exists bool) (store.ResourceEntry, error) {
+		existing := Policy{Version: 1, Etag: DefaultEtag, Bindings: []any{}}
+		if exists {
+			json.Unmarshal(current.Data, &existing)
+		}
+		if reqEtag != "" && reqEtag != existing.Etag {
+			return store.ResourceEntry{}, errEtagMismatch
+		}
+		data, _ := json.Marshal(pol)
+		return store.ResourceEntry{Type: resourceType, ID: id, Data: data}, nil
+	})
+	if err != nil {
+		if err == errEtagMismatch {
+			return Policy{}, errEtagMismatch
+		}
+		return Policy{}, err
+	}
 	return pol, nil
 }
 

--- a/internal/gcp/policy/policy_test.go
+++ b/internal/gcp/policy/policy_test.go
@@ -2,6 +2,9 @@ package policy
 
 import (
 	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"jaiscloud/internal/store"
@@ -35,6 +38,66 @@ func TestSetIamPolicyEtagOCC(t *testing.T) {
 	body["policy"].(map[string]any)["etag"] = pol.Etag
 	if _, err := Set(ctx, s, "proj", "gcp_topic_policy", "t1", body); err != nil {
 		t.Fatalf("set with current etag: %v", err)
+	}
+}
+
+// TestSetIamPolicyConcurrentSameEtagOnlyOneWins proves Set's etag check and
+// its write happen atomically. Every goroutine reads the SAME starting etag
+// (as a real client pair racing on the same base policy would) and calls Set
+// with it as the precondition. Only one may succeed: if Load-check-Upsert
+// were not atomic, every goroutine's check would pass against the same
+// pre-race etag before any of them wrote, and all would report success even
+// though only the last physical write survives — a silent lost update.
+func TestSetIamPolicyConcurrentSameEtagOnlyOneWins(t *testing.T) {
+	ctx := context.Background()
+	s := store.NewMemoryResourceStore()
+
+	initial, err := Set(ctx, s, "proj", "gcp_topic_policy", "t1", map[string]any{
+		"policy": map[string]any{"bindings": []any{}},
+	})
+	if err != nil {
+		t.Fatalf("initial set: %v", err)
+	}
+
+	const n = 50
+	var successCount int64
+	var wg sync.WaitGroup
+	results := make([]Policy, n)
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			body := map[string]any{
+				"policy": map[string]any{
+					"etag": initial.Etag,
+					"bindings": []any{map[string]any{
+						"role":    "roles/pubsub.publisher",
+						"members": []any{fmt.Sprintf("user:%d@example.com", i)},
+					}},
+				},
+			}
+			pol, err := Set(ctx, s, "proj", "gcp_topic_policy", "t1", body)
+			results[i] = pol
+			errs[i] = err
+			if err == nil {
+				atomic.AddInt64(&successCount, 1)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if successCount != 1 {
+		t.Fatalf("expected exactly 1 of %d concurrent same-etag Set calls to succeed, got %d", n, successCount)
+	}
+
+	// The stored policy must match the one caller that reported success —
+	// not some other goroutine's overwritten-and-lost bindings.
+	final := Load(ctx, s, "proj", "gcp_topic_policy", "t1")
+	for i, err := range errs {
+		if err == nil && final.Etag != results[i].Etag {
+			t.Fatalf("stored etag %q does not match the reported winner's etag %q", final.Etag, results[i].Etag)
+		}
 	}
 }
 

--- a/internal/resourcemgr/adapter_test.go
+++ b/internal/resourcemgr/adapter_test.go
@@ -49,6 +49,16 @@ func (m *memStore) Upsert(_ context.Context, _, _ string, e store.ResourceEntry)
 	return nil
 }
 
+func (m *memStore) UpsertAtomic(_ context.Context, _, _, t, id string, mutate func(store.ResourceEntry, bool) (store.ResourceEntry, error)) (store.ResourceEntry, error) {
+	current, exists := m.entries[m.key(t, id)]
+	next, err := mutate(current, exists)
+	if err != nil {
+		return store.ResourceEntry{}, err
+	}
+	m.entries[m.key(next.Type, next.ID)] = next
+	return next, nil
+}
+
 func (m *memStore) Delete(_ context.Context, _, _, t, id string) error {
 	delete(m.entries, m.key(t, id))
 	return nil
@@ -219,6 +229,9 @@ func (s *errStore) Update(_ context.Context, _, _ string, _ store.ResourceEntry)
 }
 func (s *errStore) Upsert(_ context.Context, _, _ string, _ store.ResourceEntry) error {
 	return s.err
+}
+func (s *errStore) UpsertAtomic(_ context.Context, _, _, _, _ string, _ func(store.ResourceEntry, bool) (store.ResourceEntry, error)) (store.ResourceEntry, error) {
+	return store.ResourceEntry{}, s.err
 }
 func (s *errStore) Delete(_ context.Context, _, _, _, _ string) error { return s.err }
 func (s *errStore) List(_ context.Context, _, _, _, _ string) ([]store.ResourceEntry, error) {

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -88,6 +88,31 @@ func (s *MemoryResourceStore) Update(ctx context.Context, account, region string
 	return nil
 }
 
+func (s *MemoryResourceStore) UpsertAtomic(ctx context.Context, account, region, resourceType, id string, mutate func(current ResourceEntry, exists bool) (ResourceEntry, error)) (ResourceEntry, error) {
+	if region == "" {
+		return ResourceEntry{}, fmt.Errorf("store: region must not be empty (type=%s id=%s); use store.GlobalRegion for global services", resourceType, id)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := key(account, region, resourceType, id)
+	current, exists := s.entries[k]
+	next, err := mutate(current, exists)
+	if err != nil {
+		return ResourceEntry{}, err
+	}
+	now := clock.Now()
+	if exists {
+		next.CreatedAt = current.CreatedAt
+	} else {
+		next.CreatedAt = now
+	}
+	next.UpdatedAt = now
+	next.Type = resourceType
+	next.ID = id
+	s.entries[k] = next
+	return next, nil
+}
+
 func (s *MemoryResourceStore) Delete(ctx context.Context, account, region, resourceType, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -159,6 +159,99 @@ func (s *PostgresResourceStore) Update(ctx context.Context, account, region stri
 	return nil
 }
 
+// UpsertAtomic mirrors MemoryResourceStore's version: a Serializable
+// transaction with SELECT ... FOR UPDATE row-locks the entry for the
+// duration of mutate, so a concurrent writer on the same key blocks (or, for
+// the narrow case of two concurrent first-writes racing on a not-yet-existing
+// row, is retried) instead of silently overwriting this call's result. See
+// gcp/store/firestore/postgres.go's Commit for the same convention.
+func (s *PostgresResourceStore) UpsertAtomic(ctx context.Context, account, region, resourceType, id string, mutate func(current ResourceEntry, exists bool) (ResourceEntry, error)) (ResourceEntry, error) {
+	if region == "" {
+		return ResourceEntry{}, fmt.Errorf("store: region must not be empty (type=%s id=%s); use store.GlobalRegion for global services", resourceType, id)
+	}
+	const maxAttempts = 5
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		entry, err := s.upsertAtomicOnce(ctx, account, region, resourceType, id, mutate)
+		if err == nil {
+			return entry, nil
+		}
+		if !isSerializationFailure(err) {
+			return ResourceEntry{}, err
+		}
+		lastErr = err
+	}
+	return ResourceEntry{}, lastErr
+}
+
+func (s *PostgresResourceStore) upsertAtomicOnce(ctx context.Context, account, region, resourceType, id string, mutate func(current ResourceEntry, exists bool) (ResourceEntry, error)) (ResourceEntry, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return ResourceEntry{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	var current ResourceEntry
+	var data []byte
+	err = tx.QueryRow(ctx, `
+		SELECT resource_type, id, data, created_at, updated_at, seeded
+		FROM jc_resources
+		WHERE account_id=$1 AND region=$2 AND resource_type=$3 AND id=$4
+		FOR UPDATE
+	`, account, region, resourceType, id).Scan(&current.Type, &current.ID, &data, &current.CreatedAt, &current.UpdatedAt, &current.Seeded)
+	exists := true
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		exists = false
+	case err != nil:
+		return ResourceEntry{}, wrapPgError("UpsertAtomic", err)
+	default:
+		current.Data = json.RawMessage(data)
+	}
+
+	next, err := mutate(current, exists)
+	if err != nil {
+		return ResourceEntry{}, err
+	}
+
+	now := clock.Now()
+	if exists {
+		next.CreatedAt = current.CreatedAt
+	} else {
+		next.CreatedAt = now
+	}
+	next.UpdatedAt = now
+	next.Type = resourceType
+	next.ID = id
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO jc_resources (account_id, region, resource_type, id, data, created_at, updated_at, seeded)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		ON CONFLICT (account_id, region, resource_type, id)
+		DO UPDATE SET data = EXCLUDED.data, updated_at = EXCLUDED.updated_at, seeded = EXCLUDED.seeded
+	`, account, region, resourceType, id, json.RawMessage(next.Data), next.CreatedAt, next.UpdatedAt, next.Seeded)
+	if err != nil {
+		return ResourceEntry{}, wrapPgError("UpsertAtomic", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ResourceEntry{}, wrapPgError("UpsertAtomic commit", err)
+	}
+	return next, nil
+}
+
+// isSerializationFailure returns true when err is a PostgreSQL serialization
+// failure (SQLSTATE 40001 — could not serialize access), which can occur when
+// two UpsertAtomic calls race to create the same not-yet-existing key (no row
+// exists for SELECT ... FOR UPDATE to lock, so both transactions proceed to
+// INSERT and Postgres's serializable snapshot isolation aborts one of them).
+func isSerializationFailure(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "40001"
+	}
+	return false
+}
+
 func (s *PostgresResourceStore) Delete(ctx context.Context, account, region, resourceType, id string) error {
 	tag, err := s.pool.Exec(ctx, `
 		DELETE FROM jc_resources WHERE account_id=$1 AND region=$2 AND resource_type=$3 AND id=$4

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -44,6 +44,16 @@ type ResourceStore interface {
 	List(ctx context.Context, account, region, resourceType, prefix string) ([]ResourceEntry, error)
 	Purge(ctx context.Context, account, region, resourceType string) error
 
+	// UpsertAtomic performs a locked read-mutate-write cycle on a single entry:
+	// mutate receives the current entry (zero value, exists=false if absent)
+	// and returns the entry to persist, or an error to abort without writing.
+	// Unlike a separate Get followed by Update/Upsert, the read and write are
+	// atomic with respect to concurrent Create/Upsert/Update/UpsertAtomic calls
+	// on the same key — callers doing read-modify-write with an in-value
+	// precondition (e.g. etag/CAS checks) must use this instead of Get+Upsert
+	// to avoid a lost-update race between two concurrent callers.
+	UpsertAtomic(ctx context.Context, account, region, resourceType, id string, mutate func(current ResourceEntry, exists bool) (ResourceEntry, error)) (ResourceEntry, error)
+
 	// Reset wipes all state — used by the admin reset endpoint.
 	Reset(ctx context.Context)
 }


### PR DESCRIPTION
## Summary
- `policy.Set` (the shared IAM-policy CAS helper used by Pub/Sub topic/subscription, Secret Manager, IAM service account, and KMS `SetIamPolicy`) enforced its etag precondition non-atomically: `Load()` (a `Get`) → compare `reqEtag` in Go → separate `Upsert`. Two concurrent `SetIamPolicy` calls reading the same starting etag would both pass the check and both write — the second silently clobbers the first, even though both callers supplied a correct, matching precondition.
- Adds `UpsertAtomic` to the shared `store.ResourceStore` interface: a locked read-mutate-write cycle, implemented in `MemoryResourceStore` (single mutex critical section) and `PostgresResourceStore` (Serializable transaction + `SELECT ... FOR UPDATE`, with a bounded retry on `40001` serialization failures for the narrow concurrent-first-write case), mirroring the convention already established in `firestore/postgres.go`'s `Commit` and `secretmanager`'s `UpdateSecretAtomic`.
- Rewires `policy.Set` to perform the etag comparison inside the atomic `mutate` callback, so the check and the write are indivisible.
- This touches shared infrastructure (`internal/store`), not GCP-only code, since `ResourceStore` is implemented once and used by both clouds — verified the full `-race` suite for `internal/gcp/...`, `internal/store/...`, `internal/resourcemgr/...`, and `internal/aws/...` all still pass, and that `internal/gcp` still never imports `internal/aws` (cloud isolation intact).

## Verification
Added `TestSetIamPolicyConcurrentSameEtagOnlyOneWins`: 50 goroutines all read the same starting etag and race to `Set`. Confirmed the test fails against the old code (4/50 falsely succeeded) by temporarily reverting the fix, then confirmed it passes (exactly 1/50 succeeds, stored state matches the reported winner) with the fix restored.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./internal/gcp/... ./internal/store/... ./internal/resourcemgr/... ./internal/aws/...` — all pass
- [x] Regression test confirmed to fail on old code, pass on fixed code
- [x] `grep -rn "jaiscloud/internal/aws" internal/gcp/` — empty (isolation intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)