### PR TITLE
fix(gcp/functions): atomic UpdateFunction closes disjoint-field lost-update race

### DIFF
--- a/internal/gcp/provider/functions/function.go
+++ b/internal/gcp/provider/functions/function.go
@@ -294,44 +294,43 @@ func (p *Provider) UpdateFunction(ctx context.Context, nr *model.NormalizedReque
 	}
 	location := strParam(nr, "location")
 	id := functionID(name)
-	f, err := p.functions.GetFunction(ctx, nr.AccountID, location, id)
-	if err != nil {
-		return nil, mapErr(err)
-	}
 	body, _ := nr.Params["body"].(map[string]any)
-	// PATCH is a merge: apply only the fields present in the body.
-	if v := bodyString(body, "runtime"); v != "" {
-		f.Runtime = v
-	}
-	if v := bodyString(body, "entryPoint"); v != "" {
-		f.EntryPoint = v
-	}
-	if v := bodyString(body, "sourceUploadUrl"); v != "" {
-		f.SourceUploadURL = v
-	}
-	if v := bodyString(body, "sourceArchiveUrl"); v != "" {
-		f.SourceArchiveURL = v
-	}
-	if env := bodyStringMap(body, "environmentVariables"); env != nil {
-		f.EnvironmentVariables = env
-	}
-	if labels := bodyStringMap(body, "labels"); labels != nil {
-		f.Labels = labels
-	}
-	if v := bodyString(body, "description"); v != "" {
-		f.Description = v
-	}
-	if v := bodyString(body, "timeout"); v != "" {
-		f.Timeout = v
-	}
-	if n, ok := body["availableMemoryMb"].(float64); ok && n > 0 {
-		f.AvailableMemoryMB = int(n)
-	}
-	if et := bodyEventTrigger(body); et != nil {
-		f.EventTrigger = et
-	}
-	f.UpdateTime = clock.Now().UTC()
-	if err := p.functions.UpdateFunction(ctx, nr.AccountID, location, id, f); err != nil {
+	f, err := p.functions.UpdateFunctionAtomic(ctx, nr.AccountID, location, id, func(f functionsstore.Function) (functionsstore.Function, error) {
+		// PATCH is a merge: apply only the fields present in the body.
+		if v := bodyString(body, "runtime"); v != "" {
+			f.Runtime = v
+		}
+		if v := bodyString(body, "entryPoint"); v != "" {
+			f.EntryPoint = v
+		}
+		if v := bodyString(body, "sourceUploadUrl"); v != "" {
+			f.SourceUploadURL = v
+		}
+		if v := bodyString(body, "sourceArchiveUrl"); v != "" {
+			f.SourceArchiveURL = v
+		}
+		if env := bodyStringMap(body, "environmentVariables"); env != nil {
+			f.EnvironmentVariables = env
+		}
+		if labels := bodyStringMap(body, "labels"); labels != nil {
+			f.Labels = labels
+		}
+		if v := bodyString(body, "description"); v != "" {
+			f.Description = v
+		}
+		if v := bodyString(body, "timeout"); v != "" {
+			f.Timeout = v
+		}
+		if n, ok := body["availableMemoryMb"].(float64); ok && n > 0 {
+			f.AvailableMemoryMB = int(n)
+		}
+		if et := bodyEventTrigger(body); et != nil {
+			f.EventTrigger = et
+		}
+		f.UpdateTime = clock.Now().UTC()
+		return f, nil
+	})
+	if err != nil {
 		return nil, mapErr(err)
 	}
 	return provider.OK(functionToMap(nr, f)), nil

--- a/internal/gcp/provider/functions/function_test.go
+++ b/internal/gcp/provider/functions/function_test.go
@@ -3,7 +3,11 @@ package functions
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	lambdaexec "jaiscloud/internal/executor/lambda"
 	"jaiscloud/internal/gcp/resource"
@@ -108,6 +112,100 @@ func TestFunctionCRUD(t *testing.T) {
 	nr = newNR(map[string]any{"location": "us-central1", "name": "locations/us-central1/functions/hello"})
 	if _, err := p.GetFunction(ctx, nr); err == nil {
 		t.Errorf("expected NotFound after delete")
+	}
+}
+
+// delayedGetStore wraps a functionsstore.Store, delaying every GetFunction
+// call to widen a TOCTOU race window in tests.
+type delayedGetStore struct {
+	functionsstore.Store
+	delay time.Duration
+}
+
+func (d *delayedGetStore) GetFunction(ctx context.Context, projectID, location, id string) (functionsstore.Function, error) {
+	f, err := d.Store.GetFunction(ctx, projectID, location, id)
+	time.Sleep(d.delay)
+	return f, err
+}
+
+// TestUpdateFunctionConcurrentDisjointFieldsNoLostUpdate proves that
+// UpdateFunction's get-merge-write cycle is atomic with respect to other
+// concurrent PATCH requests. Without atomicity, a PATCH that only intends to
+// change "description" reads a stale full copy of the function (taken before
+// a concurrent "runtime"-only PATCH committed), then writes that stale copy
+// back — silently reverting the runtime change even though the description
+// PATCH never touched runtime. Here, 25 goroutines each PATCH only "runtime"
+// to a unique value and 25 PATCH only "description" to a unique value; if the
+// bug is present, the final runtime (or description) will revert to its
+// original pre-race value because some racing writer's stale snapshot landed
+// last, instead of ending on one of the values a goroutine actually wrote.
+func TestUpdateFunctionConcurrentDisjointFieldsNoLostUpdate(t *testing.T) {
+	ctx := context.Background()
+	// delayedGetStore widens the TOCTOU window between a read and a
+	// subsequent write so the race manifests reliably instead of depending on
+	// scheduler luck (in-memory Get+merge+Update round trips otherwise
+	// complete in nanoseconds, too fast to overlap reliably). Irrelevant to
+	// the fixed code path, which no longer calls GetFunction from Update at
+	// all — UpdateFunctionAtomic does its own locked read internally.
+	p := New(&delayedGetStore{Store: functionsstore.NewMemoryStore(), delay: 5 * time.Millisecond}, store.NewMemoryResourceStore(), nil)
+
+	createNR := newNR(map[string]any{
+		"location":   "us-central1",
+		"functionId": "f1",
+		"body": map[string]any{
+			"runtime":     "nodejs20",
+			"entryPoint":  "h",
+			"description": "d0",
+			"timeout":     "60s",
+		},
+	})
+	if _, err := p.CreateFunction(ctx, createNR); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	const perField = 25
+	var wg sync.WaitGroup
+	errs := make([]error, 2*perField)
+	for i := 0; i < perField; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			nr := newNR(map[string]any{
+				"location": "us-central1", "name": "locations/us-central1/functions/f1",
+				"body": map[string]any{"runtime": fmt.Sprintf("vR%d", i)},
+			})
+			_, errs[i] = p.UpdateFunction(ctx, nr)
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			nr := newNR(map[string]any{
+				"location": "us-central1", "name": "locations/us-central1/functions/f1",
+				"body": map[string]any{"description": fmt.Sprintf("vD%d", i)},
+			})
+			_, errs[perField+i] = p.UpdateFunction(ctx, nr)
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("update %d: %v", i, err)
+		}
+	}
+
+	got, err := p.GetFunction(ctx, newNR(map[string]any{"location": "us-central1", "name": "locations/us-central1/functions/f1"}))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	runtime, _ := got.Data["runtime"].(string)
+	description, _ := got.Data["description"].(string)
+	if runtime == "nodejs20" || !strings.HasPrefix(runtime, "vR") {
+		t.Errorf("runtime reverted to a stale value instead of one of the 25 concurrent writers': got %q", runtime)
+	}
+	if description == "d0" || !strings.HasPrefix(description, "vD") {
+		t.Errorf("description reverted to a stale value instead of one of the 25 concurrent writers': got %q", description)
+	}
+	if got.Data["timeout"] != "60s" {
+		t.Errorf("untouched field timeout should be unaffected, got %v", got.Data["timeout"])
 	}
 }
 

--- a/internal/gcp/store/functions/memory.go
+++ b/internal/gcp/store/functions/memory.go
@@ -59,6 +59,24 @@ func (s *MemoryStore) UpdateFunction(_ context.Context, projectID, location, id 
 	return nil
 }
 
+func (s *MemoryStore) UpdateFunctionAtomic(_ context.Context, projectID, location, id string, mutate func(Function) (Function, error)) (Function, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := lkey(projectID, location)
+	current, ok := s.functions[key][id]
+	if !ok {
+		return Function{}, ErrNoSuchFunction
+	}
+	next, err := mutate(current)
+	if err != nil {
+		return Function{}, err
+	}
+	next.ID = id
+	next.Location = location
+	s.functions[key][id] = next
+	return next, nil
+}
+
 func (s *MemoryStore) DeleteFunction(_ context.Context, projectID, location, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/gcp/store/functions/postgres.go
+++ b/internal/gcp/store/functions/postgres.go
@@ -110,6 +110,61 @@ func (s *PostgresStore) UpdateFunction(ctx context.Context, projectID, location,
 	return nil
 }
 
+// UpdateFunctionAtomic mirrors MemoryStore's version: a Serializable
+// transaction with SELECT ... FOR UPDATE row-locks the function for the
+// duration of mutate, so a concurrent UpdateFunctionAtomic on the same
+// function blocks until this transaction commits or rolls back, instead of
+// racing to silently overwrite this call's write. See
+// store/firestore/postgres.go's Commit for the same convention.
+func (s *PostgresStore) UpdateFunctionAtomic(ctx context.Context, projectID, location, id string, mutate func(Function) (Function, error)) (Function, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return Function{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	current, err := scanFunction(tx.QueryRow(ctx, `
+		SELECT function_id, location, runtime, entry_point, source_upload_url, source_archive_url,
+		       https_trigger_url, event_trigger, environment_variables, status, create_time, update_time, labels,
+		       available_memory_mb, timeout, description
+		FROM jc_functions WHERE project_id=$1 AND location=$2 AND function_id=$3 FOR UPDATE
+	`, projectID, location, id))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Function{}, ErrNoSuchFunction
+	}
+	if err != nil {
+		return Function{}, err
+	}
+
+	next, err := mutate(current)
+	if err != nil {
+		return Function{}, err
+	}
+
+	env, _ := json.Marshal(next.EnvironmentVariables)
+	labels, _ := json.Marshal(next.Labels)
+	tag, err := tx.Exec(ctx, `
+		UPDATE jc_functions SET runtime=$4, entry_point=$5, source_upload_url=$6, source_archive_url=$7,
+		       https_trigger_url=$8, event_trigger=$9, environment_variables=$10, status=$11, update_time=$12, labels=$13,
+		       available_memory_mb=$14, timeout=$15, description=$16
+		WHERE project_id=$1 AND location=$2 AND function_id=$3
+	`, projectID, location, id, next.Runtime, next.EntryPoint, next.SourceUploadURL, next.SourceArchiveURL,
+		next.HttpsTriggerURL, nullableJSON(next.EventTrigger), json.RawMessage(env), next.Status, next.UpdateTime,
+		json.RawMessage(labels), next.AvailableMemoryMB, next.Timeout, next.Description)
+	if err != nil {
+		return Function{}, err
+	}
+	if tag.RowsAffected() == 0 {
+		return Function{}, ErrNoSuchFunction
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Function{}, err
+	}
+	next.ID = id
+	next.Location = location
+	return next, nil
+}
+
 func (s *PostgresStore) DeleteFunction(ctx context.Context, projectID, location, id string) error {
 	tag, err := s.pool.Exec(ctx, `DELETE FROM jc_functions WHERE project_id=$1 AND location=$2 AND function_id=$3`, projectID, location, id)
 	if err != nil {

--- a/internal/gcp/store/functions/store.go
+++ b/internal/gcp/store/functions/store.go
@@ -48,6 +48,13 @@ type Store interface {
 	CreateFunction(ctx context.Context, projectID, location, id string, f Function) error
 	GetFunction(ctx context.Context, projectID, location, id string) (Function, error)
 	UpdateFunction(ctx context.Context, projectID, location, id string, f Function) error
+	// UpdateFunctionAtomic performs a locked get-mutate-set cycle: mutate
+	// receives the current function and returns the version to persist, or an
+	// error to abort without writing. Unlike a separate GetFunction followed
+	// by UpdateFunction, this is atomic with respect to concurrent updates on
+	// the same function, so a PATCH that merges only a subset of fields can't
+	// lose a concurrent PATCH's changes to other fields.
+	UpdateFunctionAtomic(ctx context.Context, projectID, location, id string, mutate func(Function) (Function, error)) (Function, error)
 	DeleteFunction(ctx context.Context, projectID, location, id string) error
 	ListFunctions(ctx context.Context, projectID, location string) ([]Function, error)
 	// ListFunctionsAllLocations returns every function for a project across all


### PR DESCRIPTION
## Summary
- `UpdateFunction` (Cloud Functions v1 PATCH) did a plain `GetFunction`, merged only the fields present in the request body onto the result in Go, then called a separate `UpdateFunction` to persist it — the same Get-then-separate-write shape already fixed in Secret Manager (#45), Datastore (#47), and GCS (#48). Two concurrent PATCH requests touching *different* fields (e.g. one changing only `runtime`, another only `description`) could race: both read the same base snapshot, and whichever write landed last silently reverted the other's already-applied field change.
- Adds `UpdateFunctionAtomic` to the `functions.Store` interface: `MemoryStore` uses a single locked critical section, `PostgresStore` uses a Serializable transaction + `SELECT ... FOR UPDATE`, mirroring the established convention (`firestore/postgres.go`'s `Commit`, `secretmanager`'s `UpdateSecretAtomic`).
- Rewires the provider's `UpdateFunction` to perform the body merge inside the atomic `mutate` callback instead of a separate `Get` + `Update` pair.

## Verification
Added `TestUpdateFunctionConcurrentDisjointFieldsNoLostUpdate`: 25 goroutines PATCH only `runtime`, 25 PATCH only `description`, concurrently. A delayed-`Get` store wrapper widens the TOCTOU window reliably (the real in-memory round trip otherwise completes in nanoseconds). Confirmed the test fails against the old code (`runtime`/`description` revert to their pre-race values, 3/3 runs) by temporarily reverting the fix, then confirmed it passes (3/3 runs) with the fix restored.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/gcp/... ./internal/store/...` — all pass
- [x] Regression test confirmed to fail on old code, pass on fixed code
- [x] `grep -rn "jaiscloud/internal/aws" internal/gcp/` — empty (isolation intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)