### PR TITLE
fix(gcp/workflows): atomic UpdateWorkflow closes disjoint-field lost-update race

### DIFF
--- a/internal/gcp/provider/workflows/workflow.go
+++ b/internal/gcp/provider/workflows/workflow.go
@@ -324,50 +324,49 @@ func (p *Provider) UpdateWorkflow(ctx context.Context, nr *model.NormalizedReque
 		return nil, model.NewProviderError("InvalidArgument", "missing workflow name", 400)
 	}
 	id := workflowID(name)
-	w, err := p.workflows.GetWorkflow(ctx, nr.AccountID, location, id)
-	if err != nil {
-		return nil, mapErr(err)
-	}
 	body, _ := nr.Params["body"].(map[string]any)
 	mask := strParam(nr, "updateMask")
 
 	apply := func(field string) bool {
 		return mask == "" || strings.Contains(","+mask+",", ","+field+",")
 	}
-	sourceChanged := false
-	if apply("description") {
-		w.Description = bodyString(body, "description")
-	}
-	if apply("labels") {
-		if labels := bodyStringMap(body, "labels"); labels != nil {
-			w.Labels = labels
+	w, err := p.workflows.UpdateWorkflowAtomic(ctx, nr.AccountID, location, id, func(w workflowsstore.Workflow) (workflowsstore.Workflow, error) {
+		sourceChanged := false
+		if apply("description") {
+			w.Description = bodyString(body, "description")
 		}
-	}
-	if apply("userEnvVars") {
-		if vars := bodyStringMap(body, "userEnvVars"); vars != nil {
-			w.UserEnvVars = vars
+		if apply("labels") {
+			if labels := bodyStringMap(body, "labels"); labels != nil {
+				w.Labels = labels
+			}
 		}
-	}
-	if apply("serviceAccount") {
-		if v := bodyString(body, "serviceAccount"); v != w.ServiceAccount {
-			w.ServiceAccount = v
-			sourceChanged = true
+		if apply("userEnvVars") {
+			if vars := bodyStringMap(body, "userEnvVars"); vars != nil {
+				w.UserEnvVars = vars
+			}
 		}
-	}
-	if apply("sourceContents") {
-		if v := bodyString(body, "sourceContents"); v != w.SourceContents {
-			w.SourceContents = v
-			sourceChanged = true
+		if apply("serviceAccount") {
+			if v := bodyString(body, "serviceAccount"); v != w.ServiceAccount {
+				w.ServiceAccount = v
+				sourceChanged = true
+			}
 		}
-	}
-	if apply("callLogLevel") {
-		w.CallLogLevel = bodyString(body, "callLogLevel")
-	}
-	if sourceChanged {
-		w.RevisionID = nextRevision(w.RevisionID)
-	}
-	w.UpdateTime = clock.Now().UTC()
-	if err := p.workflows.UpdateWorkflow(ctx, nr.AccountID, location, id, w); err != nil {
+		if apply("sourceContents") {
+			if v := bodyString(body, "sourceContents"); v != w.SourceContents {
+				w.SourceContents = v
+				sourceChanged = true
+			}
+		}
+		if apply("callLogLevel") {
+			w.CallLogLevel = bodyString(body, "callLogLevel")
+		}
+		if sourceChanged {
+			w.RevisionID = nextRevision(w.RevisionID)
+		}
+		w.UpdateTime = clock.Now().UTC()
+		return w, nil
+	})
+	if err != nil {
 		return nil, mapErr(err)
 	}
 	target := nr.ResourceID("workflow", location+"/"+id)

--- a/internal/gcp/provider/workflows/workflow_test.go
+++ b/internal/gcp/provider/workflows/workflow_test.go
@@ -2,9 +2,12 @@ package workflows
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"jaiscloud/internal/gcp/resource"
 	workflowsstore "jaiscloud/internal/gcp/store/workflows"
@@ -23,6 +26,92 @@ const simpleSource = "main:\n  steps:\n    - r:\n        return: 1\n"
 // revisionRE matches the GCP revision_id format "000001-a4d": a zero-padded
 // six-digit ordinal, a hyphen, and exactly three hexadecimal characters.
 var revisionRE = regexp.MustCompile(`^[0-9]{6}-[0-9a-f]{3}$`)
+
+// delayedGetStore wraps a workflowsstore.Store, delaying every GetWorkflow
+// call to widen a TOCTOU race window in tests.
+type delayedGetStore struct {
+	workflowsstore.Store
+	delay time.Duration
+}
+
+func (d *delayedGetStore) GetWorkflow(ctx context.Context, projectID, location, id string) (workflowsstore.Workflow, error) {
+	w, err := d.Store.GetWorkflow(ctx, projectID, location, id)
+	time.Sleep(d.delay)
+	return w, err
+}
+
+// TestUpdateWorkflowConcurrentDisjointFieldsNoLostUpdate proves that
+// UpdateWorkflow's get-merge-write cycle is atomic with respect to other
+// concurrent masked-PATCH requests. Without atomicity, a PATCH updating only
+// "description" (via updateMask) reads a stale full copy of the workflow
+// (taken before a concurrent "callLogLevel"-only PATCH committed), then
+// writes that stale copy back — silently reverting the callLogLevel change
+// even though the description PATCH's mask never named it. 25 goroutines
+// each PATCH only "description" to a unique value and 25 PATCH only
+// "callLogLevel" to a unique value; a delayed-Get store wrapper widens the
+// TOCTOU window reliably (the real in-memory round trip otherwise completes
+// in nanoseconds, too fast to overlap deterministically).
+func TestUpdateWorkflowConcurrentDisjointFieldsNoLostUpdate(t *testing.T) {
+	ctx := context.Background()
+	p := New(&delayedGetStore{Store: workflowsstore.NewMemoryStore(), delay: 5 * time.Millisecond})
+
+	createNR := newNR(map[string]any{
+		"location":   "us-central1",
+		"workflowId": "wf1",
+		"body": map[string]any{
+			"description":    "d0",
+			"sourceContents": simpleSource,
+			"callLogLevel":   "LOG_ALL_CALLS",
+		},
+	})
+	if _, err := p.CreateWorkflow(ctx, createNR); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	const perField = 25
+	var wg sync.WaitGroup
+	errs := make([]error, 2*perField)
+	for i := 0; i < perField; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			nr := newNR(map[string]any{
+				"location": "us-central1", "name": "locations/us-central1/workflows/wf1",
+				"updateMask": "description",
+				"body":       map[string]any{"description": fmt.Sprintf("vDesc%d", i)},
+			})
+			_, errs[i] = p.UpdateWorkflow(ctx, nr)
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			nr := newNR(map[string]any{
+				"location": "us-central1", "name": "locations/us-central1/workflows/wf1",
+				"updateMask": "callLogLevel",
+				"body":       map[string]any{"callLogLevel": fmt.Sprintf("LEVEL%d", i)},
+			})
+			_, errs[perField+i] = p.UpdateWorkflow(ctx, nr)
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("update %d: %v", i, err)
+		}
+	}
+
+	got, err := p.GetWorkflow(ctx, newNR(map[string]any{"location": "us-central1", "name": "locations/us-central1/workflows/wf1"}))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	description, _ := got.Data["description"].(string)
+	callLogLevel, _ := got.Data["callLogLevel"].(string)
+	if description == "d0" || !strings.HasPrefix(description, "vDesc") {
+		t.Errorf("description reverted to a stale value instead of one of the 25 concurrent writers': got %q", description)
+	}
+	if callLogLevel == "LOG_ALL_CALLS" || !strings.HasPrefix(callLogLevel, "LEVEL") {
+		t.Errorf("callLogLevel reverted to a stale value instead of one of the 25 concurrent writers': got %q", callLogLevel)
+	}
+}
 
 func TestWorkflowCRUDAndLRO(t *testing.T) {
 	ctx := context.Background()

--- a/internal/gcp/store/workflows/memory.go
+++ b/internal/gcp/store/workflows/memory.go
@@ -68,6 +68,24 @@ func (s *MemoryStore) UpdateWorkflow(_ context.Context, projectID, location, id 
 	return nil
 }
 
+func (s *MemoryStore) UpdateWorkflowAtomic(_ context.Context, projectID, location, id string, mutate func(Workflow) (Workflow, error)) (Workflow, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := wlkey(projectID, location)
+	current, ok := s.workflows[key][id]
+	if !ok {
+		return Workflow{}, ErrNoSuchWorkflow
+	}
+	next, err := mutate(current)
+	if err != nil {
+		return Workflow{}, err
+	}
+	next.ID = id
+	next.Location = location
+	s.workflows[key][id] = next
+	return next, nil
+}
+
 func (s *MemoryStore) DeleteWorkflow(_ context.Context, projectID, location, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/gcp/store/workflows/postgres.go
+++ b/internal/gcp/store/workflows/postgres.go
@@ -107,6 +107,59 @@ func (s *PostgresStore) UpdateWorkflow(ctx context.Context, projectID, location,
 	return nil
 }
 
+// UpdateWorkflowAtomic mirrors MemoryStore's version: a Serializable
+// transaction with SELECT ... FOR UPDATE row-locks the workflow for the
+// duration of mutate, so a concurrent UpdateWorkflowAtomic on the same
+// workflow blocks until this transaction commits or rolls back, instead of
+// racing to silently overwrite this call's write. See
+// store/firestore/postgres.go's Commit for the same convention.
+func (s *PostgresStore) UpdateWorkflowAtomic(ctx context.Context, projectID, location, id string, mutate func(Workflow) (Workflow, error)) (Workflow, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return Workflow{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	current, err := scanWorkflow(tx.QueryRow(ctx, `
+		SELECT workflow_id, location, description, labels, service_account, source_contents,
+		       state, revision_id, create_time, update_time, call_log_level, user_env_vars, tags
+		FROM jc_workflows WHERE project_id=$1 AND location=$2 AND workflow_id=$3 FOR UPDATE
+	`, projectID, location, id))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Workflow{}, ErrNoSuchWorkflow
+	}
+	if err != nil {
+		return Workflow{}, err
+	}
+
+	next, err := mutate(current)
+	if err != nil {
+		return Workflow{}, err
+	}
+
+	labels, _ := json.Marshal(next.Labels)
+	userEnvVars, _ := json.Marshal(next.UserEnvVars)
+	tags, _ := json.Marshal(next.Tags)
+	tag, err := tx.Exec(ctx, `
+		UPDATE jc_workflows SET description=$4, labels=$5, service_account=$6, source_contents=$7,
+		       state=$8, revision_id=$9, update_time=$10, call_log_level=$11, user_env_vars=$12, tags=$13
+		WHERE project_id=$1 AND location=$2 AND workflow_id=$3
+	`, projectID, location, id, next.Description, json.RawMessage(labels), next.ServiceAccount, next.SourceContents,
+		next.State, next.RevisionID, next.UpdateTime, next.CallLogLevel, json.RawMessage(userEnvVars), json.RawMessage(tags))
+	if err != nil {
+		return Workflow{}, err
+	}
+	if tag.RowsAffected() == 0 {
+		return Workflow{}, ErrNoSuchWorkflow
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Workflow{}, err
+	}
+	next.ID = id
+	next.Location = location
+	return next, nil
+}
+
 func (s *PostgresStore) DeleteWorkflow(ctx context.Context, projectID, location, id string) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {

--- a/internal/gcp/store/workflows/store.go
+++ b/internal/gcp/store/workflows/store.go
@@ -104,6 +104,13 @@ type Store interface {
 	CreateWorkflow(ctx context.Context, projectID, location, id string, w Workflow) error
 	GetWorkflow(ctx context.Context, projectID, location, id string) (Workflow, error)
 	UpdateWorkflow(ctx context.Context, projectID, location, id string, w Workflow) error
+	// UpdateWorkflowAtomic performs a locked get-mutate-set cycle: mutate
+	// receives the current workflow and returns the version to persist, or an
+	// error to abort without writing. Unlike a separate GetWorkflow followed
+	// by UpdateWorkflow, this is atomic with respect to concurrent updates on
+	// the same workflow, so a masked PATCH that merges only a subset of
+	// fields can't lose a concurrent PATCH's changes to other fields.
+	UpdateWorkflowAtomic(ctx context.Context, projectID, location, id string, mutate func(Workflow) (Workflow, error)) (Workflow, error)
 	DeleteWorkflow(ctx context.Context, projectID, location, id string) error
 	ListWorkflows(ctx context.Context, projectID, location string) ([]Workflow, error)
 


### PR DESCRIPTION
## Summary
- `UpdateWorkflow` (Cloud Workflows masked PATCH) did a plain `GetWorkflow`, merged only the `updateMask`-named fields onto the result in Go, then called a separate `UpdateWorkflow` to persist it — the same Get-then-separate-write shape already fixed in Secret Manager (#45), Datastore (#47), GCS (#48), and Cloud Functions (#50). Two concurrent PATCH requests with disjoint masks (e.g. one updating only `description`, another only `callLogLevel`) could race: both read the same base snapshot, and whichever write landed last silently reverted the other's already-applied field change.
- Adds `UpdateWorkflowAtomic` to the `workflows.Store` interface: `MemoryStore` uses a single locked critical section, `PostgresStore` uses a Serializable transaction + `SELECT ... FOR UPDATE`, mirroring the established convention.
- Rewires the provider's `UpdateWorkflow` to perform the masked merge inside the atomic `mutate` callback instead of a separate `Get` + `Update` pair.
- Reviewed `UpdateExecution` (used only by `CancelExecution`) and left it alone: executions run synchronously in this emulator, so by the code's own comment the `ACTIVE` state it guards is never actually observed at cancel time — there is no real concurrent writer to race against.

## Verification
Added `TestUpdateWorkflowConcurrentDisjointFieldsNoLostUpdate`: 25 goroutines PATCH only `description`, 25 PATCH only `callLogLevel`, concurrently, using a delayed-`Get` store wrapper to reliably widen the TOCTOU window. Confirmed the test fails against the old code (`description` reverts to its pre-race value, 3/3 runs) by temporarily reverting the fix, then confirmed it passes (3/3 runs) with the fix restored.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/gcp/...` — all pass
- [x] Regression test confirmed to fail on old code, pass on fixed code
- [x] `grep -rn "jaiscloud/internal/aws" internal/gcp/` — empty (isolation intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)