### PR TITLE
fix(gcp/dataproc): atomic UpdateCluster/CancelJob close lost-update and LRO races

### DIFF
--- a/internal/gcp/provider/dataproc/clusters.go
+++ b/internal/gcp/provider/dataproc/clusters.go
@@ -98,10 +98,6 @@ func (p *Provider) UpdateCluster(ctx context.Context, nr *model.NormalizedReques
 	if region == "" || name == "" {
 		return nil, model.NewProviderError("InvalidArgument", "missing region or clusterName", 400)
 	}
-	c, err := p.store.GetCluster(ctx, nr.AccountID, region, name)
-	if err != nil {
-		return nil, mapErr(err)
-	}
 	body, _ := nr.Params["body"].(map[string]any)
 	mask := strParam(nr, "updateMask")
 
@@ -109,25 +105,28 @@ func (p *Provider) UpdateCluster(ctx context.Context, nr *model.NormalizedReques
 		return mask == "" || containsMaskField(mask, field)
 	}
 
-	// labels
-	if apply("labels") {
-		if labels := bodyStringMap(body, "labels"); labels != nil {
-			c.Labels = labels
-		}
-	}
-	// config.* fields are applied onto the stored config verbatim (the
-	// updateMask selects the path; only top-level config.* keys are honored).
-	if c.Config != nil && bodyConfig(body) != nil {
-		var stored map[string]any
-		if json.Unmarshal(c.Config, &stored) == nil {
-			applyConfigMask(stored, bodyConfig(body), mask)
-			if data, err := json.Marshal(stored); err == nil {
-				c.Config = data
+	c, err := p.store.UpdateClusterAtomic(ctx, nr.AccountID, region, name, func(c dataprocstore.Cluster) (dataprocstore.Cluster, error) {
+		// labels
+		if apply("labels") {
+			if labels := bodyStringMap(body, "labels"); labels != nil {
+				c.Labels = labels
 			}
 		}
-	}
-	c.UpdateTime = clock.Now().UTC()
-	if err := p.store.UpdateCluster(ctx, nr.AccountID, region, c); err != nil {
+		// config.* fields are applied onto the stored config verbatim (the
+		// updateMask selects the path; only top-level config.* keys are honored).
+		if c.Config != nil && bodyConfig(body) != nil {
+			var stored map[string]any
+			if json.Unmarshal(c.Config, &stored) == nil {
+				applyConfigMask(stored, bodyConfig(body), mask)
+				if data, err := json.Marshal(stored); err == nil {
+					c.Config = data
+				}
+			}
+		}
+		c.UpdateTime = clock.Now().UTC()
+		return c, nil
+	})
+	if err != nil {
 		return nil, mapErr(err)
 	}
 	target := nr.ResourceID("dataproc-cluster", region+"/"+name)
@@ -170,14 +169,13 @@ func (p *Provider) startStopCluster(ctx context.Context, nr *model.NormalizedReq
 	if region == "" || name == "" {
 		return nil, model.NewProviderError("InvalidArgument", "missing region or clusterName", 400)
 	}
-	c, err := p.store.GetCluster(ctx, nr.AccountID, region, name)
+	c, err := p.store.UpdateClusterAtomic(ctx, nr.AccountID, region, name, func(c dataprocstore.Cluster) (dataprocstore.Cluster, error) {
+		c.StatusHistory = append(c.StatusHistory, c.Status)
+		c.Status = dataprocstore.ClusterStatus{State: toState, StateStartTime: clock.Now().UTC()}
+		c.UpdateTime = clock.Now().UTC()
+		return c, nil
+	})
 	if err != nil {
-		return nil, mapErr(err)
-	}
-	c.StatusHistory = append(c.StatusHistory, c.Status)
-	c.Status = dataprocstore.ClusterStatus{State: toState, StateStartTime: clock.Now().UTC()}
-	c.UpdateTime = clock.Now().UTC()
-	if err := p.store.UpdateCluster(ctx, nr.AccountID, region, c); err != nil {
 		return nil, mapErr(err)
 	}
 	target := nr.ResourceID("dataproc-cluster", region+"/"+name)

--- a/internal/gcp/provider/dataproc/dataproc_test.go
+++ b/internal/gcp/provider/dataproc/dataproc_test.go
@@ -3,7 +3,9 @@ package dataproc
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"jaiscloud/internal/gcp/resource"
 	dataprocstore "jaiscloud/internal/gcp/store/dataproc"
@@ -134,6 +136,74 @@ func TestUpdateCluster_UpdateMask(t *testing.T) {
 	config, _ := c.Data["config"].(map[string]any)
 	if config == nil || config["workerConfig"] == nil {
 		t.Fatalf("config was clobbered by label-only update: %v", c.Data)
+	}
+}
+
+// delayedGetClusterStore wraps a dataprocstore.Store, delaying every
+// GetCluster call to widen a TOCTOU race window in tests.
+type delayedGetClusterStore struct {
+	dataprocstore.Store
+	delay time.Duration
+}
+
+func (d *delayedGetClusterStore) GetCluster(ctx context.Context, projectID, region, name string) (dataprocstore.Cluster, error) {
+	c, err := d.Store.GetCluster(ctx, projectID, region, name)
+	time.Sleep(d.delay)
+	return c, err
+}
+
+// TestUpdateClusterVsStopClusterConcurrent_NoLostUpdate proves UpdateCluster
+// and startStopCluster (Start/StopCluster) are atomic with respect to each
+// other. Without atomicity, a labels-only PATCH and a concurrent StopCluster
+// status transition each do a separate Get-then-Update: both read the same
+// base snapshot, and whichever write lands last silently reverts the other's
+// already-applied change (labels reverting to their pre-race value, or the
+// status transition being lost). A delayed-Get store wrapper widens the
+// TOCTOU window reliably (the real in-memory round trip otherwise completes
+// in nanoseconds, too fast to overlap deterministically).
+func TestUpdateClusterVsStopClusterConcurrent_NoLostUpdate(t *testing.T) {
+	p := New(&delayedGetClusterStore{Store: dataprocstore.NewMemoryStore(), delay: 5 * time.Millisecond}, store.NewMemoryResourceStore())
+	ctx := context.Background()
+	if _, err := p.CreateCluster(ctx, testNR(map[string]any{
+		"region": "us-central1",
+		"body":   map[string]any{"projectId": "proj", "clusterName": "c1", "labels": map[string]any{"env": "dev"}},
+	})); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	var updateErr, stopErr error
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, updateErr = p.UpdateCluster(ctx, testNR(map[string]any{
+			"region": "us-central1", "clusterName": "c1", "updateMask": "labels",
+			"body": map[string]any{"labels": map[string]any{"env": "prod"}},
+		}))
+	}()
+	go func() {
+		defer wg.Done()
+		_, stopErr = p.StopCluster(ctx, testNR(map[string]any{"region": "us-central1", "clusterName": "c1"}))
+	}()
+	wg.Wait()
+	if updateErr != nil {
+		t.Fatalf("update: %v", updateErr)
+	}
+	if stopErr != nil {
+		t.Fatalf("stop: %v", stopErr)
+	}
+
+	c, err := p.GetCluster(ctx, testNR(map[string]any{"region": "us-central1", "clusterName": "c1"}))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	labels, _ := c.Data["labels"].(map[string]string)
+	if labels["env"] != "prod" {
+		t.Errorf("labels PATCH lost: got %v, want env=prod", labels)
+	}
+	status, _ := c.Data["status"].(map[string]any)
+	if status["state"] != "STOPPED" {
+		t.Errorf("StopCluster transition lost: got %v, want STOPPED", status["state"])
 	}
 }
 

--- a/internal/gcp/provider/dataproc/jobs.go
+++ b/internal/gcp/provider/dataproc/jobs.go
@@ -218,11 +218,21 @@ func (p *Provider) CancelJob(ctx context.Context, nr *model.NormalizedRequest) (
 	if region == "" || jobID == "" {
 		return nil, model.NewProviderError("InvalidArgument", "missing region or jobId", 400)
 	}
-	j, err := p.store.GetJob(ctx, nr.AccountID, region, jobID)
+	now := clock.Now().UTC()
+	var transitioned bool
+	j, err := p.store.UpdateJobAtomic(ctx, nr.AccountID, region, jobID, func(j dataprocstore.Job) (dataprocstore.Job, error) {
+		if jobTerminal(j.Status.State) {
+			return j, nil // already terminal — nothing to cancel
+		}
+		transitioned = true
+		j.StatusHistory = append(j.StatusHistory, j.Status)
+		j.Status = dataprocstore.JobStatus{State: "CANCELLED", StateStartTime: now}
+		return j, nil
+	})
 	if err != nil {
 		return nil, mapErr(err)
 	}
-	if jobTerminal(j.Status.State) {
+	if !transitioned {
 		return provider.OK(jobToMap(j)), nil
 	}
 
@@ -232,13 +242,10 @@ func (p *Provider) CancelJob(ctx context.Context, nr *model.NormalizedRequest) (
 	if ok {
 		cancel()
 	}
-
-	now := clock.Now().UTC()
-	j.StatusHistory = append(j.StatusHistory, j.Status)
-	j.Status = dataprocstore.JobStatus{State: "CANCELLED", StateStartTime: now}
-	if err := p.store.UpdateJob(ctx, nr.AccountID, region, j); err != nil {
-		return nil, mapErr(err)
-	}
+	// Close out the SubmitJobAsOperation LRO for this transition — finishJob
+	// won't run it (or will see the job already terminal and no-op) once
+	// CancelJob has won the race for the terminal-state transition.
+	p.completeSubmitOperation(nr.AccountID, region, j)
 	return provider.OK(jobToMap(j)), nil
 }
 

--- a/internal/gcp/provider/dataproc/spark_lifecycle_test.go
+++ b/internal/gcp/provider/dataproc/spark_lifecycle_test.go
@@ -17,6 +17,7 @@ import (
 	"jaiscloud/internal/clock"
 	dataprocstore "jaiscloud/internal/gcp/store/dataproc"
 	"jaiscloud/internal/k8shelpers"
+	"jaiscloud/internal/model"
 	"jaiscloud/internal/store"
 )
 
@@ -331,6 +332,92 @@ func TestCancelJob_NotFound(t *testing.T) {
 	_, err := p.CancelJob(context.Background(), testNR(map[string]any{"region": "us-central1", "jobId": "nope"}))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "job not found")
+}
+
+// delayedGetJobStore wraps a dataprocstore.Store, delaying every GetJob call
+// to widen a TOCTOU race window in tests. It only affects the pre-fix code
+// path (CancelJob/finishJob calling a standalone GetJob); UpdateJobAtomic
+// does its own internal locked read and never reaches this override, so
+// against the fixed code the delay is simply never invoked.
+type delayedGetJobStore struct {
+	dataprocstore.Store
+	delay time.Duration
+}
+
+func (d *delayedGetJobStore) GetJob(ctx context.Context, projectID, region, jobID string) (dataprocstore.Job, error) {
+	j, err := d.Store.GetJob(ctx, projectID, region, jobID)
+	time.Sleep(d.delay)
+	return j, err
+}
+
+// TestCancelJob_CompletesSubmitOperation proves CancelJob closes out the
+// SubmitJobAsOperation LRO on its own terminal-state transition. Previously
+// only finishJob ever called completeSubmitOperation, so a job submitted
+// asynchronously and then cancelled left its operation stuck at done=false
+// forever — a client polling the operation would hang indefinitely even
+// though the job itself correctly shows CANCELLED.
+func TestCancelJob_CompletesSubmitOperation(t *testing.T) {
+	ctx := context.Background()
+	p := newProvider(t)
+	j := newTestJob()
+	j.JobID = "j-cancel-lro"
+	require.NoError(t, p.store.CreateJob(ctx, j.ProjectID, j.Region, j))
+	require.NoError(t, p.store.CreateOperation(ctx, j.ProjectID, j.Region, dataprocstore.Operation{
+		ID: j.JobID, Verb: "submit", Target: j.JobID, CreateTime: clock.Now().UTC(),
+	}))
+
+	resp, err := p.CancelJob(ctx, testNR(map[string]any{"region": j.Region, "jobId": j.JobID}))
+	require.NoError(t, err)
+	require.Equal(t, "CANCELLED", resp.Data["status"].(map[string]any)["state"])
+
+	op, err := p.store.GetOperation(ctx, j.ProjectID, j.Region, j.JobID)
+	require.NoError(t, err)
+	require.True(t, op.Done, "operation must be closed once CancelJob transitions the job to CANCELLED")
+}
+
+// TestFinishJobDoesNotResurrectCancelledJob deterministically reproduces the
+// TOCTOU race between CancelJob and finishJob: both are launched concurrently
+// against a job that a client is racing to cancel just as it finishes
+// naturally. A delayed-Get store wrapper widens the window between each
+// side's read and write. Without atomicity, whichever write lands last wins
+// outright regardless of which one the client was actually told about via
+// CancelJob's response — so a client told "CANCELLED" could see the job
+// silently resurrect to DONE moments later. With UpdateJobAtomic, CancelJob's
+// response is always consistent with the job's final persisted state: if
+// CancelJob performed the transition, nothing can un-cancel it afterward.
+func TestCancelJobVsFinishJobConcurrent_ResponseMatchesFinalState(t *testing.T) {
+	ctx := context.Background()
+	p := New(&delayedGetJobStore{Store: dataprocstore.NewMemoryStore(), delay: 5 * time.Millisecond}, store.NewMemoryResourceStore())
+	j := newTestJob()
+	j.JobID = "j-race-1"
+	require.NoError(t, p.store.CreateJob(ctx, j.ProjectID, j.Region, j))
+	require.NoError(t, p.store.CreateOperation(ctx, j.ProjectID, j.Region, dataprocstore.Operation{
+		ID: j.JobID, Verb: "submit", Target: j.JobID, CreateTime: clock.Now().UTC(),
+	}))
+
+	var cancelResp *model.ProviderResponse
+	var cancelErr error
+	finishDone := make(chan struct{})
+	go func() {
+		defer close(finishDone)
+		p.finishJob(j.ProjectID, j.Region, j, "DONE", "")
+	}()
+	cancelResp, cancelErr = p.CancelJob(ctx, testNR(map[string]any{"region": j.Region, "jobId": j.JobID}))
+	<-finishDone
+	require.NoError(t, cancelErr)
+
+	got, err := p.store.GetJob(ctx, j.ProjectID, j.Region, j.JobID)
+	require.NoError(t, err)
+
+	respState := cancelResp.Data["status"].(map[string]any)["state"]
+	if respState == "CANCELLED" {
+		require.Equal(t, "CANCELLED", got.Status.State,
+			"CancelJob told the client CANCELLED, but the job later resurrected to %q", got.Status.State)
+	}
+
+	op, err := p.store.GetOperation(ctx, j.ProjectID, j.Region, j.JobID)
+	require.NoError(t, err)
+	require.True(t, op.Done, "operation must be closed regardless of whether CancelJob or finishJob won the race")
 }
 
 // TestCancelJob_ConcurrentCancels_SingleTerminal stresses the cancel map under

--- a/internal/gcp/provider/dataproc/submit.go
+++ b/internal/gcp/provider/dataproc/submit.go
@@ -137,25 +137,31 @@ func entryPointForJob(j dataprocstore.Job) (sparkhelpers.EntryPoint, []string, [
 	return ep, propertiesToConfArgs(mustJSONMap(j.TypeJob)), jarArgs, nil
 }
 
-// finishJob writes the terminal state back to the jobs store (loading fresh to
-// avoid clobbering a CancelJob write).
+// finishJob writes the terminal state back to the jobs store. The get-check-
+// set cycle is atomic (UpdateJobAtomic) so it can't race with a concurrent
+// CancelJob: whichever of the two acquires the lock first wins the terminal-
+// state transition, and the other sees the already-terminal state inside its
+// own mutate and no-ops instead of overwriting it.
 func (p *Provider) finishJob(project, region string, j dataprocstore.Job, state, details string) {
 	now := clock.Now().UTC()
-	fresh, err := p.store.GetJob(context.Background(), project, region, j.JobID)
+	var transitioned bool
+	fresh, err := p.store.UpdateJobAtomic(context.Background(), project, region, j.JobID, func(fresh dataprocstore.Job) (dataprocstore.Job, error) {
+		if jobTerminal(fresh.Status.State) {
+			return fresh, nil // already terminal (e.g. cancelled) — first write wins
+		}
+		transitioned = true
+		fresh.StatusHistory = append(fresh.StatusHistory, fresh.Status)
+		fresh.Status = dataprocstore.JobStatus{State: state, Details: details, StateStartTime: now}
+		if state == "DONE" && fresh.DriverOutputResourceURI == "" {
+			fresh.DriverOutputResourceURI = "gs://jaiscloud-dataproc/" + fresh.JobUUID + "/driveroutput"
+		}
+		return fresh, nil
+	})
 	if err != nil {
-		slog.Warn("dataproc: finishJob load failed", "job", j.JobID, "err", err)
+		slog.Warn("dataproc: finishJob update failed", "job", j.JobID, "err", err)
 		return
 	}
-	if jobTerminal(fresh.Status.State) {
-		return // already terminal (e.g. cancelled) — first write wins
-	}
-	fresh.StatusHistory = append(fresh.StatusHistory, fresh.Status)
-	fresh.Status = dataprocstore.JobStatus{State: state, Details: details, StateStartTime: now}
-	if state == "DONE" && fresh.DriverOutputResourceURI == "" {
-		fresh.DriverOutputResourceURI = "gs://jaiscloud-dataproc/" + fresh.JobUUID + "/driveroutput"
-	}
-	if err := p.store.UpdateJob(context.Background(), project, region, fresh); err != nil {
-		slog.Warn("dataproc: finishJob update failed", "job", j.JobID, "err", err)
+	if !transitioned {
 		return
 	}
 	p.completeSubmitOperation(project, region, fresh)

--- a/internal/gcp/store/dataproc/memory.go
+++ b/internal/gcp/store/dataproc/memory.go
@@ -64,6 +64,24 @@ func (s *MemoryStore) UpdateCluster(_ context.Context, projectID, region string,
 	return nil
 }
 
+func (s *MemoryStore) UpdateClusterAtomic(_ context.Context, projectID, region, name string, mutate func(Cluster) (Cluster, error)) (Cluster, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := scopeKey(projectID, region)
+	current, ok := s.clusters[key][name]
+	if !ok {
+		return Cluster{}, ErrNoSuchCluster
+	}
+	next, err := mutate(current)
+	if err != nil {
+		return Cluster{}, err
+	}
+	next.ProjectID = projectID
+	next.Region = region
+	s.clusters[key][name] = next
+	return next, nil
+}
+
 func (s *MemoryStore) DeleteCluster(_ context.Context, projectID, region, name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -124,6 +142,24 @@ func (s *MemoryStore) UpdateJob(_ context.Context, projectID, region string, j J
 	j.Region = region
 	s.jobs[key][j.JobID] = j
 	return nil
+}
+
+func (s *MemoryStore) UpdateJobAtomic(_ context.Context, projectID, region, jobID string, mutate func(Job) (Job, error)) (Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := scopeKey(projectID, region)
+	current, ok := s.jobs[key][jobID]
+	if !ok {
+		return Job{}, ErrNoSuchJob
+	}
+	next, err := mutate(current)
+	if err != nil {
+		return Job{}, err
+	}
+	next.ProjectID = projectID
+	next.Region = region
+	s.jobs[key][jobID] = next
+	return next, nil
 }
 
 func (s *MemoryStore) DeleteJob(_ context.Context, projectID, region, jobID string) error {

--- a/internal/gcp/store/dataproc/postgres.go
+++ b/internal/gcp/store/dataproc/postgres.go
@@ -103,6 +103,58 @@ func (s *PostgresStore) UpdateCluster(ctx context.Context, projectID, region str
 	return nil
 }
 
+// UpdateClusterAtomic mirrors MemoryStore's version: a Serializable
+// transaction with SELECT ... FOR UPDATE row-locks the cluster for the
+// duration of mutate, so a concurrent UpdateClusterAtomic on the same
+// cluster (e.g. a labels PATCH racing a StartCluster/StopCluster status
+// transition) blocks until this transaction commits or rolls back, instead
+// of racing to silently overwrite this call's write. See
+// store/firestore/postgres.go's Commit for the same convention.
+func (s *PostgresStore) UpdateClusterAtomic(ctx context.Context, projectID, region, name string, mutate func(Cluster) (Cluster, error)) (Cluster, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return Cluster{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	current, err := scanCluster(tx.QueryRow(ctx, `
+		SELECT project_id, region, cluster_name, config, labels, status, status_history, cluster_uuid, create_time, update_time
+		FROM jc_dataproc_clusters WHERE project_id=$1 AND region=$2 AND cluster_name=$3 FOR UPDATE
+	`, projectID, region, name))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Cluster{}, ErrNoSuchCluster
+	}
+	if err != nil {
+		return Cluster{}, err
+	}
+
+	next, err := mutate(current)
+	if err != nil {
+		return Cluster{}, err
+	}
+
+	labels, _ := json.Marshal(next.Labels)
+	status, _ := json.Marshal(next.Status)
+	history, _ := json.Marshal(next.StatusHistory)
+	tag, err := tx.Exec(ctx, `
+		UPDATE jc_dataproc_clusters SET config=$4, labels=$5, status=$6, status_history=$7, cluster_uuid=$8, update_time=$9
+		WHERE project_id=$1 AND region=$2 AND cluster_name=$3
+	`, projectID, region, name, nullableJSONRaw(next.Config, "{}"), nullableJSONRaw(labels, "{}"), nullableJSONRaw(status, "{}"),
+		nullableJSONRaw(history, "[]"), next.ClusterUUID, next.UpdateTime)
+	if err != nil {
+		return Cluster{}, err
+	}
+	if tag.RowsAffected() == 0 {
+		return Cluster{}, ErrNoSuchCluster
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Cluster{}, err
+	}
+	next.ProjectID = projectID
+	next.Region = region
+	return next, nil
+}
+
 func (s *PostgresStore) DeleteCluster(ctx context.Context, projectID, region, name string) error {
 	tag, err := s.pool.Exec(ctx, `DELETE FROM jc_dataproc_clusters WHERE project_id=$1 AND region=$2 AND cluster_name=$3`, projectID, region, name)
 	if err != nil {
@@ -206,6 +258,58 @@ func (s *PostgresStore) UpdateJob(ctx context.Context, projectID, region string,
 		return ErrNoSuchJob
 	}
 	return nil
+}
+
+// UpdateJobAtomic mirrors MemoryStore's version: a Serializable transaction
+// with SELECT ... FOR UPDATE row-locks the job for the duration of mutate,
+// so CancelJob and finishJob (which both call this) can't race to overwrite
+// each other's terminal-state transition. See store/firestore/postgres.go's
+// Commit for the same convention.
+func (s *PostgresStore) UpdateJobAtomic(ctx context.Context, projectID, region, jobID string, mutate func(Job) (Job, error)) (Job, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return Job{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	current, err := scanJob(tx.QueryRow(ctx, `
+		SELECT project_id, region, job_id, placement_cluster_name, job_type, type_job, labels, status, status_history,
+		       driver_output_resource_uri, driver_control_files_uri, job_uuid, create_time
+		FROM jc_dataproc_jobs WHERE project_id=$1 AND region=$2 AND job_id=$3 FOR UPDATE
+	`, projectID, region, jobID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Job{}, ErrNoSuchJob
+	}
+	if err != nil {
+		return Job{}, err
+	}
+
+	next, err := mutate(current)
+	if err != nil {
+		return Job{}, err
+	}
+
+	labels, _ := json.Marshal(next.Labels)
+	status, _ := json.Marshal(next.Status)
+	history, _ := json.Marshal(next.StatusHistory)
+	tag, err := tx.Exec(ctx, `
+		UPDATE jc_dataproc_jobs SET placement_cluster_name=$4, job_type=$5, type_job=$6, labels=$7, status=$8,
+		       status_history=$9, driver_output_resource_uri=$10, driver_control_files_uri=$11, job_uuid=$12
+		WHERE project_id=$1 AND region=$2 AND job_id=$3
+	`, projectID, region, jobID, next.PlacementClusterName, next.Type, nullableJSONRaw(next.TypeJob, "{}"), nullableJSONRaw(labels, "{}"),
+		nullableJSONRaw(status, "{}"), nullableJSONRaw(history, "[]"), next.DriverOutputResourceURI, next.DriverControlFilesURI, next.JobUUID)
+	if err != nil {
+		return Job{}, err
+	}
+	if tag.RowsAffected() == 0 {
+		return Job{}, ErrNoSuchJob
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Job{}, err
+	}
+	next.ProjectID = projectID
+	next.Region = region
+	return next, nil
 }
 
 func (s *PostgresStore) DeleteJob(ctx context.Context, projectID, region, jobID string) error {

--- a/internal/gcp/store/dataproc/store.go
+++ b/internal/gcp/store/dataproc/store.go
@@ -92,12 +92,26 @@ type Store interface {
 	CreateCluster(ctx context.Context, projectID, region string, c Cluster) error
 	GetCluster(ctx context.Context, projectID, region, name string) (Cluster, error)
 	UpdateCluster(ctx context.Context, projectID, region string, c Cluster) error
+	// UpdateClusterAtomic performs a locked get-mutate-set cycle: mutate
+	// receives the current cluster and returns the version to persist, or an
+	// error to abort without writing. Unlike a separate GetCluster followed
+	// by UpdateCluster, this is atomic with respect to concurrent updates on
+	// the same cluster, so a labels/config PATCH can't race with a concurrent
+	// StartCluster/StopCluster status transition and lose one or the other.
+	UpdateClusterAtomic(ctx context.Context, projectID, region, name string, mutate func(Cluster) (Cluster, error)) (Cluster, error)
 	DeleteCluster(ctx context.Context, projectID, region, name string) error
 	ListClusters(ctx context.Context, projectID, region string) ([]Cluster, error)
 
 	CreateJob(ctx context.Context, projectID, region string, j Job) error
 	GetJob(ctx context.Context, projectID, region, jobID string) (Job, error)
 	UpdateJob(ctx context.Context, projectID, region string, j Job) error
+	// UpdateJobAtomic performs a locked get-mutate-set cycle: mutate receives
+	// the current job and returns the version to persist, or an error to
+	// abort without writing. Used by CancelJob and finishJob so a client
+	// cancelling a job can't race with the job's own goroutine reaching a
+	// terminal state — whichever acquires the lock first wins, and the other
+	// sees the already-terminal state inside its own mutate and no-ops.
+	UpdateJobAtomic(ctx context.Context, projectID, region, jobID string, mutate func(Job) (Job, error)) (Job, error)
 	DeleteJob(ctx context.Context, projectID, region, jobID string) error
 	ListJobs(ctx context.Context, projectID, region string) ([]Job, error)
 


### PR DESCRIPTION
## Summary
Two related lost-update bugs, both the same Get-then-separate-write shape already fixed in Secret Manager (#45), Datastore (#47), GCS (#48), Cloud Functions (#50), and Workflows (#51):

- `UpdateCluster` (labels/config PATCH) and `startStopCluster` (Start/Stop) each did a separate `GetCluster` + `UpdateCluster`. A labels PATCH racing a concurrent StartCluster/StopCluster status transition could silently drop one of the two changes.
- `CancelJob` and `finishJob` (the terminal-state write a job's own goroutine makes on completion) each did a separate `GetJob` + `UpdateJob`. A client cancelling a job just as it finishes naturally could race: whichever write landed last won outright, regardless of what `CancelJob` had already told the client — a job reported as CANCELLED could silently resurrect to DONE moments later. Separately, `CancelJob` never called `completeSubmitOperation`, so a job submitted via `SubmitJobAsOperation` and then cancelled left its LRO stuck at `done=false` forever (`finishJob` was the only caller, and it correctly no-ops once it sees the job already terminal — meaning it never gets a chance to close the LRO either).

## Fix
Adds `UpdateClusterAtomic` and `UpdateJobAtomic` to the dataproc `Store` interface: `MemoryStore` uses a single locked critical section, `PostgresStore` uses a Serializable transaction + `SELECT ... FOR UPDATE`, mirroring the established convention. Rewires `UpdateCluster`, `startStopCluster`, `CancelJob`, and `finishJob` to perform their get-check-mutate cycle inside the atomic callback. `CancelJob` now also calls `completeSubmitOperation` on its own transition, closing the LRO regardless of which side wins the race.

## Verification
Three regression tests, each confirmed to fail against the old code before restoring the fix:
- `TestUpdateClusterVsStopClusterConcurrent_NoLostUpdate` (3/3 failures, using a delayed-Get store wrapper to widen the TOCTOU window)
- `TestCancelJob_CompletesSubmitOperation` (5/5 failures — deterministic, no concurrency needed: old `CancelJob` simply never closes the LRO)
- `TestCancelJobVsFinishJobConcurrent_ResponseMatchesFinalState` (caught the exact resurrection bug in 1/5 runs: "CancelJob told the client CANCELLED, but the job later resurrected to DONE")

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/gcp/...` — all pass
- [x] All three regression tests confirmed to fail on old code, pass on fixed code
- [x] `grep -rn "jaiscloud/internal/aws" internal/gcp/` — empty (isolation intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)