### PR TITLE
fix(gcp/bigquery): atomic UpdateDataset/UpdateTable close disjoint-field lost-update race

### DIFF
--- a/internal/gcp/provider/bigquery/bigquery.go
+++ b/internal/gcp/provider/bigquery/bigquery.go
@@ -306,28 +306,27 @@ func (p *Provider) UpdateDataset(ctx context.Context, nr *model.NormalizedReques
 	if datasetID == "" {
 		return nil, invalidArgument("datasetId is required")
 	}
-	d, err := p.store.GetDataset(ctx, projectOf(nr), datasetID)
-	if err != nil {
-		return nil, mapErr(err)
-	}
 	body := bodyMap(nr)
-	if body != nil {
-		stored := map[string]any{}
-		if len(d.Config) > 0 {
-			_ = json.Unmarshal(d.Config, &stored)
+	d, err := p.store.UpdateDatasetAtomic(ctx, projectOf(nr), datasetID, func(d bqstore.Dataset) (bqstore.Dataset, error) {
+		if body != nil {
+			stored := map[string]any{}
+			if len(d.Config) > 0 {
+				_ = json.Unmarshal(d.Config, &stored)
+			}
+			for k, v := range body {
+				stored[k] = v
+			}
+			if data, err := json.Marshal(stored); err == nil {
+				d.Config = data
+			}
+			if labels := stringMap(body, "labels"); labels != nil {
+				d.Labels = labels
+			}
 		}
-		for k, v := range body {
-			stored[k] = v
-		}
-		if data, err := json.Marshal(stored); err == nil {
-			d.Config = data
-		}
-		if labels := stringMap(body, "labels"); labels != nil {
-			d.Labels = labels
-		}
-	}
-	d.UpdateTime = clock.Now().UTC()
-	if err := p.store.UpdateDataset(ctx, projectOf(nr), d); err != nil {
+		d.UpdateTime = clock.Now().UTC()
+		return d, nil
+	})
+	if err != nil {
 		return nil, mapErr(err)
 	}
 	return provider.OK(p.datasetMap(projectOf(nr), d)), nil
@@ -426,33 +425,32 @@ func (p *Provider) UpdateTable(ctx context.Context, nr *model.NormalizedRequest)
 	if datasetID == "" || tableID == "" {
 		return nil, invalidArgument("datasetId and tableId are required")
 	}
-	t, err := p.store.GetTable(ctx, projectOf(nr), datasetID, tableID)
-	if err != nil {
-		return nil, mapErr(err)
-	}
 	body := bodyMap(nr)
-	if body != nil {
-		stored := map[string]any{}
-		if len(t.Config) > 0 {
-			_ = json.Unmarshal(t.Config, &stored)
-		}
-		for k, v := range body {
-			stored[k] = v
-		}
-		if data, err := json.Marshal(stored); err == nil {
-			t.Config = data
-		}
-		if schema := mapValue(body, "schema"); schema != nil {
-			if data, err := json.Marshal(schema); err == nil {
-				t.Schema = data
+	t, err := p.store.UpdateTableAtomic(ctx, projectOf(nr), datasetID, tableID, func(t bqstore.Table) (bqstore.Table, error) {
+		if body != nil {
+			stored := map[string]any{}
+			if len(t.Config) > 0 {
+				_ = json.Unmarshal(t.Config, &stored)
+			}
+			for k, v := range body {
+				stored[k] = v
+			}
+			if data, err := json.Marshal(stored); err == nil {
+				t.Config = data
+			}
+			if schema := mapValue(body, "schema"); schema != nil {
+				if data, err := json.Marshal(schema); err == nil {
+					t.Schema = data
+				}
+			}
+			if labels := stringMap(body, "labels"); labels != nil {
+				t.Labels = labels
 			}
 		}
-		if labels := stringMap(body, "labels"); labels != nil {
-			t.Labels = labels
-		}
-	}
-	t.UpdateTime = clock.Now().UTC()
-	if err := p.store.UpdateTable(ctx, projectOf(nr), datasetID, t); err != nil {
+		t.UpdateTime = clock.Now().UTC()
+		return t, nil
+	})
+	if err != nil {
 		return nil, mapErr(err)
 	}
 	return provider.OK(p.tableMap(projectOf(nr), t)), nil

--- a/internal/gcp/provider/bigquery/bigquery_test.go
+++ b/internal/gcp/provider/bigquery/bigquery_test.go
@@ -2,8 +2,12 @@ package bigquery
 
 import (
 	"context"
+	"fmt"
 	"math"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	bqstore "jaiscloud/internal/gcp/store/bigquery"
 	"jaiscloud/internal/model"
@@ -89,6 +93,84 @@ func TestDatasetCRUD(t *testing.T) {
 	}
 	if _, err := p.GetDataset(ctx, newNR(map[string]any{"datasetId": "sales"})); err == nil {
 		t.Fatalf("expected NotFound after delete")
+	}
+}
+
+// delayedGetDatasetStore wraps a bqstore.Store, delaying every GetDataset
+// call to widen a TOCTOU race window in tests. It only affects the pre-fix
+// code path (UpdateDataset calling a standalone GetDataset);
+// UpdateDatasetAtomic does its own internal locked read and never reaches
+// this override.
+type delayedGetDatasetStore struct {
+	bqstore.Store
+	delay time.Duration
+}
+
+func (d *delayedGetDatasetStore) GetDataset(ctx context.Context, projectID, datasetID string) (bqstore.Dataset, error) {
+	ds, err := d.Store.GetDataset(ctx, projectID, datasetID)
+	time.Sleep(d.delay)
+	return ds, err
+}
+
+// TestUpdateDatasetConcurrentDisjointFieldsNoLostUpdate proves UpdateDataset's
+// get-merge-write cycle is atomic with respect to other concurrent PATCH
+// requests. Without atomicity, a PATCH touching only "friendlyName" reads a
+// stale full copy of the dataset (taken before a concurrent "description"-only
+// PATCH committed), then writes that stale copy back — silently reverting the
+// description change even though the friendlyName PATCH never touched it. 25
+// goroutines each PATCH only "friendlyName" and 25 PATCH only "description";
+// a delayed-Get store wrapper widens the TOCTOU window reliably (the real
+// in-memory round trip otherwise completes in nanoseconds).
+func TestUpdateDatasetConcurrentDisjointFieldsNoLostUpdate(t *testing.T) {
+	ctx := context.Background()
+	p := New(&delayedGetDatasetStore{Store: bqstore.NewMemoryStore(), delay: 5 * time.Millisecond})
+
+	if _, err := p.CreateDataset(ctx, newNR(map[string]any{"body": map[string]any{
+		"datasetReference": map[string]any{"projectId": "proj", "datasetId": "ds1"},
+		"friendlyName":     "orig-name",
+		"description":      "orig-desc",
+	}})); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	const perField = 25
+	var wg sync.WaitGroup
+	errs := make([]error, 2*perField)
+	for i := 0; i < perField; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = p.UpdateDataset(ctx, newNR(map[string]any{
+				"datasetId": "ds1",
+				"body":      map[string]any{"friendlyName": fmt.Sprintf("vName%d", i)},
+			}))
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[perField+i] = p.UpdateDataset(ctx, newNR(map[string]any{
+				"datasetId": "ds1",
+				"body":      map[string]any{"description": fmt.Sprintf("vDesc%d", i)},
+			}))
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("update %d: %v", i, err)
+		}
+	}
+
+	got, err := p.GetDataset(ctx, newNR(map[string]any{"datasetId": "ds1"}))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	friendlyName, _ := got.Data["friendlyName"].(string)
+	description, _ := got.Data["description"].(string)
+	if friendlyName == "orig-name" || !strings.HasPrefix(friendlyName, "vName") {
+		t.Errorf("friendlyName reverted to a stale value instead of one of the 25 concurrent writers': got %q", friendlyName)
+	}
+	if description == "orig-desc" || !strings.HasPrefix(description, "vDesc") {
+		t.Errorf("description reverted to a stale value instead of one of the 25 concurrent writers': got %q", description)
 	}
 }
 

--- a/internal/gcp/store/bigquery/memory.go
+++ b/internal/gcp/store/bigquery/memory.go
@@ -68,6 +68,23 @@ func (s *MemoryStore) UpdateDataset(_ context.Context, projectID string, d Datas
 	return nil
 }
 
+func (s *MemoryStore) UpdateDatasetAtomic(_ context.Context, projectID, datasetID string, mutate func(Dataset) (Dataset, error)) (Dataset, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := datasetScope(projectID, datasetID)
+	current, ok := s.datasets[key]
+	if !ok {
+		return Dataset{}, ErrNoSuchDataset
+	}
+	next, err := mutate(current)
+	if err != nil {
+		return Dataset{}, err
+	}
+	next.ProjectID = projectID
+	s.datasets[key] = next
+	return next, nil
+}
+
 func (s *MemoryStore) DeleteDataset(_ context.Context, projectID, datasetID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -138,6 +155,24 @@ func (s *MemoryStore) UpdateTable(_ context.Context, projectID, datasetID string
 	t.DatasetID = datasetID
 	s.tables[key] = t
 	return nil
+}
+
+func (s *MemoryStore) UpdateTableAtomic(_ context.Context, projectID, datasetID, tableID string, mutate func(Table) (Table, error)) (Table, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := tableScope(projectID, datasetID, tableID)
+	current, ok := s.tables[key]
+	if !ok {
+		return Table{}, ErrNoSuchTable
+	}
+	next, err := mutate(current)
+	if err != nil {
+		return Table{}, err
+	}
+	next.ProjectID = projectID
+	next.DatasetID = datasetID
+	s.tables[key] = next
+	return next, nil
 }
 
 func (s *MemoryStore) DeleteTable(_ context.Context, projectID, datasetID, tableID string) error {

--- a/internal/gcp/store/bigquery/postgres.go
+++ b/internal/gcp/store/bigquery/postgres.go
@@ -86,6 +86,53 @@ func (s *PostgresStore) UpdateDataset(ctx context.Context, projectID string, d D
 	return nil
 }
 
+// UpdateDatasetAtomic mirrors MemoryStore's version: a Serializable
+// transaction with SELECT ... FOR UPDATE row-locks the dataset for the
+// duration of mutate, so a concurrent UpdateDatasetAtomic on the same
+// dataset blocks until this transaction commits or rolls back, instead of
+// racing to silently overwrite this call's write. See
+// store/firestore/postgres.go's Commit for the same convention.
+func (s *PostgresStore) UpdateDatasetAtomic(ctx context.Context, projectID, datasetID string, mutate func(Dataset) (Dataset, error)) (Dataset, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return Dataset{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	current, err := scanDataset(tx.QueryRow(ctx, `
+		SELECT project_id, dataset_id, config, labels, create_time, update_time
+		FROM jc_bq_datasets WHERE project_id=$1 AND dataset_id=$2 FOR UPDATE
+	`, projectID, datasetID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Dataset{}, ErrNoSuchDataset
+	}
+	if err != nil {
+		return Dataset{}, err
+	}
+
+	next, err := mutate(current)
+	if err != nil {
+		return Dataset{}, err
+	}
+
+	labels, _ := json.Marshal(next.Labels)
+	tag, err := tx.Exec(ctx, `
+		UPDATE jc_bq_datasets SET config=$3, labels=$4, update_time=$5
+		WHERE project_id=$1 AND dataset_id=$2
+	`, projectID, datasetID, nullableJSONRaw(next.Config, "{}"), nullableJSONRaw(labels, "{}"), next.UpdateTime)
+	if err != nil {
+		return Dataset{}, err
+	}
+	if tag.RowsAffected() == 0 {
+		return Dataset{}, ErrNoSuchDataset
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Dataset{}, err
+	}
+	next.ProjectID = projectID
+	return next, nil
+}
+
 func (s *PostgresStore) DeleteDataset(ctx context.Context, projectID, datasetID string) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -190,6 +237,54 @@ func (s *PostgresStore) UpdateTable(ctx context.Context, projectID, datasetID st
 		return ErrNoSuchTable
 	}
 	return nil
+}
+
+// UpdateTableAtomic mirrors MemoryStore's version: a Serializable
+// transaction with SELECT ... FOR UPDATE row-locks the table for the
+// duration of mutate, so a concurrent UpdateTableAtomic on the same table
+// blocks until this transaction commits or rolls back, instead of racing to
+// silently overwrite this call's write. See store/firestore/postgres.go's
+// Commit for the same convention.
+func (s *PostgresStore) UpdateTableAtomic(ctx context.Context, projectID, datasetID, tableID string, mutate func(Table) (Table, error)) (Table, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return Table{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	current, err := scanTable(tx.QueryRow(ctx, `
+		SELECT project_id, dataset_id, table_id, config, schema, labels, num_rows, create_time, update_time
+		FROM jc_bq_tables WHERE project_id=$1 AND dataset_id=$2 AND table_id=$3 FOR UPDATE
+	`, projectID, datasetID, tableID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Table{}, ErrNoSuchTable
+	}
+	if err != nil {
+		return Table{}, err
+	}
+
+	next, err := mutate(current)
+	if err != nil {
+		return Table{}, err
+	}
+
+	labels, _ := json.Marshal(next.Labels)
+	tag, err := tx.Exec(ctx, `
+		UPDATE jc_bq_tables SET config=$4, schema=$5, labels=$6, update_time=$7
+		WHERE project_id=$1 AND dataset_id=$2 AND table_id=$3
+	`, projectID, datasetID, tableID, nullableJSONRaw(next.Config, "{}"), nullableJSONRaw(next.Schema, "{}"), nullableJSONRaw(labels, "{}"), next.UpdateTime)
+	if err != nil {
+		return Table{}, err
+	}
+	if tag.RowsAffected() == 0 {
+		return Table{}, ErrNoSuchTable
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Table{}, err
+	}
+	next.ProjectID = projectID
+	next.DatasetID = datasetID
+	return next, nil
 }
 
 func (s *PostgresStore) DeleteTable(ctx context.Context, projectID, datasetID, tableID string) error {

--- a/internal/gcp/store/bigquery/store.go
+++ b/internal/gcp/store/bigquery/store.go
@@ -71,12 +71,26 @@ type Store interface {
 	CreateDataset(ctx context.Context, projectID string, d Dataset) error
 	GetDataset(ctx context.Context, projectID, datasetID string) (Dataset, error)
 	UpdateDataset(ctx context.Context, projectID string, d Dataset) error
+	// UpdateDatasetAtomic performs a locked get-mutate-set cycle: mutate
+	// receives the current dataset and returns the version to persist, or an
+	// error to abort without writing. Unlike a separate GetDataset followed
+	// by UpdateDataset, this is atomic with respect to concurrent updates on
+	// the same dataset, so two concurrent PATCH requests merging different
+	// fields can't lose one or the other.
+	UpdateDatasetAtomic(ctx context.Context, projectID, datasetID string, mutate func(Dataset) (Dataset, error)) (Dataset, error)
 	DeleteDataset(ctx context.Context, projectID, datasetID string) error
 	ListDatasets(ctx context.Context, projectID string) ([]Dataset, error)
 
 	CreateTable(ctx context.Context, projectID, datasetID string, t Table) error
 	GetTable(ctx context.Context, projectID, datasetID, tableID string) (Table, error)
 	UpdateTable(ctx context.Context, projectID, datasetID string, t Table) error
+	// UpdateTableAtomic performs a locked get-mutate-set cycle: mutate
+	// receives the current table and returns the version to persist, or an
+	// error to abort without writing. Unlike a separate GetTable followed by
+	// UpdateTable, this is atomic with respect to concurrent updates on the
+	// same table, so two concurrent PATCH requests merging different fields
+	// can't lose one or the other.
+	UpdateTableAtomic(ctx context.Context, projectID, datasetID, tableID string, mutate func(Table) (Table, error)) (Table, error)
 	DeleteTable(ctx context.Context, projectID, datasetID, tableID string) error
 	ListTables(ctx context.Context, projectID, datasetID string) ([]Table, error)
 


### PR DESCRIPTION
## Summary
- `UpdateDataset` and `UpdateTable` (BigQuery PATCH) each did a plain `Get`, merged the request body onto a local copy of the stored JSON config in Go, then called a separate `Update` to persist it — the same Get-then-separate-write shape already fixed in Secret Manager (#45), Datastore (#47), GCS (#48), Cloud Functions (#50), Workflows (#51), and Dataproc (#53). Two concurrent PATCH requests touching different top-level fields (e.g. one changing only `friendlyName`, another only `description`) could race: both merged onto the same stale snapshot, and whichever write landed last silently overwrote the other's already-applied field.
- Adds `UpdateDatasetAtomic` and `UpdateTableAtomic` to the bigquery `Store` interface: `MemoryStore` uses a single locked critical section, `PostgresStore` uses a Serializable transaction + `SELECT ... FOR UPDATE`, mirroring the established convention.
- Rewires the provider's `UpdateDataset`/`UpdateTable` to perform the JSON merge inside the atomic `mutate` callback instead of a separate `Get` + `Update` pair.

## Verification
Added `TestUpdateDatasetConcurrentDisjointFieldsNoLostUpdate`: 25 goroutines PATCH only `friendlyName`, 25 PATCH only `description`, concurrently, using a delayed-`Get` store wrapper to reliably widen the TOCTOU window. Confirmed the test fails against the old code (`description` reverts to its pre-race value, 3/3 runs) by temporarily reverting the fix, then confirmed it passes (3/3 runs) with the fix restored.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/gcp/...` — all pass
- [x] Regression test confirmed to fail on old code, pass on fixed code
- [x] `grep -rn "jaiscloud/internal/aws" internal/gcp/` — empty (isolation intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)