### PR TITLE
fix(gcp/managedkafka): atomic UpdateCluster/UpdateTopic close disjoint-field lost-update race

### DIFF
--- a/internal/gcp/provider/managedkafka/managedkafka.go
+++ b/internal/gcp/provider/managedkafka/managedkafka.go
@@ -232,28 +232,27 @@ func (p *Provider) UpdateCluster(ctx context.Context, nr *model.NormalizedReques
 	if location == "" || clusterID == "" {
 		return nil, model.NewProviderError("InvalidArgument", "missing location or clusterId", 400)
 	}
-	c, err := p.store.GetCluster(ctx, nr.AccountID, location, clusterID)
-	if err != nil {
-		return nil, mapErr(err)
-	}
 	body, _ := nr.Params["body"].(map[string]any)
-	if body != nil {
-		stored := map[string]any{}
-		if len(c.Config) > 0 {
-			_ = json.Unmarshal(c.Config, &stored)
+	c, err := p.store.UpdateClusterAtomic(ctx, nr.AccountID, location, clusterID, func(c mkstore.Cluster) (mkstore.Cluster, error) {
+		if body != nil {
+			stored := map[string]any{}
+			if len(c.Config) > 0 {
+				_ = json.Unmarshal(c.Config, &stored)
+			}
+			for k, v := range body {
+				stored[k] = v
+			}
+			if labels := bodyStringMap(body, "labels"); labels != nil {
+				c.Labels = labels
+			}
+			if data, err := json.Marshal(stored); err == nil {
+				c.Config = data
+			}
 		}
-		for k, v := range body {
-			stored[k] = v
-		}
-		if labels := bodyStringMap(body, "labels"); labels != nil {
-			c.Labels = labels
-		}
-		if data, err := json.Marshal(stored); err == nil {
-			c.Config = data
-		}
-	}
-	c.UpdateTime = clock.Now().UTC()
-	if err := p.store.UpdateCluster(ctx, nr.AccountID, location, c); err != nil {
+		c.UpdateTime = clock.Now().UTC()
+		return c, nil
+	})
+	if err != nil {
 		return nil, mapErr(err)
 	}
 	return p.clusterLRO(nr, c), nil
@@ -348,31 +347,30 @@ func (p *Provider) UpdateTopic(ctx context.Context, nr *model.NormalizedRequest)
 	if location == "" || clusterID == "" || topicID == "" {
 		return nil, model.NewProviderError("InvalidArgument", "missing location, clusterId, or topicId", 400)
 	}
-	t, err := p.store.GetTopic(ctx, nr.AccountID, location, clusterID, topicID)
-	if err != nil {
-		return nil, mapErr(err)
-	}
 	body, _ := nr.Params["body"].(map[string]any)
-	if body != nil {
-		if _, ok := body["partitionCount"]; ok {
-			t.PartitionCount = bodyInt(body, "partitionCount")
+	t, err := p.store.UpdateTopicAtomic(ctx, nr.AccountID, location, clusterID, topicID, func(t mkstore.Topic) (mkstore.Topic, error) {
+		if body != nil {
+			if _, ok := body["partitionCount"]; ok {
+				t.PartitionCount = bodyInt(body, "partitionCount")
+			}
+			if _, ok := body["replicationFactor"]; ok {
+				t.ReplicationFactor = bodyInt(body, "replicationFactor")
+			}
+			stored := map[string]any{}
+			if len(t.Config) > 0 {
+				_ = json.Unmarshal(t.Config, &stored)
+			}
+			for k, v := range body {
+				stored[k] = v
+			}
+			if data, err := json.Marshal(stored); err == nil {
+				t.Config = data
+			}
 		}
-		if _, ok := body["replicationFactor"]; ok {
-			t.ReplicationFactor = bodyInt(body, "replicationFactor")
-		}
-		stored := map[string]any{}
-		if len(t.Config) > 0 {
-			_ = json.Unmarshal(t.Config, &stored)
-		}
-		for k, v := range body {
-			stored[k] = v
-		}
-		if data, err := json.Marshal(stored); err == nil {
-			t.Config = data
-		}
-	}
-	t.UpdateTime = clock.Now().UTC()
-	if err := p.store.UpdateTopic(ctx, nr.AccountID, location, clusterID, t); err != nil {
+		t.UpdateTime = clock.Now().UTC()
+		return t, nil
+	})
+	if err != nil {
 		return nil, mapErr(err)
 	}
 	return provider.OK(p.topicMap(nr, t)), nil

--- a/internal/gcp/provider/managedkafka/managedkafka_test.go
+++ b/internal/gcp/provider/managedkafka/managedkafka_test.go
@@ -2,7 +2,9 @@ package managedkafka
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"jaiscloud/internal/gcp/resource"
 	mkstore "jaiscloud/internal/gcp/store/managedkafka"
@@ -92,6 +94,78 @@ func TestClusterCRUDAndLRO(t *testing.T) {
 
 	if _, err := p.GetCluster(ctx, newNR(map[string]any{"location": "us-central1", "clusterId": "c1"})); err == nil {
 		t.Fatal("expected NotFound after delete, got nil error")
+	}
+}
+
+// delayedGetClusterStore wraps a mkstore.Store, delaying every GetCluster
+// call to widen a TOCTOU race window in tests. It only affects the pre-fix
+// code path (UpdateCluster calling a standalone GetCluster);
+// UpdateClusterAtomic does its own internal locked read and never reaches
+// this override.
+type delayedGetClusterStore struct {
+	mkstore.Store
+	delay time.Duration
+}
+
+func (d *delayedGetClusterStore) GetCluster(ctx context.Context, projectID, location, name string) (mkstore.Cluster, error) {
+	c, err := d.Store.GetCluster(ctx, projectID, location, name)
+	time.Sleep(d.delay)
+	return c, err
+}
+
+// TestUpdateClusterConcurrentDisjointFieldsNoLostUpdate proves UpdateCluster's
+// get-merge-write cycle is atomic with respect to other concurrent PATCH
+// requests. Without atomicity, a PATCH touching only "labels" reads a stale
+// full copy of the cluster (taken before a concurrent "gcpConfig"-only PATCH
+// committed), then writes that stale copy back — silently reverting the
+// gcpConfig change even though the labels PATCH never touched it.
+func TestUpdateClusterConcurrentDisjointFieldsNoLostUpdate(t *testing.T) {
+	ctx := context.Background()
+	p := New(&delayedGetClusterStore{Store: mkstore.NewMemoryStore(), delay: 5 * time.Millisecond})
+
+	if _, err := p.CreateCluster(ctx, newNR(createParams("us-central1", "c1", map[string]any{
+		"labels":    map[string]any{"env": "dev"},
+		"gcpConfig": map[string]any{"kmsKey": "orig"},
+	}))); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	const perField = 25
+	var wg sync.WaitGroup
+	errs := make([]error, 2*perField)
+	for i := 0; i < perField; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = p.UpdateCluster(ctx, newNR(createParams("us-central1", "c1", map[string]any{
+				"labels": map[string]any{"i": string(rune('a' + i%26))},
+			})))
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[perField+i] = p.UpdateCluster(ctx, newNR(createParams("us-central1", "c1", map[string]any{
+				"gcpConfig": map[string]any{"kmsKey": string(rune('A' + i%26))},
+			})))
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("update %d: %v", i, err)
+		}
+	}
+
+	got, err := p.GetCluster(ctx, newNR(map[string]any{"location": "us-central1", "clusterId": "c1"}))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	labels, _ := got.Data["labels"].(map[string]string)
+	if _, hasEnv := labels["env"]; hasEnv {
+		t.Errorf("labels reverted to the stale pre-race value instead of one of the 25 concurrent writers': got %v", labels)
+	}
+	gcpConfig, _ := got.Data["gcpConfig"].(map[string]any)
+	if gcpConfig["kmsKey"] == "orig" {
+		t.Errorf("gcpConfig.kmsKey reverted to the stale pre-race value instead of one of the 25 concurrent writers'")
 	}
 }
 
@@ -204,6 +278,83 @@ func TestTopicCRUD(t *testing.T) {
 	}
 	if _, err := p.GetTopic(ctx, newNR(map[string]any{"location": "us-central1", "clusterId": "c1", "topicId": "t1"})); err == nil {
 		t.Fatal("expected NotFound after delete, got nil error")
+	}
+}
+
+// delayedGetTopicStore wraps a mkstore.Store, delaying every GetTopic call
+// to widen a TOCTOU race window in tests. It only affects the pre-fix code
+// path (UpdateTopic calling a standalone GetTopic); UpdateTopicAtomic does
+// its own internal locked read and never reaches this override.
+type delayedGetTopicStore struct {
+	mkstore.Store
+	delay time.Duration
+}
+
+func (d *delayedGetTopicStore) GetTopic(ctx context.Context, projectID, location, clusterName, topicName string) (mkstore.Topic, error) {
+	tpc, err := d.Store.GetTopic(ctx, projectID, location, clusterName, topicName)
+	time.Sleep(d.delay)
+	return tpc, err
+}
+
+// TestUpdateTopicConcurrentDisjointFieldsNoLostUpdate proves UpdateTopic's
+// get-merge-write cycle is atomic with respect to other concurrent PATCH
+// requests. Without atomicity, a PATCH touching only "partitionCount" reads a
+// stale full copy of the topic (taken before a concurrent
+// "replicationFactor"-only PATCH committed), then writes that stale copy
+// back — silently reverting the replicationFactor change even though the
+// partitionCount PATCH never touched it.
+func TestUpdateTopicConcurrentDisjointFieldsNoLostUpdate(t *testing.T) {
+	ctx := context.Background()
+	p := New(&delayedGetTopicStore{Store: mkstore.NewMemoryStore(), delay: 5 * time.Millisecond})
+
+	if _, err := p.CreateCluster(ctx, newNR(createParams("us-central1", "c1", nil))); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+	if _, err := p.CreateTopic(ctx, newNR(map[string]any{
+		"location": "us-central1", "clusterId": "c1", "topicId": "t1",
+		"body": map[string]any{"partitionCount": float64(3), "replicationFactor": float64(2)},
+	})); err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+
+	const perField = 25
+	var wg sync.WaitGroup
+	errs := make([]error, 2*perField)
+	for i := 0; i < perField; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = p.UpdateTopic(ctx, newNR(map[string]any{
+				"location": "us-central1", "clusterId": "c1", "topicId": "t1",
+				"body": map[string]any{"partitionCount": float64(100 + i)},
+			}))
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[perField+i] = p.UpdateTopic(ctx, newNR(map[string]any{
+				"location": "us-central1", "clusterId": "c1", "topicId": "t1",
+				"body": map[string]any{"replicationFactor": float64(200 + i)},
+			}))
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("update %d: %v", i, err)
+		}
+	}
+
+	got, err := p.GetTopic(ctx, newNR(map[string]any{"location": "us-central1", "clusterId": "c1", "topicId": "t1"}))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	pc, _ := got.Data["partitionCount"].(int)
+	rf, _ := got.Data["replicationFactor"].(int)
+	if pc < 100 {
+		t.Errorf("partitionCount reverted to a stale value instead of one of the 25 concurrent writers': got %d", pc)
+	}
+	if rf < 200 {
+		t.Errorf("replicationFactor reverted to a stale value instead of one of the 25 concurrent writers': got %d", rf)
 	}
 }
 

--- a/internal/gcp/store/managedkafka/memory.go
+++ b/internal/gcp/store/managedkafka/memory.go
@@ -66,6 +66,24 @@ func (s *MemoryStore) UpdateCluster(_ context.Context, projectID, location strin
 	return nil
 }
 
+func (s *MemoryStore) UpdateClusterAtomic(_ context.Context, projectID, location, name string, mutate func(Cluster) (Cluster, error)) (Cluster, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := clusterScope(projectID, location)
+	current, ok := s.clusters[key][name]
+	if !ok {
+		return Cluster{}, ErrNoSuchCluster
+	}
+	next, err := mutate(current)
+	if err != nil {
+		return Cluster{}, err
+	}
+	next.ProjectID = projectID
+	next.Location = location
+	s.clusters[key][name] = next
+	return next, nil
+}
+
 func (s *MemoryStore) DeleteCluster(_ context.Context, projectID, location, name string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -129,6 +147,25 @@ func (s *MemoryStore) UpdateTopic(_ context.Context, projectID, location, cluste
 	t.ClusterName = clusterName
 	s.topics[key][t.Name] = t
 	return nil
+}
+
+func (s *MemoryStore) UpdateTopicAtomic(_ context.Context, projectID, location, clusterName, topicName string, mutate func(Topic) (Topic, error)) (Topic, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := topicScope(projectID, location, clusterName)
+	current, ok := s.topics[key][topicName]
+	if !ok {
+		return Topic{}, ErrNoSuchTopic
+	}
+	next, err := mutate(current)
+	if err != nil {
+		return Topic{}, err
+	}
+	next.ProjectID = projectID
+	next.Location = location
+	next.ClusterName = clusterName
+	s.topics[key][topicName] = next
+	return next, nil
 }
 
 func (s *MemoryStore) DeleteTopic(_ context.Context, projectID, location, clusterName, topicName string) error {

--- a/internal/gcp/store/managedkafka/postgres.go
+++ b/internal/gcp/store/managedkafka/postgres.go
@@ -86,6 +86,54 @@ func (s *PostgresStore) UpdateCluster(ctx context.Context, projectID, location s
 	return nil
 }
 
+// UpdateClusterAtomic mirrors MemoryStore's version: a Serializable
+// transaction with SELECT ... FOR UPDATE row-locks the cluster for the
+// duration of mutate, so a concurrent UpdateClusterAtomic on the same
+// cluster blocks until this transaction commits or rolls back, instead of
+// racing to silently overwrite this call's write. See
+// store/firestore/postgres.go's Commit for the same convention.
+func (s *PostgresStore) UpdateClusterAtomic(ctx context.Context, projectID, location, name string, mutate func(Cluster) (Cluster, error)) (Cluster, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return Cluster{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	current, err := scanCluster(tx.QueryRow(ctx, `
+		SELECT project_id, location, cluster_name, config, labels, create_time, update_time
+		FROM jc_mk_clusters WHERE project_id=$1 AND location=$2 AND cluster_name=$3 FOR UPDATE
+	`, projectID, location, name))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Cluster{}, ErrNoSuchCluster
+	}
+	if err != nil {
+		return Cluster{}, err
+	}
+
+	next, err := mutate(current)
+	if err != nil {
+		return Cluster{}, err
+	}
+
+	labels, _ := json.Marshal(next.Labels)
+	tag, err := tx.Exec(ctx, `
+		UPDATE jc_mk_clusters SET config=$4, labels=$5, update_time=$6
+		WHERE project_id=$1 AND location=$2 AND cluster_name=$3
+	`, projectID, location, name, nullableJSONRaw(next.Config, "{}"), nullableJSONRaw(labels, "{}"), next.UpdateTime)
+	if err != nil {
+		return Cluster{}, err
+	}
+	if tag.RowsAffected() == 0 {
+		return Cluster{}, ErrNoSuchCluster
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Cluster{}, err
+	}
+	next.ProjectID = projectID
+	next.Location = location
+	return next, nil
+}
+
 func (s *PostgresStore) DeleteCluster(ctx context.Context, projectID, location, name string) error {
 	// Delete the cluster's topics first so no orphaned rows remain, mirroring
 	// MemoryStore.DeleteCluster (which drops the topic scope alongside the
@@ -183,6 +231,54 @@ func (s *PostgresStore) UpdateTopic(ctx context.Context, projectID, location, cl
 		return ErrNoSuchTopic
 	}
 	return nil
+}
+
+// UpdateTopicAtomic mirrors MemoryStore's version: a Serializable
+// transaction with SELECT ... FOR UPDATE row-locks the topic for the
+// duration of mutate, so a concurrent UpdateTopicAtomic on the same topic
+// blocks until this transaction commits or rolls back, instead of racing to
+// silently overwrite this call's write. See store/firestore/postgres.go's
+// Commit for the same convention.
+func (s *PostgresStore) UpdateTopicAtomic(ctx context.Context, projectID, location, clusterName, topicName string, mutate func(Topic) (Topic, error)) (Topic, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return Topic{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	current, err := scanTopic(tx.QueryRow(ctx, `
+		SELECT project_id, location, cluster_name, topic_name, partition_count, replication_factor, config, create_time, update_time
+		FROM jc_mk_topics WHERE project_id=$1 AND location=$2 AND cluster_name=$3 AND topic_name=$4 FOR UPDATE
+	`, projectID, location, clusterName, topicName))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Topic{}, ErrNoSuchTopic
+	}
+	if err != nil {
+		return Topic{}, err
+	}
+
+	next, err := mutate(current)
+	if err != nil {
+		return Topic{}, err
+	}
+
+	tag, err := tx.Exec(ctx, `
+		UPDATE jc_mk_topics SET partition_count=$5, replication_factor=$6, config=$7, update_time=$8
+		WHERE project_id=$1 AND location=$2 AND cluster_name=$3 AND topic_name=$4
+	`, projectID, location, clusterName, topicName, next.PartitionCount, next.ReplicationFactor, nullableJSONRaw(next.Config, "{}"), next.UpdateTime)
+	if err != nil {
+		return Topic{}, err
+	}
+	if tag.RowsAffected() == 0 {
+		return Topic{}, ErrNoSuchTopic
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Topic{}, err
+	}
+	next.ProjectID = projectID
+	next.Location = location
+	next.ClusterName = clusterName
+	return next, nil
 }
 
 func (s *PostgresStore) DeleteTopic(ctx context.Context, projectID, location, clusterName, topicName string) error {

--- a/internal/gcp/store/managedkafka/store.go
+++ b/internal/gcp/store/managedkafka/store.go
@@ -52,12 +52,26 @@ type Store interface {
 	CreateCluster(ctx context.Context, projectID, location string, c Cluster) error
 	GetCluster(ctx context.Context, projectID, location, name string) (Cluster, error)
 	UpdateCluster(ctx context.Context, projectID, location string, c Cluster) error
+	// UpdateClusterAtomic performs a locked get-mutate-set cycle: mutate
+	// receives the current cluster and returns the version to persist, or an
+	// error to abort without writing. Unlike a separate GetCluster followed
+	// by UpdateCluster, this is atomic with respect to concurrent updates on
+	// the same cluster, so two concurrent PATCH requests merging different
+	// fields can't lose one or the other.
+	UpdateClusterAtomic(ctx context.Context, projectID, location, name string, mutate func(Cluster) (Cluster, error)) (Cluster, error)
 	DeleteCluster(ctx context.Context, projectID, location, name string) error
 	ListClusters(ctx context.Context, projectID, location string) ([]Cluster, error)
 
 	CreateTopic(ctx context.Context, projectID, location, clusterName string, t Topic) error
 	GetTopic(ctx context.Context, projectID, location, clusterName, topicName string) (Topic, error)
 	UpdateTopic(ctx context.Context, projectID, location, clusterName string, t Topic) error
+	// UpdateTopicAtomic performs a locked get-mutate-set cycle: mutate
+	// receives the current topic and returns the version to persist, or an
+	// error to abort without writing. Unlike a separate GetTopic followed by
+	// UpdateTopic, this is atomic with respect to concurrent updates on the
+	// same topic, so two concurrent PATCH requests merging different fields
+	// can't lose one or the other.
+	UpdateTopicAtomic(ctx context.Context, projectID, location, clusterName, topicName string, mutate func(Topic) (Topic, error)) (Topic, error)
 	DeleteTopic(ctx context.Context, projectID, location, clusterName, topicName string) error
 	ListTopics(ctx context.Context, projectID, location, clusterName string) ([]Topic, error)
 


### PR DESCRIPTION
## Summary
- `UpdateCluster` and `UpdateTopic` (Managed Kafka PATCH) each did a plain `Get`, merged the request body onto a local copy of the stored JSON config in Go, then called a separate `Update` to persist it — the same Get-then-separate-write shape already fixed in Secret Manager (#45), Datastore (#47), GCS (#48), Cloud Functions (#50), Workflows (#51), Dataproc (#53), and BigQuery (#54). Two concurrent PATCH requests touching different fields (e.g. one changing only `labels`, another only `gcpConfig`; or one changing only `partitionCount`, another only `replicationFactor`) could race: both merged onto the same stale snapshot, and whichever write landed last silently overwrote the other's already-applied field.
- Adds `UpdateClusterAtomic` and `UpdateTopicAtomic` to the managedkafka `Store` interface: `MemoryStore` uses a single locked critical section, `PostgresStore` uses a Serializable transaction + `SELECT ... FOR UPDATE`, mirroring the established convention.
- Rewires the provider's `UpdateCluster`/`UpdateTopic` to perform the merge inside the atomic `mutate` callback instead of a separate `Get` + `Update` pair.
- ConsumerGroup resource operations (get/update/delete) are unimplemented (always return `Unimplemented`) and untracked by the emulator, so there is no update path there to race — left alone.

## Verification
Two regression tests, each confirmed to fail against the old code (3/3 runs) before restoring the fix, using a delayed-`Get` store wrapper to reliably widen the TOCTOU window:
- `TestUpdateClusterConcurrentDisjointFieldsNoLostUpdate` (`labels` vs `gcpConfig`)
- `TestUpdateTopicConcurrentDisjointFieldsNoLostUpdate` (`partitionCount` vs `replicationFactor`)

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/gcp/...` — all pass
- [x] Both regression tests confirmed to fail on old code, pass on fixed code
- [x] `grep -rn "jaiscloud/internal/aws" internal/gcp/` — empty (isolation intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)