### PR TITLE
fix(gcp/monitoring): atomic UpdateAlertPolicy closes disjoint-mask lost-update race

### DIFF
--- a/internal/gcp/grpc/monitoring/service.go
+++ b/internal/gcp/grpc/monitoring/service.go
@@ -378,20 +378,18 @@ func (s *Service) UpdateAlertPolicy(ctx context.Context, req *monitoringpb.Updat
 
 	// An empty/nil update mask is a full replace (the historical behavior).
 	// A non-empty mask merges field-by-field: masked paths take the incoming
-	// value, unmasked paths retain the stored value.
-	p := incoming
-	if paths := req.GetUpdateMask().GetPaths(); len(paths) > 0 {
-		stored, err := s.store.GetAlertPolicy(ctx, project, id)
-		if err != nil {
-			return nil, mapError(err)
+	// value, unmasked paths retain the stored value. The get-check-merge
+	// happens inside UpdateAlertPolicyAtomic's locked section so a concurrent
+	// masked update touching different fields can't read the same stale
+	// snapshot and silently overwrite this one's change.
+	p, err := s.store.UpdateAlertPolicyAtomic(ctx, project, id, func(stored monitoringstore.AlertPolicy) (monitoringstore.AlertPolicy, error) {
+		paths := req.GetUpdateMask().GetPaths()
+		if len(paths) == 0 {
+			return incoming, nil
 		}
-		merged, err := applyAlertPolicyMask(stored, incoming, paths)
-		if err != nil {
-			return nil, mapError(err)
-		}
-		p = merged
-	}
-	if err := s.store.UpdateAlertPolicy(ctx, project, p); err != nil {
+		return applyAlertPolicyMask(stored, incoming, paths)
+	})
+	if err != nil {
 		return nil, mapError(err)
 	}
 	return alertPolicyToProto(p, project), nil

--- a/internal/gcp/grpc/monitoring/service_test.go
+++ b/internal/gcp/grpc/monitoring/service_test.go
@@ -2,8 +2,10 @@ package monitoring
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -24,7 +26,12 @@ import (
 
 func testServer(t *testing.T) (monitoringpb.MetricServiceClient, monitoringpb.AlertPolicyServiceClient, func()) {
 	t.Helper()
-	svc := NewService(monitoringstore.NewMemoryStore(), "test")
+	return testServerWithStore(t, monitoringstore.NewMemoryStore())
+}
+
+func testServerWithStore(t *testing.T, store monitoringstore.Store) (monitoringpb.MetricServiceClient, monitoringpb.AlertPolicyServiceClient, func()) {
+	t.Helper()
+	svc := NewService(store, "test")
 
 	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
@@ -402,6 +409,94 @@ func TestUpdateAlertPolicyUpdateMask(t *testing.T) {
 		},
 	}); status.Code(err) != codes.Unimplemented {
 		t.Fatalf("unsupported mask path err = %v, want Unimplemented", err)
+	}
+}
+
+// delayedGetAlertPolicyStore wraps a monitoringstore.Store, delaying every
+// GetAlertPolicy call to widen a TOCTOU race window in tests. It only
+// affects the pre-fix code path (UpdateAlertPolicy calling a standalone
+// GetAlertPolicy); UpdateAlertPolicyAtomic does its own internal locked read
+// and never reaches this override.
+type delayedGetAlertPolicyStore struct {
+	monitoringstore.Store
+	delay time.Duration
+}
+
+func (d *delayedGetAlertPolicyStore) GetAlertPolicy(ctx context.Context, project, id string) (monitoringstore.AlertPolicy, error) {
+	p, err := d.Store.GetAlertPolicy(ctx, project, id)
+	time.Sleep(d.delay)
+	return p, err
+}
+
+// TestUpdateAlertPolicyConcurrentDisjointMasksNoLostUpdate proves
+// UpdateAlertPolicy's get-merge-write cycle is atomic with respect to other
+// concurrent masked-update requests. Without atomicity, a masked update
+// touching only "display_name" reads a stale full copy of the policy (taken
+// before a concurrent "enabled"-only masked update committed), then writes
+// that stale copy back — silently reverting the enabled change even though
+// the display_name update's mask never named it. 25 goroutines each update
+// only "display_name" and 25 update only "enabled"; a delayed-Get store
+// wrapper widens the TOCTOU window reliably (the real in-memory round trip
+// otherwise completes in nanoseconds).
+func TestUpdateAlertPolicyConcurrentDisjointMasksNoLostUpdate(t *testing.T) {
+	_, ac, cleanup := testServerWithStore(t, &delayedGetAlertPolicyStore{Store: monitoringstore.NewMemoryStore(), delay: 5 * time.Millisecond})
+	defer cleanup()
+	ctx := context.Background()
+
+	created, err := ac.CreateAlertPolicy(ctx, &monitoringpb.CreateAlertPolicyRequest{
+		Name: "projects/test",
+		AlertPolicy: &monitoringpb.AlertPolicy{
+			DisplayName: "orig-name",
+			Combiner:    monitoringpb.AlertPolicy_AND,
+			Enabled:     wrapperspb.Bool(false),
+		},
+	})
+	if err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+
+	const perField = 25
+	var wg sync.WaitGroup
+	errs := make([]error, 2*perField)
+	for i := 0; i < perField; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = ac.UpdateAlertPolicy(ctx, &monitoringpb.UpdateAlertPolicyRequest{
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"display_name"}},
+				AlertPolicy: &monitoringpb.AlertPolicy{
+					Name:        created.GetName(),
+					DisplayName: fmt.Sprintf("vName%d", i),
+				},
+			})
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[perField+i] = ac.UpdateAlertPolicy(ctx, &monitoringpb.UpdateAlertPolicyRequest{
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"enabled"}},
+				AlertPolicy: &monitoringpb.AlertPolicy{
+					Name:    created.GetName(),
+					Enabled: wrapperspb.Bool(true),
+				},
+			})
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("update %d: %v", i, err)
+		}
+	}
+
+	got, err := ac.GetAlertPolicy(ctx, &monitoringpb.GetAlertPolicyRequest{Name: created.GetName()})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !strings.HasPrefix(got.GetDisplayName(), "vName") {
+		t.Errorf("display_name reverted to a stale value instead of one of the 25 concurrent writers': got %q", got.GetDisplayName())
+	}
+	if !got.GetEnabled().GetValue() {
+		t.Errorf("enabled reverted to the stale pre-race value (false) instead of the 25 concurrent writers' value (true)")
 	}
 }
 

--- a/internal/gcp/store/monitoring/memory.go
+++ b/internal/gcp/store/monitoring/memory.go
@@ -144,6 +144,22 @@ func (s *MemoryStore) UpdateAlertPolicy(_ context.Context, project string, p Ale
 	return nil
 }
 
+func (s *MemoryStore) UpdateAlertPolicyAtomic(_ context.Context, project, id string, mutate func(AlertPolicy) (AlertPolicy, error)) (AlertPolicy, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.policies[project][id]
+	if !ok {
+		return AlertPolicy{}, ErrAlertPolicyNotFound
+	}
+	next, err := mutate(current)
+	if err != nil {
+		return AlertPolicy{}, err
+	}
+	next.ID = id
+	s.policies[project][id] = next
+	return next, nil
+}
+
 func (s *MemoryStore) DeleteAlertPolicy(_ context.Context, project, id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/gcp/store/monitoring/postgres.go
+++ b/internal/gcp/store/monitoring/postgres.go
@@ -271,6 +271,54 @@ func (s *PostgresStore) UpdateAlertPolicy(ctx context.Context, project string, p
 	return nil
 }
 
+// UpdateAlertPolicyAtomic mirrors MemoryStore's version: a Serializable
+// transaction with SELECT ... FOR UPDATE row-locks the policy for the
+// duration of mutate, so a concurrent UpdateAlertPolicyAtomic on the same
+// policy blocks until this transaction commits or rolls back, instead of
+// racing to silently overwrite this call's write. See
+// store/firestore/postgres.go's Commit for the same convention.
+func (s *PostgresStore) UpdateAlertPolicyAtomic(ctx context.Context, project, id string, mutate func(AlertPolicy) (AlertPolicy, error)) (AlertPolicy, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return AlertPolicy{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	row := tx.QueryRow(ctx, `
+		SELECT `+policyCols+` FROM jc_monitoring_alert_policies WHERE project_id=$1 AND id=$2 FOR UPDATE
+	`, project, id)
+	current, err := scanAlertPolicy(row.Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return AlertPolicy{}, ErrAlertPolicyNotFound
+	}
+	if err != nil {
+		return AlertPolicy{}, err
+	}
+
+	next, err := mutate(current)
+	if err != nil {
+		return AlertPolicy{}, err
+	}
+
+	tag, err := tx.Exec(ctx, `
+		UPDATE jc_monitoring_alert_policies
+		SET display_name=$3, combiner=$4, enabled=$5, documentation=$6, conditions=$7, notification_channels=$8, user_labels=$9
+		WHERE project_id=$1 AND id=$2
+	`, project, id, next.DisplayName, next.Combiner, next.Enabled, jsonb(next.Documentation),
+		jsonb(next.Conditions), jsonb(next.NotificationChannels), jsonb(next.UserLabels))
+	if err != nil {
+		return AlertPolicy{}, fmt.Errorf("monitoring UpdateAlertPolicyAtomic: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return AlertPolicy{}, ErrAlertPolicyNotFound
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return AlertPolicy{}, err
+	}
+	next.ID = id
+	return next, nil
+}
+
 func (s *PostgresStore) DeleteAlertPolicy(ctx context.Context, project, id string) error {
 	tag, err := s.pool.Exec(ctx, `
 		DELETE FROM jc_monitoring_alert_policies WHERE project_id=$1 AND id=$2

--- a/internal/gcp/store/monitoring/store.go
+++ b/internal/gcp/store/monitoring/store.go
@@ -108,6 +108,14 @@ type Store interface {
 	GetAlertPolicy(ctx context.Context, project, id string) (AlertPolicy, error)
 	ListAlertPolicies(ctx context.Context, project string) ([]AlertPolicy, error)
 	UpdateAlertPolicy(ctx context.Context, project string, p AlertPolicy) error
+	// UpdateAlertPolicyAtomic performs a locked get-mutate-set cycle: mutate
+	// receives the current policy and returns the version to persist, or an
+	// error to abort without writing. Unlike a separate GetAlertPolicy
+	// followed by UpdateAlertPolicy, this is atomic with respect to
+	// concurrent updates on the same policy, so a masked PATCH that merges
+	// only a subset of fields can't lose a concurrent PATCH's changes to
+	// other fields.
+	UpdateAlertPolicyAtomic(ctx context.Context, project, id string, mutate func(AlertPolicy) (AlertPolicy, error)) (AlertPolicy, error)
 	DeleteAlertPolicy(ctx context.Context, project, id string) error
 
 	Reset(ctx context.Context)


### PR DESCRIPTION
## Summary
- `UpdateAlertPolicy`'s masked-update path did a plain `GetAlertPolicy`, merged only the `updateMask`-named fields onto the result in Go, then called a separate `UpdateAlertPolicy` to persist it — the same Get-then-separate-write shape already fixed in Secret Manager (#45), Datastore (#47), GCS (#48), Cloud Functions (#50), Workflows (#51), Dataproc (#53), BigQuery (#54), and Managed Kafka (#55). Two concurrent masked updates with disjoint masks (e.g. one updating only `display_name`, another only `enabled`) could race: both merged onto the same stale snapshot, and whichever write landed last silently reverted the other's already-applied field change.
- Adds `UpdateAlertPolicyAtomic` to the monitoring `Store` interface: `MemoryStore` uses a single locked critical section, `PostgresStore` uses a Serializable transaction + `SELECT ... FOR UPDATE`, mirroring the established convention.
- Rewires the gRPC service's `UpdateAlertPolicy` to perform the mask application inside the atomic `mutate` callback instead of a separate `Get` + `Update` pair. The unmasked (full-replace) path is unaffected.

## Verification
Added `TestUpdateAlertPolicyConcurrentDisjointMasksNoLostUpdate`: 25 goroutines update only `display_name`, 25 update only `enabled`, concurrently, using a delayed-`Get` store wrapper to reliably widen the TOCTOU window. Confirmed the test fails against the old code (3/3 runs — either `display_name` or `enabled` reverts to its pre-race value) by temporarily reverting the fix, then confirmed it passes (3/3 runs) with the fix restored. The existing `TestUpdateAlertPolicyUpdateMask` (masked-merge correctness) still passes.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/gcp/...` — all pass
- [x] Regression test confirmed to fail on old code, pass on fixed code
- [x] `grep -rn "jaiscloud/internal/aws" internal/gcp/` — empty (isolation intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)