### PR TITLE
feat(gcp/metastore): DPMS Hive Metastore Thrift serving plane

### DIFF
--- a/cmd/jaiscloud-gcp/main.go
+++ b/cmd/jaiscloud-gcp/main.go
@@ -33,6 +33,7 @@ import (
 	grpcsecretmanager "jaiscloud/internal/gcp/grpc/secretmanager"
 	grpcstorage "jaiscloud/internal/gcp/grpc/storage"
 	grpcstoragepb "jaiscloud/internal/gcp/grpc/storage/storagepb"
+	hms "jaiscloud/internal/gcp/hms"
 	bigqueryprovider "jaiscloud/internal/gcp/provider/bigquery"
 	dataprocprovider "jaiscloud/internal/gcp/provider/dataproc"
 	firestoreprovider "jaiscloud/internal/gcp/provider/firestore"
@@ -55,6 +56,7 @@ import (
 	firestorestore "jaiscloud/internal/gcp/store/firestore"
 	functionsstore "jaiscloud/internal/gcp/store/functions"
 	"jaiscloud/internal/gcp/store/gcs"
+	hmsstore "jaiscloud/internal/gcp/store/hms"
 	icebergstore "jaiscloud/internal/gcp/store/iceberg"
 	kmsstore "jaiscloud/internal/gcp/store/kms"
 	loggingstore "jaiscloud/internal/gcp/store/logging"
@@ -307,6 +309,7 @@ func startCmd() *cobra.Command {
 			adminHandler.RegisterResetter(stores.managedkafka)
 			adminHandler.RegisterResetter(stores.metastore)
 			adminHandler.RegisterResetter(stores.iceberg)
+			adminHandler.RegisterResetter(stores.hms)
 			adminHandler.RegisterResetter(stores.bigquery)
 			adminHandler.RegisterResetter(stores.logEntries)
 			adminHandler.RegisterResetter(stores.monitoring)
@@ -354,6 +357,9 @@ func startCmd() *cobra.Command {
 			}
 			if snap, ok := stores.iceberg.(admin.Snapshotter); ok {
 				adminHandler.RegisterSnapshotter("iceberg", snap)
+			}
+			if snap, ok := stores.hms.(admin.Snapshotter); ok {
+				adminHandler.RegisterSnapshotter("hms", snap)
 			}
 			if snap, ok := stores.bigquery.(admin.Snapshotter); ok {
 				adminHandler.RegisterSnapshotter("bigquery", snap)
@@ -479,6 +485,21 @@ func startCmd() *cobra.Command {
 			}()
 			defer gserv.Stop()
 
+			// Serve the Hive Metastore (Thrift) serving plane on its own TCP
+			// listener. Thrift is a binary protocol over raw TCP — it does not
+			// flow through the HTTP gateway or the gRPC server. The catalog is
+			// single-global (gcp-dpms-hms-thrift.md §2.4/F6): the per-Service
+			// endpoint_uri emitted by the control plane is cosmetic.
+			hmsPort, _ := cmd.Flags().GetInt("hms-port")
+			hmsServer := hms.NewServer(fmt.Sprintf(":%d", hmsPort), stores.hms)
+			go func() {
+				slog.Info("hive metastore (thrift) server starting", "hms_port", hmsPort)
+				if err := hmsServer.Serve(); err != nil {
+					slog.Error("hive metastore server error", "err", err)
+				}
+			}()
+			defer hmsServer.Stop()
+
 			return srv.ListenAndServe()
 		},
 	}
@@ -497,6 +518,7 @@ func startCmd() *cobra.Command {
 	cmd.Flags().Bool("gcp-metadata", false, "Enable the GCP metadata-server emulator")
 	cmd.Flags().String("kms-master-key", "", "32-byte hex KEK for KMS envelope encryption")
 	cmd.Flags().Int("grpc-port", 8081, "gRPC (h2c) listen port")
+	cmd.Flags().Int("hms-port", 9083, "Hive Metastore (Thrift) listen port")
 	return cmd
 }
 
@@ -531,6 +553,7 @@ type stores struct {
 	managedkafka managedkafkastore.Store
 	metastore    metastorestore.Store
 	iceberg      icebergstore.Store
+	hms          hmsstore.Store
 	bigquery     bigquerystore.Store
 	logEntries   loggingstore.Store
 	monitoring   monitoringstore.Store
@@ -567,6 +590,7 @@ func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*st
 			managedkafka: managedkafkastore.NewPostgresStore(pg.Pool()),
 			metastore:    metastorestore.NewPostgresStore(pg.Pool()),
 			iceberg:      icebergstore.NewPostgresStore(pg.Pool()),
+			hms:          hmsstore.NewPostgresStore(pg.Pool()),
 			bigquery:     bigquerystore.NewPostgresStore(pg.Pool()),
 			logEntries:   loggingstore.NewPostgresStore(pg.Pool()),
 			monitoring:   monitoringstore.NewPostgresStore(pg.Pool()),
@@ -589,6 +613,7 @@ func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*st
 			managedkafka: managedkafkastore.NewMemoryStore(),
 			metastore:    metastorestore.NewMemoryStore(),
 			iceberg:      icebergstore.NewMemoryStore(),
+			hms:          hmsstore.NewMemoryStore(),
 			bigquery:     bigquerystore.NewMemoryStore(),
 			logEntries:   loggingstore.NewMemoryStore(),
 			monitoring:   monitoringstore.NewMemoryStore(),
@@ -614,6 +639,7 @@ func initStores(ctx context.Context, cfg *config.Config, instanceID string) (*st
 		managedkafka: managedkafkastore.NewMemoryStore(),
 		metastore:    metastorestore.NewMemoryStore(),
 		iceberg:      icebergstore.NewMemoryStore(),
+		hms:          hmsstore.NewMemoryStore(),
 		bigquery:     bigquerystore.NewMemoryStore(),
 		logEntries:   loggingstore.NewMemoryStore(),
 		monitoring:   monitoringstore.NewMemoryStore(),

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	cloud.google.com/go/monitoring v1.30.0
 	cloud.google.com/go/pubsub/v2 v2.7.0
 	cloud.google.com/go/secretmanager v1.21.0
+	github.com/apache/thrift v0.24.0
 	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ cloud.google.com/go/pubsub/v2 v2.7.0 h1:MFrBTZZa6PDWZzCi4NJRsHKMm2w0a4oAaYNqwjgb
 cloud.google.com/go/pubsub/v2 v2.7.0/go.mod h1:JaFvWNVRk3Knoil/4M1ECeLOaI9D8drbmJWypQlK5aM=
 cloud.google.com/go/secretmanager v1.21.0 h1:e56QQaKWRyzBdUz40AeZaio/ZHAl268cFx3QFAAw9CY=
 cloud.google.com/go/secretmanager v1.21.0/go.mod h1:+nlV+GYqTD8DM+x7Kk3UF7ZPYgdYMowrkZxAmMXORQ8=
+github.com/apache/thrift v0.24.0 h1:zy31L1a49QTNB2bG1BBfMXol3yJrTH975G3pPubQVLQ=
+github.com/apache/thrift v0.24.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
 github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
 github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=

--- a/internal/gcp/hms/codec_test.go
+++ b/internal/gcp/hms/codec_test.go
@@ -1,0 +1,484 @@
+package hms
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+// A reference TBinaryProtocol encoder (apache/thrift primitives, independent of
+// this package's codec) is used to "capture" authoritative byte fixtures for
+// the round-trip tests. writeRefStruct writes fields in the given order and
+// returns the wire bytes, exactly as a generated Java client would.
+
+type refField struct {
+	typ thrift.TType
+	id  int16
+	val refValue
+}
+
+// refValue is one of: bool, int8, int16, int32, int64, float64, string,
+// refStruct, refList, refMap.
+type refValue struct {
+	kind string
+	b    bool
+	i8   int8
+	i16  int16
+	i32  int32
+	i64  int64
+	f64  float64
+	str  string
+	st   refStruct
+	lst  refList
+	m    refMap
+}
+
+type refStruct struct{ fields []refField }
+
+type refList struct {
+	elem  thrift.TType
+	items []refValue
+}
+
+type refMap struct {
+	k, v  thrift.TType
+	items []refMapEntry
+}
+
+type refMapEntry struct{ k, v refValue }
+
+func rfBool(v bool) refValue      { return refValue{kind: "bool", b: v} }
+func rfByte(v int8) refValue      { return refValue{kind: "i8", i8: v} }
+func rfI16(v int16) refValue      { return refValue{kind: "i16", i16: v} }
+func rfI32(v int32) refValue      { return refValue{kind: "i32", i32: v} }
+func rfI64(v int64) refValue      { return refValue{kind: "i64", i64: v} }
+func rfDouble(v float64) refValue { return refValue{kind: "f64", f64: v} }
+func rfStr(v string) refValue     { return refValue{kind: "str", str: v} }
+func rfStruct(s refStruct) refValue {
+	return refValue{kind: "struct", st: s}
+}
+func rfList(e thrift.TType, items ...refValue) refValue {
+	return refValue{kind: "list", lst: refList{elem: e, items: items}}
+}
+func rfMap(k, v thrift.TType, items ...refMapEntry) refValue {
+	return refValue{kind: "map", m: refMap{k: k, v: v, items: items}}
+}
+func rfEntry(k, v refValue) refMapEntry { return refMapEntry{k: k, v: v} }
+
+func refWriteValue(p thrift.TProtocol, v refValue) error {
+	ctx := context.Background()
+	switch v.kind {
+	case "bool":
+		return p.WriteBool(ctx, v.b)
+	case "i8":
+		return p.WriteByte(ctx, v.i8)
+	case "i16":
+		return p.WriteI16(ctx, v.i16)
+	case "i32":
+		return p.WriteI32(ctx, v.i32)
+	case "i64":
+		return p.WriteI64(ctx, v.i64)
+	case "f64":
+		return p.WriteDouble(ctx, v.f64)
+	case "str":
+		return p.WriteString(ctx, v.str)
+	case "struct":
+		return refWriteStruct(p, v.st)
+	case "list":
+		if err := p.WriteListBegin(ctx, v.lst.elem, len(v.lst.items)); err != nil {
+			return err
+		}
+		for _, it := range v.lst.items {
+			if err := refWriteValue(p, it); err != nil {
+				return err
+			}
+		}
+		return p.WriteListEnd(ctx)
+	case "map":
+		if err := p.WriteMapBegin(ctx, v.m.k, v.m.v, len(v.m.items)); err != nil {
+			return err
+		}
+		for _, it := range v.m.items {
+			if err := refWriteValue(p, it.k); err != nil {
+				return err
+			}
+			if err := refWriteValue(p, it.v); err != nil {
+				return err
+			}
+		}
+		return p.WriteMapEnd(ctx)
+	}
+	return nil
+}
+
+func refWriteStruct(p thrift.TProtocol, s refStruct) error {
+	ctx := context.Background()
+	if err := p.WriteStructBegin(ctx, ""); err != nil {
+		return err
+	}
+	for _, f := range s.fields {
+		if err := p.WriteFieldBegin(ctx, "", f.typ, f.id); err != nil {
+			return err
+		}
+		if err := refWriteValue(p, f.val); err != nil {
+			return err
+		}
+		if err := p.WriteFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := p.WriteFieldStop(ctx); err != nil {
+		return err
+	}
+	return p.WriteStructEnd(ctx)
+}
+
+// refEncode renders a struct's wire bytes with the reference encoder.
+func refEncode(s refStruct) []byte {
+	buf := thrift.NewTMemoryBuffer()
+	p := thrift.NewTBinaryProtocolTransport(buf)
+	if err := refWriteStruct(p, s); err != nil {
+		panic(err)
+	}
+	p.Flush(context.Background())
+	return append([]byte(nil), buf.Bytes()...)
+}
+
+// refDecode reads a struct with this package's codec.
+func refDecode(t *testing.T, b []byte) *Struct {
+	t.Helper()
+	buf := thrift.NewTMemoryBuffer()
+	buf.Write(b)
+	p := thrift.NewTBinaryProtocolTransport(buf)
+	s, err := ReadStruct(context.Background(), p)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return s
+}
+
+// refReencode writes a struct with this package's codec.
+func refReencode(t *testing.T, s *Struct) []byte {
+	t.Helper()
+	buf := thrift.NewTMemoryBuffer()
+	p := thrift.NewTBinaryProtocolTransport(buf)
+	if err := WriteStruct(context.Background(), p, s); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	p.Flush(context.Background())
+	return append([]byte(nil), buf.Bytes()...)
+}
+
+func assertRoundTrip(t *testing.T, name string, src refStruct, want []byte, check func(*Struct)) {
+	t.Helper()
+	decoded := refDecode(t, want)
+	if check != nil {
+		check(decoded)
+	}
+	got := refReencode(t, decoded)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("%s: encode(decode(bytes)) != bytes\n got  %x\n want %x", name, got, want)
+	}
+	// Also round-trip through the reference encoder's own struct (sanity).
+	if src.fields != nil && len(decoded.Fields) != len(src.fields) {
+		t.Fatalf("%s: decoded %d fields, want %d", name, len(decoded.Fields), len(src.fields))
+	}
+}
+
+// TestGoldenFieldSchema is a fully hand-computed fixture: FieldSchema
+// {1:"id", 2:"string", 3:"id column"} in strict TBinaryProtocol.
+func TestGoldenFieldSchema(t *testing.T) {
+	golden, err := hex.DecodeString("0b00010000000269640b000200000006737472696e670b000300000009696420636f6c756d6e00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertRoundTrip(t, "FieldSchema", refStruct{}, golden, func(s *Struct) {
+		if s.String(1) != "id" || s.String(2) != "string" || s.String(3) != "id column" {
+			t.Fatalf("field values wrong: name=%q type=%q comment=%q", s.String(1), s.String(2), s.String(3))
+		}
+	})
+}
+
+// TestRoundTripScalars covers every scalar type the codec handles.
+func TestRoundTripScalars(t *testing.T) {
+	src := refStruct{fields: []refField{
+		{thrift.BOOL, 1, rfBool(true)},
+		{thrift.BYTE, 2, rfByte(-3)},
+		{thrift.I16, 3, rfI16(-1234)},
+		{thrift.I32, 4, rfI32(123456)},
+		{thrift.I64, 5, rfI64(1234567890123)},
+		{thrift.DOUBLE, 6, rfDouble(3.141592653589793)},
+		{thrift.STRING, 7, rfStr("hello world")},
+	}}
+	got := refEncode(src)
+	assertRoundTrip(t, "Scalars", src, got, func(s *Struct) {
+		if v, _ := s.Get(1); !v.B {
+			t.Fatal("bool wrong")
+		}
+		if v, _ := s.Get(2); v.I8 != -3 {
+			t.Fatal("i8 wrong")
+		}
+		if v, _ := s.Get(3); v.I16 != -1234 {
+			t.Fatal("i16 wrong")
+		}
+		if v, _ := s.Get(4); v.I32 != 123456 {
+			t.Fatal("i32 wrong")
+		}
+		if v, _ := s.Get(5); v.I64 != 1234567890123 {
+			t.Fatal("i64 wrong")
+		}
+		if v, _ := s.Get(6); v.F64 != 3.141592653589793 {
+			t.Fatal("double wrong")
+		}
+		if s.String(7) != "hello world" {
+			t.Fatal("string wrong")
+		}
+	})
+}
+
+// TestRoundTripContainers covers list/set/map, including nested containers and
+// struct-typed elements.
+func TestRoundTripContainers(t *testing.T) {
+	src := refStruct{fields: []refField{
+		{thrift.LIST, 1, rfList(thrift.STRING, rfStr("a"), rfStr("b"), rfStr("c"))},
+		{thrift.SET, 2, rfList(thrift.I32, rfI32(1), rfI32(2))},
+		{thrift.MAP, 3, rfMap(thrift.STRING, thrift.STRING, rfEntry(rfStr("k1"), rfStr("v1")), rfEntry(rfStr("k2"), rfStr("v2")))},
+		{thrift.LIST, 4, rfList(thrift.LIST, rfList(thrift.STRING, rfStr("x"), rfStr("y")), rfList(thrift.STRING, rfStr("z")))},
+	}}
+	got := refEncode(src)
+	assertRoundTrip(t, "Containers", src, got, func(s *Struct) {
+		if l := s.List(1); len(l) != 3 || l[0].Str != "a" {
+			t.Fatalf("list wrong: %+v", l)
+		}
+		if l := s.List(2); len(l) != 2 {
+			t.Fatalf("set wrong: %+v", l)
+		}
+		if m := s.MapStrStr(3); m["k1"] != "v1" || m["k2"] != "v2" {
+			t.Fatalf("map wrong: %+v", m)
+		}
+		if l := s.List(4); len(l) != 2 {
+			t.Fatalf("nested list wrong: %+v", l)
+		}
+	})
+}
+
+// TestRoundTripSerDeInfo exercises the SerDeInfo struct + a map field.
+func TestRoundTripSerDeInfo(t *testing.T) {
+	src := refStruct{fields: []refField{
+		{thrift.STRING, 1, rfStr("iceberg")},
+		{thrift.STRING, 2, rfStr("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")},
+		{thrift.MAP, 3, rfMap(thrift.STRING, thrift.STRING, rfEntry(rfStr("serialization.format"), rfStr("1")))},
+	}}
+	got := refEncode(src)
+	assertRoundTrip(t, "SerDeInfo", src, got, func(s *Struct) {
+		if s.String(1) != "iceberg" || s.String(2) != "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe" {
+			t.Fatal("serde fields wrong")
+		}
+		if m := s.MapStrStr(3); m["serialization.format"] != "1" {
+			t.Fatal("serde params wrong")
+		}
+	})
+}
+
+// TestRoundTripStorageDescriptor exercises the full StorageDescriptor struct.
+func TestRoundTripStorageDescriptor(t *testing.T) {
+	fs := refStruct{fields: []refField{{thrift.STRING, 1, rfStr("id")}, {thrift.STRING, 2, rfStr("int")}}}
+	serde := refStruct{fields: []refField{
+		{thrift.STRING, 1, rfStr("t")},
+		{thrift.STRING, 2, rfStr("lib")},
+		{thrift.MAP, 3, rfMap(thrift.STRING, thrift.STRING)},
+	}}
+	src := refStruct{fields: []refField{
+		{thrift.LIST, 1, rfList(thrift.STRUCT, rfStruct(fs))},
+		{thrift.STRING, 2, rfStr("gs://bucket/wh/db/tbl")},
+		{thrift.STRING, 3, rfStr("InputFormat")},
+		{thrift.STRING, 4, rfStr("OutputFormat")},
+		{thrift.BOOL, 5, rfBool(false)},
+		{thrift.I32, 6, rfI32(0)},
+		{thrift.STRUCT, 7, rfStruct(serde)},
+		{thrift.LIST, 8, rfList(thrift.STRING)},
+		{thrift.LIST, 9, rfList(thrift.STRUCT)},
+		{thrift.MAP, 10, rfMap(thrift.STRING, thrift.STRING, rfEntry(rfStr("k"), rfStr("v")))},
+		{thrift.BOOL, 12, rfBool(false)},
+	}}
+	got := refEncode(src)
+	assertRoundTrip(t, "StorageDescriptor", src, got, func(s *Struct) {
+		if s.String(2) != "gs://bucket/wh/db/tbl" {
+			t.Fatal("sd location wrong")
+		}
+		if s.String(3) != "InputFormat" || s.String(4) != "OutputFormat" {
+			t.Fatal("sd formats wrong")
+		}
+		if sd := s.Struct(7); sd == nil || sd.String(2) != "lib" {
+			t.Fatal("sd serdeInfo wrong")
+		}
+		if m := s.MapStrStr(10); m["k"] != "v" {
+			t.Fatal("sd parameters wrong")
+		}
+	})
+}
+
+// TestRoundTripDatabase exercises the Database struct (the decomposed store
+// fields plus ownerName/ownerType).
+func TestRoundTripDatabase(t *testing.T) {
+	src := refStruct{fields: []refField{
+		{thrift.STRING, 1, rfStr("default")},
+		{thrift.STRING, 2, rfStr("desc")},
+		{thrift.STRING, 3, rfStr("file:/tmp/default")},
+		{thrift.MAP, 4, rfMap(thrift.STRING, thrift.STRING, rfEntry(rfStr("a"), rfStr("b")))},
+		{thrift.STRING, 6, rfStr("owner")},
+		{thrift.I32, 7, rfI32(1)},
+	}}
+	got := refEncode(src)
+	assertRoundTrip(t, "Database", src, got, func(s *Struct) {
+		if s.String(1) != "default" || s.String(2) != "desc" || s.String(3) != "file:/tmp/default" {
+			t.Fatal("db fields wrong")
+		}
+		if m := s.MapStrStr(4); m["a"] != "b" {
+			t.Fatal("db params wrong")
+		}
+		if s.String(6) != "owner" || s.I32(7) != 1 {
+			t.Fatal("db owner wrong")
+		}
+	})
+}
+
+// TestRoundTripTable exercises the FULL Table struct: every field populated,
+// including nested StorageDescriptor -> SerDeInfo/FieldSchema/Order and
+// partitionKeys. This is the lossless-round-trip guard F5 demands.
+func TestRoundTripTable(t *testing.T) {
+	fs := refStruct{fields: []refField{
+		{thrift.STRING, 1, rfStr("id")},
+		{thrift.STRING, 2, rfStr("bigint")},
+		{thrift.STRING, 3, rfStr("the id")},
+	}}
+	serde := refStruct{fields: []refField{
+		{thrift.STRING, 1, rfStr("tbl")},
+		{thrift.STRING, 2, rfStr("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")},
+		{thrift.MAP, 3, rfMap(thrift.STRING, thrift.STRING, rfEntry(rfStr("serialization.format"), rfStr("1")))},
+	}}
+	order := refStruct{fields: []refField{{thrift.STRING, 1, rfStr("id")}, {thrift.I32, 2, rfI32(1)}}}
+	sd := refStruct{fields: []refField{
+		{thrift.LIST, 1, rfList(thrift.STRUCT, rfStruct(fs))},
+		{thrift.STRING, 2, rfStr("gs://bucket/wh/db/tbl")},
+		{thrift.STRING, 3, rfStr("org.apache.hadoop.mapred.FileInputFormat")},
+		{thrift.STRING, 4, rfStr("org.apache.hadoop.mapred.FileOutputFormat")},
+		{thrift.BOOL, 5, rfBool(false)},
+		{thrift.I32, 6, rfI32(0)},
+		{thrift.STRUCT, 7, rfStruct(serde)},
+		{thrift.LIST, 8, rfList(thrift.STRING)},
+		{thrift.LIST, 9, rfList(thrift.STRUCT, rfStruct(order))},
+		{thrift.MAP, 10, rfMap(thrift.STRING, thrift.STRING)},
+		{thrift.BOOL, 12, rfBool(false)},
+	}}
+	tbl := refStruct{fields: []refField{
+		{thrift.STRING, 1, rfStr("iceberg_table")},
+		{thrift.STRING, 2, rfStr("default")},
+		{thrift.STRING, 3, rfStr("spark")},
+		{thrift.I32, 4, rfI32(1700000000)},
+		{thrift.I32, 5, rfI32(0)},
+		{thrift.I32, 6, rfI32(0)},
+		{thrift.STRUCT, 7, rfStruct(sd)},
+		{thrift.LIST, 8, rfList(thrift.STRUCT)},
+		{thrift.MAP, 9, rfMap(thrift.STRING, thrift.STRING,
+			rfEntry(rfStr("metadata_location"), rfStr("gs://bucket/wh/db/tbl/metadata/00001.metadata.json")),
+			rfEntry(rfStr("previous_metadata_location"), rfStr("gs://bucket/wh/db/tbl/metadata/00000.metadata.json")),
+			rfEntry(rfStr("table_type"), rfStr("ICEBERG")),
+		)},
+		{thrift.STRING, 10, rfStr("")},
+		{thrift.STRING, 11, rfStr("")},
+		{thrift.STRING, 12, rfStr("EXTERNAL_TABLE")},
+		{thrift.BOOL, 14, rfBool(false)},
+		{thrift.BOOL, 15, rfBool(false)},
+		{thrift.STRING, 16, rfStr("hive")},
+	}}
+	got := refEncode(tbl)
+	assertRoundTrip(t, "Table", tbl, got, func(s *Struct) {
+		if s.String(tblTableName) != "iceberg_table" || s.String(tblDBName) != "default" {
+			t.Fatal("table identity wrong")
+		}
+		if m := s.MapStrStr(9); m["metadata_location"] == "" || m["table_type"] != "ICEBERG" {
+			t.Fatalf("table parameters wrong: %v", m)
+		}
+		sdDecoded := s.Struct(7)
+		if sdDecoded == nil || sdDecoded.String(2) != "gs://bucket/wh/db/tbl" {
+			t.Fatal("table sd wrong")
+		}
+		if sdDecoded.String(3) != "org.apache.hadoop.mapred.FileInputFormat" {
+			t.Fatal("table sd inputFormat wrong")
+		}
+		if serdeDecoded := sdDecoded.Struct(7); serdeDecoded == nil || serdeDecoded.String(2) == "" {
+			t.Fatal("table sd serde wrong")
+		}
+		if s.String(12) != "EXTERNAL_TABLE" || s.String(16) != "hive" {
+			t.Fatal("table type/catName wrong")
+		}
+	})
+}
+
+// TestRoundTripPartition covers the Partition struct (used only by stubs, but
+// the codec must still round-trip it).
+func TestRoundTripPartition(t *testing.T) {
+	src := refStruct{fields: []refField{
+		{thrift.LIST, 1, rfList(thrift.STRING, rfStr("2024"), rfStr("01"))},
+		{thrift.STRING, 2, rfStr("default")},
+		{thrift.STRING, 3, rfStr("tbl")},
+		{thrift.I32, 4, rfI32(1700000000)},
+		{thrift.I32, 5, rfI32(0)},
+		{thrift.STRUCT, 6, rfStruct(refStruct{fields: []refField{{thrift.STRING, 2, rfStr("loc")}}})},
+		{thrift.MAP, 7, rfMap(thrift.STRING, thrift.STRING)},
+	}}
+	got := refEncode(src)
+	assertRoundTrip(t, "Partition", src, got, func(s *Struct) {
+		if l := s.List(1); len(l) != 2 || l[0].Str != "2024" {
+			t.Fatal("partition values wrong")
+		}
+		if s.String(2) != "default" || s.String(3) != "tbl" {
+			t.Fatal("partition identity wrong")
+		}
+	})
+}
+
+// TestRoundTripLocks covers LockRequest/LockComponent/LockResponse.
+func TestRoundTripLocks(t *testing.T) {
+	comp := refStruct{fields: []refField{
+		{thrift.I32, 1, rfI32(3)}, // EXCLUSIVE
+		{thrift.I32, 2, rfI32(2)}, // TABLE
+		{thrift.STRING, 3, rfStr("default")},
+		{thrift.STRING, 4, rfStr("tbl")},
+	}}
+	req := refStruct{fields: []refField{
+		{thrift.LIST, 1, rfList(thrift.STRUCT, rfStruct(comp))},
+		{thrift.I64, 2, rfI64(0)},
+		{thrift.STRING, 3, rfStr("spark")},
+		{thrift.STRING, 4, rfStr("host")},
+	}}
+	got := refEncode(req)
+	assertRoundTrip(t, "LockRequest", req, got, func(s *Struct) {
+		comps := s.List(lrComponent)
+		if len(comps) != 1 {
+			t.Fatal("lock components wrong")
+		}
+		c := comps[0].S
+		if c.String(lcDBName) != "default" || c.String(lcTableName) != "tbl" {
+			t.Fatal("lock component wrong")
+		}
+		if s.String(lrUser) != "spark" || s.String(lrHostname) != "host" {
+			t.Fatal("lock request user/hostname wrong")
+		}
+	})
+
+	resp := refStruct{fields: []refField{
+		{thrift.I64, 1, rfI64(42)},
+		{thrift.I32, 2, rfI32(1)}, // ACQUIRED
+	}}
+	got = refEncode(resp)
+	assertRoundTrip(t, "LockResponse", resp, got, func(s *Struct) {
+		if s.I64(lockRespLockID) != 42 || s.I32(lockRespState) != 1 {
+			t.Fatal("lock response wrong")
+		}
+	})
+}

--- a/internal/gcp/hms/errors.go
+++ b/internal/gcp/hms/errors.go
@@ -1,0 +1,50 @@
+package hms
+
+import (
+	"context"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+// DeclaredError is a Thrift exception declared in a method's `throws` clause.
+// It is encoded as a field of the method's result struct (not as a
+// TApplicationException), at the position given by the throws order.
+type DeclaredError struct {
+	FieldID int16  // position in the result struct (1-based throws order)
+	Name    string // exception struct name, e.g. "MetaException"
+	Message string
+}
+
+func (e *DeclaredError) Error() string { return e.Name + ": " + e.Message }
+
+// AppError is a TApplicationException (method-missing / protocol error),
+// encoded with message type EXCEPTION rather than REPLY.
+type AppError struct {
+	Type    int32 // e.g. thrift.UNKNOWN_METHOD, thrift.INTERNAL_ERROR
+	Message string
+}
+
+func (e *AppError) Error() string { return e.Message }
+
+// Declared exception names from hive_metastore.thrift.
+const (
+	excMetaException             = "MetaException"
+	excNoSuchObjectException     = "NoSuchObjectException"
+	excAlreadyExistsException    = "AlreadyExistsException"
+	excInvalidObjectException    = "InvalidObjectException"
+	excInvalidOperationException = "InvalidOperationException"
+)
+
+// ExceptionField returns the Field to place in a result struct for a declared
+// exception: a STRUCT field (at the throws position) wrapping the exception
+// struct, which itself carries a single `message` (field 1) string — the shape
+// of every exception in hive_metastore.thrift.
+func ExceptionField(e *DeclaredError) Field {
+	return Field{ID: e.FieldID, V: StructV(NewBuilder().Str(1, e.Message).Build())}
+}
+
+// WriteAppException writes a TApplicationException as a struct with message
+// (field 1) and type (field 2), matching the Thrift-defined exception shape.
+func WriteAppException(ctx context.Context, p thrift.TProtocol, typ int32, msg string) error {
+	return WriteStruct(ctx, p, NewBuilder().Str(1, msg).I32(2, typ).Build())
+}

--- a/internal/gcp/hms/handler.go
+++ b/internal/gcp/hms/handler.go
@@ -1,0 +1,442 @@
+package hms
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/apache/thrift/lib/go/thrift"
+
+	hmsstore "jaiscloud/internal/gcp/store/hms"
+)
+
+// methodHandler decodes a method's args struct and returns its result struct.
+// A nil result with a nil error is a void success (encoded as an empty result
+// struct). A non-nil *DeclaredError is encoded as an exception field in the
+// result struct; a non-nil *AppError (or any other error) becomes a
+// TApplicationException.
+type methodHandler func(ctx context.Context, args *Struct) (*Struct, error)
+
+func result0(v Value) *Struct { return &Struct{Fields: []Field{{ID: 0, V: v}}} }
+func voidResult() *Struct     { return &Struct{} }
+
+// declared builds a *DeclaredError at the given result-struct position.
+func declared(fieldID int16, name, msg string) error {
+	return &DeclaredError{FieldID: fieldID, Name: name, Message: msg}
+}
+
+// matchName reports whether name matches pattern, which Hive's
+// get_databases/get_tables treat as a regular expression. Empty and "*"
+// patterns match everything; a pattern that fails to compile falls back to a
+// literal substring match.
+func matchName(pattern, name string) bool {
+	if pattern == "" || pattern == "*" || pattern == ".*" {
+		return true
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return strings.Contains(name, pattern)
+	}
+	return re.MatchString(name)
+}
+
+// --- Databases ---
+
+func (s *Server) createDatabase(ctx context.Context, args *Struct) (*Struct, error) {
+	db := args.Struct(1)
+	name := db.String(dbName)
+	if name == "" {
+		return nil, declared(2, excInvalidObjectException, "database name cannot be empty")
+	}
+	if err := s.store.CreateDatabase(ctx, hmsstore.Database{
+		Name:        name,
+		Description: db.String(dbDescription),
+		LocationURI: db.String(dbLocationURI),
+		Parameters:  db.MapStrStr(dbParameters),
+		Owner:       db.String(dbOwnerName),
+	}); err != nil {
+		switch {
+		case err == hmsstore.ErrDatabaseExists:
+			return nil, declared(1, excAlreadyExistsException, "database "+name+" already exists")
+		default:
+			return nil, declared(3, excMetaException, err.Error())
+		}
+	}
+	return voidResult(), nil
+}
+
+func (s *Server) getDatabase(ctx context.Context, args *Struct) (*Struct, error) {
+	name := args.String(1)
+	db, err := s.store.GetDatabase(ctx, name)
+	if err != nil {
+		switch {
+		case err == hmsstore.ErrDatabaseNotFound:
+			return nil, declared(1, excNoSuchObjectException, "database "+name+" not found")
+		default:
+			return nil, declared(2, excMetaException, err.Error())
+		}
+	}
+	return result0(StructV(buildDatabaseStruct(db))), nil
+}
+
+func (s *Server) dropDatabase(ctx context.Context, args *Struct) (*Struct, error) {
+	name := args.String(1)
+	cascade := args.Bool(3)
+	if err := s.store.DropDatabase(ctx, name, cascade); err != nil {
+		switch {
+		case err == hmsstore.ErrDatabaseNotFound:
+			return nil, declared(1, excNoSuchObjectException, "database "+name+" not found")
+		case err == hmsstore.ErrDatabaseNotEmpty:
+			return nil, declared(2, excInvalidOperationException, "database "+name+" is not empty")
+		default:
+			return nil, declared(3, excMetaException, err.Error())
+		}
+	}
+	return voidResult(), nil
+}
+
+func (s *Server) listDatabases(ctx context.Context, args *Struct) (*Struct, error) {
+	pattern := args.String(1)
+	names, err := s.store.ListDatabases(ctx)
+	if err != nil {
+		return nil, declared(1, excMetaException, err.Error())
+	}
+	filtered := make([]string, 0, len(names))
+	for _, n := range names {
+		if matchName(pattern, n) {
+			filtered = append(filtered, n)
+		}
+	}
+	b := NewBuilder()
+	b.ListStr(0, filtered)
+	return b.Build(), nil
+}
+
+func (s *Server) alterDatabase(ctx context.Context, args *Struct) (*Struct, error) {
+	name := args.String(1)
+	db := args.Struct(2)
+	if err := s.store.AlterDatabase(ctx, name, hmsstore.Database{
+		Name:        name,
+		Description: db.String(dbDescription),
+		LocationURI: db.String(dbLocationURI),
+		Parameters:  db.MapStrStr(dbParameters),
+		Owner:       db.String(dbOwnerName),
+	}); err != nil {
+		switch {
+		case err == hmsstore.ErrDatabaseNotFound:
+			return nil, declared(2, excNoSuchObjectException, "database "+name+" not found")
+		default:
+			return nil, declared(1, excMetaException, err.Error())
+		}
+	}
+	return voidResult(), nil
+}
+
+// --- Tables ---
+
+// tableJSON encodes a decoded Table struct as canonical JSON and returns its
+// (dbName, tableName, json) plus an error for an invalid object.
+func tableJSON(t *Struct) (db, tbl string, raw []byte, err error) {
+	if t == nil {
+		return "", "", nil, declared(2, excInvalidObjectException, "table is null")
+	}
+	db = t.String(tblDBName)
+	tbl = t.String(tblTableName)
+	raw, err = MarshalStruct(t)
+	if err != nil {
+		return "", "", nil, declared(3, excMetaException, err.Error())
+	}
+	return db, tbl, raw, nil
+}
+
+func (s *Server) createTable(ctx context.Context, args *Struct) (*Struct, error) {
+	db, tbl, raw, err := tableJSON(args.Struct(1))
+	if err != nil {
+		if de, ok := err.(*DeclaredError); ok {
+			return nil, de
+		}
+		return nil, declared(3, excMetaException, err.Error())
+	}
+	if tbl == "" {
+		return nil, declared(2, excInvalidObjectException, "table name cannot be empty")
+	}
+	if db == "" {
+		db = "default"
+	}
+	if serr := s.store.CreateTable(ctx, db, tbl, hmsstore.Table{DBName: db, TableName: tbl, TableJSON: raw}); serr != nil {
+		switch {
+		case serr == hmsstore.ErrTableExists:
+			return nil, declared(1, excAlreadyExistsException, "table "+db+"."+tbl+" already exists")
+		case serr == hmsstore.ErrDatabaseNotFound:
+			return nil, declared(4, excNoSuchObjectException, "database "+db+" not found")
+		default:
+			return nil, declared(3, excMetaException, serr.Error())
+		}
+	}
+	return voidResult(), nil
+}
+
+func (s *Server) getTable(ctx context.Context, args *Struct) (*Struct, error) {
+	db := args.String(1)
+	tbl := args.String(2)
+	t, err := s.store.GetTable(ctx, db, tbl)
+	if err != nil {
+		switch {
+		case err == hmsstore.ErrTableNotFound:
+			return nil, declared(2, excNoSuchObjectException, "table "+db+"."+tbl+" not found")
+		default:
+			return nil, declared(1, excMetaException, err.Error())
+		}
+	}
+	st, err := UnmarshalStruct(t.TableJSON)
+	if err != nil {
+		return nil, declared(1, excMetaException, err.Error())
+	}
+	return result0(StructV(st)), nil
+}
+
+func (s *Server) listTables(ctx context.Context, args *Struct) (*Struct, error) {
+	db := args.String(1)
+	pattern := args.String(2)
+	names, err := s.store.ListTables(ctx, db)
+	if err != nil {
+		return nil, declared(1, excMetaException, err.Error())
+	}
+	filtered := make([]string, 0, len(names))
+	for _, n := range names {
+		if matchName(pattern, n) {
+			filtered = append(filtered, n)
+		}
+	}
+	b := NewBuilder()
+	b.ListStr(0, filtered)
+	return b.Build(), nil
+}
+
+// getTableObjectsByName implements get_table_objects_by_name(dbname,
+// list<string>) -> list<Table>. It is not in D3's enumerated subset but is on
+// the real Iceberg HiveCatalog.listTables critical path (verified Iceberg
+// 1.5.2 HiveCatalog.java:133), so it is implemented rather than stubbed.
+func (s *Server) getTableObjectsByName(ctx context.Context, args *Struct) (*Struct, error) {
+	db := args.String(1)
+	names := args.List(2)
+	var tables []*Struct
+	for _, n := range names {
+		if n.T != thrift.STRING {
+			continue
+		}
+		t, err := s.store.GetTable(ctx, db, n.Str)
+		if err != nil {
+			if err == hmsstore.ErrTableNotFound {
+				continue // tolerate missing tables (the client filters them)
+			}
+			return nil, declared(1, excMetaException, err.Error())
+		}
+		st, err := UnmarshalStruct(t.TableJSON)
+		if err != nil {
+			return nil, declared(1, excMetaException, err.Error())
+		}
+		tables = append(tables, st)
+	}
+	b := NewBuilder()
+	b.ListStruct(0, tables)
+	return b.Build(), nil
+}
+
+// alterTable handles alter_table/alter_table_with_environment_context: a plain
+// overwrite of the stored Table (D5). When the incoming Table's dbName or
+// tableName differs from the addressed (db, tbl), it is a rename (the real Hive
+// rename path — Iceberg's renameTable drives alter_table with a renamed Table).
+func (s *Server) alterTable(ctx context.Context, args *Struct) (*Struct, error) {
+	db := args.String(1)
+	tbl := args.String(2)
+	newDB, newTbl, raw, err := tableJSON(args.Struct(3))
+	if err != nil {
+		if de, ok := err.(*DeclaredError); ok {
+			return nil, de
+		}
+		return nil, declared(2, excMetaException, err.Error())
+	}
+	if newTbl == "" {
+		newTbl = tbl
+	}
+	if newDB == "" {
+		newDB = db
+	}
+
+	if newDB != db || newTbl != tbl {
+		_, rerr := s.store.RenameTable(ctx, db, tbl, newDB, newTbl, hmsstore.Table{DBName: newDB, TableName: newTbl, TableJSON: raw})
+		if rerr != nil {
+			switch {
+			case rerr == hmsstore.ErrTableNotFound:
+				return nil, declared(1, excInvalidOperationException, "table "+db+"."+tbl+" not found")
+			case rerr == hmsstore.ErrDatabaseNotFound:
+				return nil, declared(1, excInvalidOperationException, "database "+newDB+" not found")
+			case rerr == hmsstore.ErrTableExists:
+				return nil, declared(1, excInvalidOperationException, "new table "+newDB+"."+newTbl+" already exists")
+			default:
+				return nil, declared(2, excMetaException, rerr.Error())
+			}
+		}
+		return voidResult(), nil
+	}
+
+	_, aerr := s.store.AlterTable(ctx, db, tbl, func(current hmsstore.Table) (hmsstore.Table, error) {
+		// Plain unconditional overwrite (D5): the lock is the only concurrency
+		// control, matching real Hive alter_table.
+		return hmsstore.Table{DBName: db, TableName: tbl, TableJSON: raw}, nil
+	})
+	if aerr != nil {
+		switch {
+		case aerr == hmsstore.ErrTableNotFound:
+			return nil, declared(1, excInvalidOperationException, "table "+db+"."+tbl+" not found")
+		default:
+			return nil, declared(2, excMetaException, aerr.Error())
+		}
+	}
+	return voidResult(), nil
+}
+
+func (s *Server) dropTable(ctx context.Context, args *Struct) (*Struct, error) {
+	db := args.String(1)
+	tbl := args.String(2)
+	if err := s.store.DropTable(ctx, db, tbl); err != nil {
+		switch {
+		case err == hmsstore.ErrTableNotFound:
+			return nil, declared(1, excNoSuchObjectException, "table "+db+"."+tbl+" not found")
+		default:
+			return nil, declared(2, excMetaException, err.Error())
+		}
+	}
+	return voidResult(), nil
+}
+
+// --- Functions (stubbed: no function store) ---
+
+func (s *Server) createFunction(_ context.Context, _ *Struct) (*Struct, error) {
+	return voidResult(), nil
+}
+
+func (s *Server) dropFunction(_ context.Context, _ *Struct) (*Struct, error) {
+	return voidResult(), nil
+}
+
+func (s *Server) getFunctions(_ context.Context, _ *Struct) (*Struct, error) {
+	return result0(ListV(thrift.STRING, nil)), nil
+}
+
+func (s *Server) getFunction(_ context.Context, args *Struct) (*Struct, error) {
+	db := args.String(1)
+	fn := args.String(2)
+	return nil, declared(2, excNoSuchObjectException, "function "+db+"."+fn+" not found")
+}
+
+func (s *Server) getAllFunctions(_ context.Context, _ *Struct) (*Struct, error) {
+	// GetAllFunctionsResponse {1: optional list<Function> functions} — omit the
+	// field so the client observes an empty registry.
+	return result0(StructV(&Struct{})), nil
+}
+
+// --- Locks ---
+
+func (s *Server) lock(ctx context.Context, args *Struct) (*Struct, error) {
+	req := args.Struct(1)
+	l := hmsstore.Lock{User: req.String(lrUser), Hostname: req.String(lrHostname)}
+	if comps := req.List(lrComponent); len(comps) > 0 {
+		if c := comps[0].S; c != nil {
+			l.DBName = c.String(lcDBName)
+			l.TableName = c.String(lcTableName)
+		}
+	}
+	id, err := s.store.Lock(ctx, l)
+	if err != nil {
+		return nil, &AppError{Type: thrift.INTERNAL_ERROR, Message: err.Error()}
+	}
+	return result0(StructV(buildLockResponse(id, hmsstore.LockStateAcquired))), nil
+}
+
+func (s *Server) checkLock(ctx context.Context, args *Struct) (*Struct, error) {
+	req := args.Struct(1)
+	id := req.I64(1)
+	state, err := s.store.CheckLock(ctx, id)
+	if err != nil {
+		return nil, &AppError{Type: thrift.INTERNAL_ERROR, Message: err.Error()}
+	}
+	return result0(StructV(buildLockResponse(id, state))), nil
+}
+
+func (s *Server) unlock(ctx context.Context, args *Struct) (*Struct, error) {
+	req := args.Struct(1)
+	id := req.I64(1)
+	if err := s.store.Unlock(ctx, id); err != nil {
+		return nil, &AppError{Type: thrift.INTERNAL_ERROR, Message: err.Error()}
+	}
+	return voidResult(), nil
+}
+
+// --- Notifications (stubbed: valid empty, never an error — F10) ---
+
+func (s *Server) getCurrentNotificationEventID(_ context.Context, _ *Struct) (*Struct, error) {
+	// CurrentNotificationEventId {1: required i64 eventId}.
+	return result0(StructV(NewBuilder().I64(notifEventID, 0).Build())), nil
+}
+
+func (s *Server) getNextNotification(_ context.Context, _ *Struct) (*Struct, error) {
+	// NotificationEventResponse {1: required list<NotificationEvent> events}.
+	return result0(StructV(NewBuilder().Add(notifEvents, ListV(thrift.STRUCT, nil)).Build())), nil
+}
+
+// --- Partition stubs (D3: return empty / NoSuchObjectException, never crash) ---
+
+// partitionNotFound is the shared NoSuchObjectException for single-partition
+// get/add methods.
+func partitionNotFound(msg string) error {
+	return declared(2, excNoSuchObjectException, msg)
+}
+
+func (s *Server) stubPartitionNotFound(_ context.Context, args *Struct) (*Struct, error) {
+	return nil, partitionNotFound("partition not found")
+}
+
+func (s *Server) stubPartitionList(_ context.Context, _ *Struct) (*Struct, error) {
+	return result0(ListV(thrift.STRUCT, nil)), nil
+}
+
+func (s *Server) stubPartitionNameList(_ context.Context, _ *Struct) (*Struct, error) {
+	return result0(ListV(thrift.STRING, nil)), nil
+}
+
+func (s *Server) stubPartitionBoolFalse(_ context.Context, _ *Struct) (*Struct, error) {
+	return result0(BoolV(false)), nil
+}
+
+func (s *Server) stubPartitionBoolTrue(_ context.Context, _ *Struct) (*Struct, error) {
+	return result0(BoolV(true)), nil
+}
+
+func (s *Server) stubPartitionI32Zero(_ context.Context, _ *Struct) (*Struct, error) {
+	return result0(I32V(0)), nil
+}
+
+func (s *Server) stubPartitionVoid(_ context.Context, _ *Struct) (*Struct, error) {
+	return voidResult(), nil
+}
+
+func (s *Server) stubPartitionNameSpec(_ context.Context, _ *Struct) (*Struct, error) {
+	return result0(MapV(thrift.STRING, thrift.STRING, nil)), nil
+}
+
+// --- Unsupported (honest failure, not a silent ACK — F10) ---
+
+// unsupportedMethod returns a TApplicationException(INTERNAL_ERROR) for methods
+// that are out of scope (ACID txn, heartbeat, Hive-3.x table-meta, ...). A
+// TApplicationException (msg type EXCEPTION) is used rather than a declared
+// exception so the failure is unambiguous even for methods with no throws
+// clause (get_open_txns, etc.).
+func (s *Server) unsupportedMethod(_ context.Context, _ *Struct) (*Struct, error) {
+	return nil, &AppError{Type: thrift.INTERNAL_ERROR, Message: "method not supported by the emulator"}
+}
+
+func (s *Server) heartbeat(_ context.Context, _ *Struct) (*Struct, error) {
+	return nil, &AppError{Type: thrift.INTERNAL_ERROR, Message: "heartbeat (ACID transaction locks) is not supported"}
+}

--- a/internal/gcp/hms/json.go
+++ b/internal/gcp/hms/json.go
@@ -1,0 +1,228 @@
+package hms
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+// Canonical (type-tagged, lossless) JSON encoding of Thrift values. The store
+// persists a full Hive Table as this JSON (jc_hms_tables.table_json); the codec
+// owns both directions so get_table -> alter_table round-trips every field the
+// client sent, including fields the emulator does not interpret.
+//
+// A value is a JSON array [tag, payload...]:
+//
+//	["b", true]                    bool
+//	["y", 5]                       byte (i8)
+//	["h", 5]                       i16
+//	["i", 5]                       i32
+//	["l", "5"]                     i64 (string to avoid float64 precision loss)
+//	["d", 1.5]                     double
+//	["s", "abc"]                   string
+//	["o", [[id, v], ...]]          struct (ordered fields)
+//	["a", elemType, [v, ...]]      list
+//	["g", elemType, [v, ...]]      set
+//	["m", kType, vType, [[k, v], ...]]  map (ordered entries)
+var errBadJSON = errors.New("hms: malformed thrift JSON")
+
+// MarshalStruct encodes a Struct as canonical JSON.
+func MarshalStruct(s *Struct) ([]byte, error) {
+	if s == nil {
+		s = &Struct{}
+	}
+	return json.Marshal(valueToAny(StructV(s)))
+}
+
+// UnmarshalStruct decodes canonical JSON into a Struct.
+func UnmarshalStruct(b []byte) (*Struct, error) {
+	var a any
+	if err := json.Unmarshal(b, &a); err != nil {
+		return nil, err
+	}
+	v, err := anyToValue(a)
+	if err != nil {
+		return nil, err
+	}
+	if v.T != thrift.STRUCT {
+		return nil, fmt.Errorf("hms: top-level JSON value is not a struct")
+	}
+	return v.S, nil
+}
+
+func valueToAny(v Value) any {
+	switch v.T {
+	case thrift.BOOL:
+		return []any{"b", v.B}
+	case thrift.BYTE:
+		return []any{"y", int64(v.I8)}
+	case thrift.I16:
+		return []any{"h", int64(v.I16)}
+	case thrift.I32:
+		return []any{"i", int64(v.I32)}
+	case thrift.I64:
+		return []any{"l", strconv.FormatInt(v.I64, 10)}
+	case thrift.DOUBLE:
+		return []any{"d", v.F64}
+	case thrift.STRING:
+		return []any{"s", v.Str}
+	case thrift.STRUCT:
+		fields := make([]any, 0, len(v.S.Fields))
+		for _, f := range v.S.Fields {
+			fields = append(fields, []any{int64(f.ID), valueToAny(f.V)})
+		}
+		return []any{"o", fields}
+	case thrift.LIST:
+		elems := make([]any, 0, len(v.List))
+		for _, e := range v.List {
+			elems = append(elems, valueToAny(e))
+		}
+		return []any{"a", int64(v.Elem), elems}
+	case thrift.SET:
+		elems := make([]any, 0, len(v.List))
+		for _, e := range v.List {
+			elems = append(elems, valueToAny(e))
+		}
+		return []any{"g", int64(v.Elem), elems}
+	case thrift.MAP:
+		entries := make([]any, 0, len(v.Entries))
+		for _, e := range v.Entries {
+			entries = append(entries, []any{valueToAny(e.K), valueToAny(e.V)})
+		}
+		return []any{"m", int64(v.K), int64(v.V), entries}
+	}
+	return []any{"z"}
+}
+
+func anyToValue(a any) (Value, error) {
+	arr, ok := a.([]any)
+	if !ok || len(arr) == 0 {
+		return Value{}, errBadJSON
+	}
+	tag, _ := arr[0].(string)
+	switch tag {
+	case "b":
+		b, ok := arr[1].(bool)
+		if !ok {
+			return Value{}, errBadJSON
+		}
+		return BoolV(b), nil
+	case "y":
+		n, err := jsonNum(arr[1])
+		return ByteV(int8(n)), err
+	case "h":
+		n, err := jsonNum(arr[1])
+		return I16V(int16(n)), err
+	case "i":
+		n, err := jsonNum(arr[1])
+		return I32V(int32(n)), err
+	case "l":
+		str, ok := arr[1].(string)
+		if !ok {
+			return Value{}, errBadJSON
+		}
+		n, err := strconv.ParseInt(str, 10, 64)
+		if err != nil {
+			return Value{}, errBadJSON
+		}
+		return I64V(n), nil
+	case "d":
+		f, ok := arr[1].(float64)
+		if !ok {
+			return Value{}, errBadJSON
+		}
+		return DoubleV(f), nil
+	case "s":
+		str, ok := arr[1].(string)
+		if !ok {
+			return Value{}, errBadJSON
+		}
+		return StringV(str), nil
+	case "o":
+		fieldsArr, ok := arr[1].([]any)
+		if !ok {
+			return Value{}, errBadJSON
+		}
+		fields := make([]Field, 0, len(fieldsArr))
+		for _, fa := range fieldsArr {
+			pair, ok := fa.([]any)
+			if !ok || len(pair) != 2 {
+				return Value{}, errBadJSON
+			}
+			id, err := jsonNum(pair[0])
+			if err != nil {
+				return Value{}, err
+			}
+			fv, err := anyToValue(pair[1])
+			if err != nil {
+				return Value{}, err
+			}
+			fields = append(fields, Field{ID: int16(id), V: fv})
+		}
+		return StructV(&Struct{Fields: fields}), nil
+	case "a", "g":
+		et, err := jsonNum(arr[1])
+		if err != nil {
+			return Value{}, err
+		}
+		elemsArr, ok := arr[2].([]any)
+		if !ok {
+			return Value{}, errBadJSON
+		}
+		elems := make([]Value, 0, len(elemsArr))
+		for _, ea := range elemsArr {
+			e, err := anyToValue(ea)
+			if err != nil {
+				return Value{}, err
+			}
+			elems = append(elems, e)
+		}
+		if tag == "a" {
+			return ListV(thrift.TType(et), elems), nil
+		}
+		return SetV(thrift.TType(et), elems), nil
+	case "m":
+		kt, err := jsonNum(arr[1])
+		if err != nil {
+			return Value{}, err
+		}
+		vt, err := jsonNum(arr[2])
+		if err != nil {
+			return Value{}, err
+		}
+		entriesArr, ok := arr[3].([]any)
+		if !ok {
+			return Value{}, errBadJSON
+		}
+		entries := make([]MapEntry, 0, len(entriesArr))
+		for _, ea := range entriesArr {
+			pair, ok := ea.([]any)
+			if !ok || len(pair) != 2 {
+				return Value{}, errBadJSON
+			}
+			k, err := anyToValue(pair[0])
+			if err != nil {
+				return Value{}, err
+			}
+			v, err := anyToValue(pair[1])
+			if err != nil {
+				return Value{}, err
+			}
+			entries = append(entries, MapEntry{K: k, V: v})
+		}
+		return MapV(thrift.TType(kt), thrift.TType(vt), entries), nil
+	}
+	return Value{}, errBadJSON
+}
+
+// jsonNum reads an encoding/json number (float64) as an int64.
+func jsonNum(a any) (int64, error) {
+	f, ok := a.(float64)
+	if !ok {
+		return 0, errBadJSON
+	}
+	return int64(f), nil
+}

--- a/internal/gcp/hms/json_test.go
+++ b/internal/gcp/hms/json_test.go
@@ -1,0 +1,96 @@
+package hms
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+// TestJSONRoundTripTable verifies MarshalStruct/UnmarshalStruct round-trips a
+// full Table losslessly: the canonical JSON preserves every field (including
+// i64 and nested containers), so re-encoding produces the identical Thrift
+// bytes.
+func TestJSONRoundTripTable(t *testing.T) {
+	fs := refStruct{fields: []refField{
+		{thrift.STRING, 1, rfStr("id")},
+		{thrift.STRING, 2, rfStr("bigint")},
+	}}
+	serde := refStruct{fields: []refField{
+		{thrift.STRING, 1, rfStr("t")},
+		{thrift.STRING, 2, rfStr("lib")},
+		{thrift.MAP, 3, rfMap(thrift.STRING, thrift.STRING, rfEntry(rfStr("k"), rfStr("v")))},
+	}}
+	sd := refStruct{fields: []refField{
+		{thrift.LIST, 1, rfList(thrift.STRUCT, rfStruct(fs))},
+		{thrift.STRING, 2, rfStr("gs://b/wh/db/t")},
+		{thrift.STRING, 3, rfStr("in")},
+		{thrift.STRING, 4, rfStr("out")},
+		{thrift.BOOL, 5, rfBool(false)},
+		{thrift.I32, 6, rfI32(0)},
+		{thrift.STRUCT, 7, rfStruct(serde)},
+		{thrift.MAP, 10, rfMap(thrift.STRING, thrift.STRING)},
+	}}
+	tbl := refStruct{fields: []refField{
+		{thrift.STRING, 1, rfStr("tbl")},
+		{thrift.STRING, 2, rfStr("db")},
+		{thrift.I32, 4, rfI32(1700000000)},
+		{thrift.I64, 5, rfI64(0)}, // i64 must survive the JSON string encoding
+		{thrift.STRUCT, 7, rfStruct(sd)},
+		{thrift.MAP, 9, rfMap(thrift.STRING, thrift.STRING, rfEntry(rfStr("metadata_location"), rfStr("loc")))},
+		{thrift.STRING, 12, rfStr("EXTERNAL_TABLE")},
+	}}
+
+	want := refEncode(tbl)
+
+	// Thrift bytes -> Struct -> JSON -> Struct -> Thrift bytes.
+	decoded := refDecode(t, want)
+	js, err := MarshalStruct(decoded)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	restored, err := UnmarshalStruct(js)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := refReencode(t, restored)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("JSON round-trip lost bytes:\n got  %x\n want %x", got, want)
+	}
+
+	// Field values survive the JSON hop.
+	if restored.String(tblTableName) != "tbl" || restored.String(tblDBName) != "db" {
+		t.Fatal("identity lost")
+	}
+	if restored.MapStrStr(9)["metadata_location"] != "loc" {
+		t.Fatal("parameters lost")
+	}
+}
+
+// TestJSONEmptyAndContainers exercises empty containers and nested lists/maps
+// through the JSON layer.
+func TestJSONEmptyAndContainers(t *testing.T) {
+	src := refStruct{fields: []refField{
+		{thrift.LIST, 1, rfList(thrift.STRING)},
+		{thrift.SET, 2, rfList(thrift.STRUCT)},
+		{thrift.MAP, 3, rfMap(thrift.STRING, thrift.I64)},
+		{thrift.LIST, 4, rfList(thrift.LIST, rfList(thrift.STRING, rfStr("x")))},
+	}}
+	want := refEncode(src)
+	decoded := refDecode(t, want)
+	js, err := MarshalStruct(decoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored, err := UnmarshalStruct(js)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := refReencode(t, restored); !bytes.Equal(got, want) {
+		t.Fatalf("empty container round-trip lost bytes:\n got  %x\n want %x", got, want)
+	}
+	// Round-trip through my codec again for sanity.
+	if got := refReencode(t, restored); !bytes.Equal(got, refReencode(t, decoded)) {
+		t.Fatal("restored struct does not match decoded struct")
+	}
+}

--- a/internal/gcp/hms/protocol.go
+++ b/internal/gcp/hms/protocol.go
@@ -1,0 +1,226 @@
+package hms
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+// maxValueDepth bounds struct/container nesting so a hostile or corrupt peer
+// can't drive unbounded recursion in the codec.
+const maxValueDepth = 64
+
+var errDepth = errors.New("hms: thrift value nesting too deep")
+
+// ReadStruct reads one Thrift struct from p (generic, lossless: fields in wire
+// order, every value type-tagged).
+func ReadStruct(ctx context.Context, p thrift.TProtocol) (*Struct, error) {
+	if _, err := p.ReadStructBegin(ctx); err != nil {
+		return nil, err
+	}
+	fields := make([]Field, 0, 4)
+	for {
+		_, typeID, id, err := p.ReadFieldBegin(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if typeID == thrift.STOP {
+			break
+		}
+		v, err := readValue(ctx, p, typeID, 0)
+		if err != nil {
+			return nil, err
+		}
+		if err := p.ReadFieldEnd(ctx); err != nil {
+			return nil, err
+		}
+		fields = append(fields, Field{ID: id, V: v})
+	}
+	if err := p.ReadStructEnd(ctx); err != nil {
+		return nil, err
+	}
+	return &Struct{Fields: fields}, nil
+}
+
+// WriteStruct writes s to p.
+func WriteStruct(ctx context.Context, p thrift.TProtocol, s *Struct) error {
+	if s == nil {
+		s = &Struct{}
+	}
+	if err := p.WriteStructBegin(ctx, ""); err != nil {
+		return err
+	}
+	for i := range s.Fields {
+		f := s.Fields[i]
+		if err := p.WriteFieldBegin(ctx, "", f.V.T, f.ID); err != nil {
+			return err
+		}
+		if err := writeValue(ctx, p, f.V, 0); err != nil {
+			return err
+		}
+		if err := p.WriteFieldEnd(ctx); err != nil {
+			return err
+		}
+	}
+	if err := p.WriteFieldStop(ctx); err != nil {
+		return err
+	}
+	return p.WriteStructEnd(ctx)
+}
+
+func readValue(ctx context.Context, p thrift.TProtocol, t thrift.TType, depth int) (Value, error) {
+	if depth > maxValueDepth {
+		return Value{}, errDepth
+	}
+	switch t {
+	case thrift.BOOL:
+		v, err := p.ReadBool(ctx)
+		return BoolV(v), err
+	case thrift.BYTE:
+		v, err := p.ReadByte(ctx)
+		return ByteV(v), err
+	case thrift.I16:
+		v, err := p.ReadI16(ctx)
+		return I16V(v), err
+	case thrift.I32:
+		v, err := p.ReadI32(ctx)
+		return I32V(v), err
+	case thrift.I64:
+		v, err := p.ReadI64(ctx)
+		return I64V(v), err
+	case thrift.DOUBLE:
+		v, err := p.ReadDouble(ctx)
+		return DoubleV(v), err
+	case thrift.STRING:
+		// TBinaryProtocol encodes `binary` as STRING; reading as string and
+		// re-writing as string is byte-identical, so binary round-trips too.
+		v, err := p.ReadString(ctx)
+		return StringV(v), err
+	case thrift.STRUCT:
+		s, err := ReadStruct(ctx, p)
+		if err != nil {
+			return Value{}, err
+		}
+		return StructV(s), nil
+	case thrift.LIST:
+		elem, size, err := p.ReadListBegin(ctx)
+		if err != nil {
+			return Value{}, err
+		}
+		elems, err := readElems(ctx, p, elem, size, depth+1)
+		if err != nil {
+			return Value{}, err
+		}
+		if err := p.ReadListEnd(ctx); err != nil {
+			return Value{}, err
+		}
+		return ListV(elem, elems), nil
+	case thrift.SET:
+		elem, size, err := p.ReadSetBegin(ctx)
+		if err != nil {
+			return Value{}, err
+		}
+		elems, err := readElems(ctx, p, elem, size, depth+1)
+		if err != nil {
+			return Value{}, err
+		}
+		if err := p.ReadSetEnd(ctx); err != nil {
+			return Value{}, err
+		}
+		return SetV(elem, elems), nil
+	case thrift.MAP:
+		kt, vt, size, err := p.ReadMapBegin(ctx)
+		if err != nil {
+			return Value{}, err
+		}
+		entries := make([]MapEntry, 0, size)
+		for i := 0; i < size; i++ {
+			k, err := readValue(ctx, p, kt, depth+1)
+			if err != nil {
+				return Value{}, err
+			}
+			v, err := readValue(ctx, p, vt, depth+1)
+			if err != nil {
+				return Value{}, err
+			}
+			entries = append(entries, MapEntry{K: k, V: v})
+		}
+		if err := p.ReadMapEnd(ctx); err != nil {
+			return Value{}, err
+		}
+		return MapV(kt, vt, entries), nil
+	}
+	return Value{}, fmt.Errorf("hms: unsupported thrift type %d", t)
+}
+
+func readElems(ctx context.Context, p thrift.TProtocol, elem thrift.TType, size, depth int) ([]Value, error) {
+	elems := make([]Value, 0, size)
+	for i := 0; i < size; i++ {
+		e, err := readValue(ctx, p, elem, depth)
+		if err != nil {
+			return nil, err
+		}
+		elems = append(elems, e)
+	}
+	return elems, nil
+}
+
+func writeValue(ctx context.Context, p thrift.TProtocol, v Value, depth int) error {
+	if depth > maxValueDepth {
+		return errDepth
+	}
+	switch v.T {
+	case thrift.BOOL:
+		return p.WriteBool(ctx, v.B)
+	case thrift.BYTE:
+		return p.WriteByte(ctx, v.I8)
+	case thrift.I16:
+		return p.WriteI16(ctx, v.I16)
+	case thrift.I32:
+		return p.WriteI32(ctx, v.I32)
+	case thrift.I64:
+		return p.WriteI64(ctx, v.I64)
+	case thrift.DOUBLE:
+		return p.WriteDouble(ctx, v.F64)
+	case thrift.STRING:
+		return p.WriteString(ctx, v.Str)
+	case thrift.STRUCT:
+		return WriteStruct(ctx, p, v.S)
+	case thrift.LIST:
+		if err := p.WriteListBegin(ctx, v.Elem, len(v.List)); err != nil {
+			return err
+		}
+		for i := range v.List {
+			if err := writeValue(ctx, p, v.List[i], depth+1); err != nil {
+				return err
+			}
+		}
+		return p.WriteListEnd(ctx)
+	case thrift.SET:
+		if err := p.WriteSetBegin(ctx, v.Elem, len(v.List)); err != nil {
+			return err
+		}
+		for i := range v.List {
+			if err := writeValue(ctx, p, v.List[i], depth+1); err != nil {
+				return err
+			}
+		}
+		return p.WriteSetEnd(ctx)
+	case thrift.MAP:
+		if err := p.WriteMapBegin(ctx, v.K, v.V, len(v.Entries)); err != nil {
+			return err
+		}
+		for i := range v.Entries {
+			if err := writeValue(ctx, p, v.Entries[i].K, depth+1); err != nil {
+				return err
+			}
+			if err := writeValue(ctx, p, v.Entries[i].V, depth+1); err != nil {
+				return err
+			}
+		}
+		return p.WriteMapEnd(ctx)
+	}
+	return fmt.Errorf("hms: unsupported thrift type %d", v.T)
+}

--- a/internal/gcp/hms/server.go
+++ b/internal/gcp/hms/server.go
@@ -1,0 +1,264 @@
+package hms
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+
+	"github.com/apache/thrift/lib/go/thrift"
+
+	hmsstore "jaiscloud/internal/gcp/store/hms"
+)
+
+// Server is the Hive Metastore Thrift serving plane: a raw TCP listener
+// speaking TBinaryProtocol over a non-framed TSocket (no TFramedTransport —
+// that is TCLIService/HiveServer2, a different protocol). It parallels the
+// gRPC listener in internal/gcp/grpc: a separate port, its own accept loop, and
+// the same store/lock discipline shared with the control plane. The catalog is
+// single-global (F6) — databases/tables are keyed by name only.
+type Server struct {
+	addr    string
+	store   hmsstore.Store
+	sock    *thrift.TServerSocket
+	mu      sync.Mutex
+	wg      sync.WaitGroup
+	methods map[string]methodHandler
+}
+
+// NewServer returns a Thrift serving-plane server bound to addr (e.g.
+// ":9083"), backed by the given store.
+func NewServer(addr string, store hmsstore.Store) *Server {
+	s := &Server{addr: addr, store: store}
+	s.methods = s.methodTable()
+	return s
+}
+
+// methodTable builds the method dispatch map. Names are the exact
+// hive_metastore.thrift method names (ThriftHiveMetastore service).
+func (s *Server) methodTable() map[string]methodHandler {
+	return map[string]methodHandler{
+		// Databases.
+		"create_database":   s.createDatabase,
+		"get_database":      s.getDatabase,
+		"drop_database":     s.dropDatabase,
+		"get_databases":     s.listDatabases,
+		"get_all_databases": s.listDatabases,
+		"alter_database":    s.alterDatabase,
+
+		// Tables.
+		"create_table":                          s.createTable,
+		"create_table_with_environment_context": s.createTable,
+		"get_table":                             s.getTable,
+		"get_table_by_name":                     s.getTable, // alias: same (dbname, tbl_name) -> Table shape
+		"get_all_tables":                        s.listTables,
+		"get_tables":                            s.listTables,
+		"get_table_objects_by_name":             s.getTableObjectsByName,
+		"alter_table":                           s.alterTable,
+		"alter_table_with_environment_context":  s.alterTable,
+		"drop_table":                            s.dropTable,
+		"drop_table_with_environment_context":   s.dropTable,
+
+		// Functions (stubbed).
+		"create_function":   s.createFunction,
+		"drop_function":     s.dropFunction,
+		"get_functions":     s.getFunctions,
+		"get_function":      s.getFunction,
+		"get_all_functions": s.getAllFunctions,
+
+		// Concurrency (Iceberg commit locking).
+		"lock":       s.lock,
+		"check_lock": s.checkLock,
+		"unlock":     s.unlock,
+
+		// Misc (valid empty stubs).
+		"get_current_notificationEventId": s.getCurrentNotificationEventID,
+		"get_next_notification":           s.getNextNotification,
+
+		// Partition methods — stubbed (return empty / NoSuchObjectException).
+		"get_partition":                                     s.stubPartitionNotFound,
+		"get_partition_with_auth":                           s.stubPartitionNotFound,
+		"get_partition_by_name":                             s.stubPartitionNotFound,
+		"add_partition":                                     s.stubPartitionNotFound,
+		"add_partition_with_environment_context":            s.stubPartitionNotFound,
+		"append_partition":                                  s.stubPartitionNotFound,
+		"append_partition_by_name":                          s.stubPartitionNotFound,
+		"append_partition_with_environment_context":         s.stubPartitionNotFound,
+		"append_partition_by_name_with_environment_context": s.stubPartitionNotFound,
+		"exchange_partition":                                s.stubPartitionNotFound,
+		"add_partitions":                                    s.stubPartitionI32Zero,
+		"add_partitions_pspec":                              s.stubPartitionI32Zero,
+		"get_num_partitions_by_filter":                      s.stubPartitionI32Zero,
+		"get_partitions":                                    s.stubPartitionList,
+		"get_partitions_with_auth":                          s.stubPartitionList,
+		"get_partitions_ps":                                 s.stubPartitionList,
+		"get_partitions_ps_with_auth":                       s.stubPartitionList,
+		"get_partitions_by_filter":                          s.stubPartitionList,
+		"get_partitions_by_names":                           s.stubPartitionList,
+		"get_partitions_pspec":                              s.stubPartitionList,
+		"get_part_specs_by_filter":                          s.stubPartitionList,
+		"exchange_partitions":                               s.stubPartitionList,
+		"get_partition_names":                               s.stubPartitionNameList,
+		"get_partition_names_ps":                            s.stubPartitionNameList,
+		"get_partition_names_ps_with_auth":                  s.stubPartitionNameList,
+		"partition_name_to_vals":                            s.stubPartitionNameList,
+		"partition_name_to_spec":                            s.stubPartitionNameSpec,
+		"drop_partition":                                    s.stubPartitionBoolFalse,
+		"drop_partition_with_environment_context":           s.stubPartitionBoolFalse,
+		"drop_partition_by_name":                            s.stubPartitionBoolFalse,
+		"drop_partition_by_name_with_environment_context":   s.stubPartitionBoolFalse,
+		"partition_name_has_valid_characters":               s.stubPartitionBoolTrue,
+		"isPartitionMarkedForEvent":                         s.stubPartitionBoolFalse,
+		"alter_partition":                                   s.stubPartitionVoid,
+		"alter_partition_with_environment_context":          s.stubPartitionVoid,
+		"alter_partitions":                                  s.stubPartitionVoid,
+		"alter_partitions_with_environment_context":         s.stubPartitionVoid,
+		"rename_partition":                                  s.stubPartitionVoid,
+		"markPartitionForEvent":                             s.stubPartitionVoid,
+		"get_partitions_by_expr":                            s.stubPartitionList,
+		"drop_partitions_req":                               s.stubPartitionList,
+		"get_partition_values":                              s.stubPartitionList,
+
+		// Out-of-scope ACID/txn methods — honest failure, never a silent ACK.
+		"heartbeat":           s.heartbeat,
+		"heartbeat_txn_range": s.unsupportedMethod,
+		"get_open_txns":       s.unsupportedMethod,
+		"get_open_txns_info":  s.unsupportedMethod,
+		"open_txns":           s.unsupportedMethod,
+		"abort_txn":           s.unsupportedMethod,
+		"abort_txns":          s.unsupportedMethod,
+		"commit_txn":          s.unsupportedMethod,
+		"get_table_meta":      s.unsupportedMethod,
+	}
+}
+
+// Serve listens on the configured address and blocks serving until Stop or the
+// process exits. Each connection is handled in its own goroutine.
+func (s *Server) Serve() error {
+	sock, err := thrift.NewTServerSocket(s.addr)
+	if err != nil {
+		return fmt.Errorf("hms thrift listen on %s: %w", s.addr, err)
+	}
+	if err := sock.Listen(); err != nil {
+		return fmt.Errorf("hms thrift listen on %s: %w", s.addr, err)
+	}
+	s.mu.Lock()
+	s.sock = sock
+	s.mu.Unlock()
+
+	for {
+		transport, err := sock.Accept()
+		if err != nil {
+			// Interrupted / closed — normal shutdown.
+			return nil
+		}
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			defer transport.Close()
+			s.handleConn(transport)
+		}()
+	}
+}
+
+// Stop gracefully stops the listener and waits for in-flight connections.
+func (s *Server) Stop() {
+	s.mu.Lock()
+	sock := s.sock
+	s.sock = nil
+	s.mu.Unlock()
+	if sock != nil {
+		_ = sock.Interrupt()
+	}
+	s.wg.Wait()
+}
+
+// handleConn serves one connection: read a message, dispatch, write the reply,
+// repeat until EOF or a transport error. Requests are processed sequentially on
+// a connection, matching the Hive metastore client's request/response model.
+func (s *Server) handleConn(transport thrift.TTransport) {
+	proto := thrift.NewTBinaryProtocolTransport(transport)
+	ctx := context.Background()
+	for {
+		name, _, seqid, err := proto.ReadMessageBegin(ctx)
+		if err != nil {
+			return
+		}
+		args, err := ReadStruct(ctx, proto)
+		if err != nil {
+			return
+		}
+		result, herr := s.dispatch(ctx, name, args)
+		if werr := s.writeReply(ctx, proto, name, seqid, result, herr); werr != nil {
+			return
+		}
+	}
+}
+
+// dispatch routes a method name to its handler, falling back to an
+// UNKNOWN_METHOD TApplicationException so the codec never hard-fails on an
+// unknown call.
+func (s *Server) dispatch(ctx context.Context, name string, args *Struct) (*Struct, error) {
+	if h, ok := s.methods[name]; ok {
+		return h(ctx, args)
+	}
+	return nil, &AppError{Type: thrift.UNKNOWN_METHOD, Message: "unknown method " + name}
+}
+
+// writeReply writes the reply message: a REPLY result struct, a REPLY carrying
+// a declared exception field, or an EXCEPTION TApplicationException.
+func (s *Server) writeReply(ctx context.Context, proto thrift.TProtocol, name string, seqid int32, result *Struct, herr error) error {
+	switch err := herr.(type) {
+	case nil:
+		if err := proto.WriteMessageBegin(ctx, name, thrift.REPLY, seqid); err != nil {
+			return err
+		}
+		if err := WriteStruct(ctx, proto, result); err != nil {
+			return err
+		}
+		return proto.WriteMessageEnd(ctx)
+	case *DeclaredError:
+		if err := proto.WriteMessageBegin(ctx, name, thrift.REPLY, seqid); err != nil {
+			return err
+		}
+		rs := &Struct{Fields: []Field{ExceptionField(err)}}
+		if err := WriteStruct(ctx, proto, rs); err != nil {
+			return err
+		}
+		return proto.WriteMessageEnd(ctx)
+	case *AppError:
+		if err := proto.WriteMessageBegin(ctx, name, thrift.EXCEPTION, seqid); err != nil {
+			return err
+		}
+		if err := WriteAppException(ctx, proto, err.Type, err.Message); err != nil {
+			return err
+		}
+		return proto.WriteMessageEnd(ctx)
+	default:
+		slog.Warn("hms: handler returned non-thrift error", "method", name, "err", err)
+		if werr := proto.WriteMessageBegin(ctx, name, thrift.EXCEPTION, seqid); werr != nil {
+			return werr
+		}
+		if werr := WriteAppException(ctx, proto, thrift.INTERNAL_ERROR, err.Error()); werr != nil {
+			return werr
+		}
+		return proto.WriteMessageEnd(ctx)
+	}
+}
+
+// Reset clears transport-level state (there is none beyond the shared store,
+// which the admin handler resets separately). Present for symmetry with the
+// gRPC server's Reset.
+func (s *Server) Reset(context.Context) {}
+
+// Addr returns the listener's bound address, or the configured address before
+// Serve has started.
+func (s *Server) Addr() net.Addr {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sock != nil {
+		return s.sock.Addr()
+	}
+	return nil
+}

--- a/internal/gcp/hms/server_test.go
+++ b/internal/gcp/hms/server_test.go
@@ -1,0 +1,347 @@
+package hms
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/apache/thrift/lib/go/thrift"
+
+	hmsstore "jaiscloud/internal/gcp/store/hms"
+)
+
+// --- test server harness ---
+
+func startServer(t *testing.T, store hmsstore.Store) (addr string, stop func()) {
+	t.Helper()
+	srv := NewServer("127.0.0.1:0", store)
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve() }()
+	deadline := time.Now().Add(2 * time.Second)
+	for srv.Addr() == nil {
+		if time.Now().After(deadline) {
+			t.Fatal("server did not bind")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return srv.Addr().String(), func() { srv.Stop(); <-done }
+}
+
+// --- raw Thrift client helper ---
+
+type reply struct {
+	name    string
+	msgType thrift.TMessageType
+	result  *Struct
+}
+
+// hmsCall dials addr, sends one CALL for method with args, and reads the reply.
+func hmsCall(t *testing.T, addr, method string, args *Struct) reply {
+	t.Helper()
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	sock := thrift.NewTSocketFromConnTimeout(conn, 2*time.Second)
+	proto := thrift.NewTBinaryProtocolTransport(sock)
+	ctx := context.Background()
+
+	if err := proto.WriteMessageBegin(ctx, method, thrift.CALL, 1); err != nil {
+		t.Fatalf("write msg begin: %v", err)
+	}
+	if err := WriteStruct(ctx, proto, args); err != nil {
+		t.Fatalf("write args: %v", err)
+	}
+	if err := proto.WriteMessageEnd(ctx); err != nil {
+		t.Fatalf("write msg end: %v", err)
+	}
+	if err := proto.Flush(ctx); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	name, msgType, _, err := proto.ReadMessageBegin(ctx)
+	if err != nil {
+		t.Fatalf("read msg begin: %v", err)
+	}
+	result, err := ReadStruct(ctx, proto)
+	if err != nil {
+		t.Fatalf("read result: %v", err)
+	}
+	if err := proto.ReadMessageEnd(ctx); err != nil {
+		t.Fatalf("read msg end: %v", err)
+	}
+	return reply{name: name, msgType: msgType, result: result}
+}
+
+func strList(vs []string) []Value {
+	out := make([]Value, 0, len(vs))
+	for _, v := range vs {
+		out = append(out, StringV(v))
+	}
+	return out
+}
+
+// testTable builds a realistic Iceberg Hive Table struct.
+func testTable(db, tbl, metadataLocation string) *Struct {
+	serde := NewBuilder().
+		Str(1, tbl).
+		Str(2, "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe").
+		MapStrStr(3, map[string]string{"serialization.format": "1"}).
+		Build()
+	sd := NewBuilder().
+		ListStruct(1, nil).
+		Str(2, "gs://bucket/wh/"+db+"/"+tbl).
+		Str(3, "org.apache.hadoop.mapred.FileInputFormat").
+		Str(4, "org.apache.hadoop.mapred.FileOutputFormat").
+		Bool(5, false).
+		I32(6, 0).
+		Struct(7, serde).
+		ListStr(8, nil).
+		ListStruct(9, nil).
+		MapStrStr(10, nil).
+		Bool(12, false).
+		Build()
+	return NewBuilder().
+		Str(tblTableName, tbl).
+		Str(tblDBName, db).
+		Str(3, "spark").
+		I32(4, 1700000000).
+		I32(5, 0).
+		I32(6, 0).
+		Struct(7, sd).
+		ListStruct(8, nil).
+		MapStrStr(9, map[string]string{
+			"metadata_location": metadataLocation,
+			"table_type":        "ICEBERG",
+		}).
+		Str(10, "").
+		Str(11, "").
+		Str(12, "EXTERNAL_TABLE").
+		Bool(14, false).
+		Bool(15, false).
+		Build()
+}
+
+func TestServerEndToEnd(t *testing.T) {
+	store := hmsstore.NewMemoryStore()
+	addr, stop := startServer(t, store)
+	defer stop()
+
+	// create_database
+	createDB := NewBuilder().Struct(1, NewBuilder().
+		Str(dbName, "default").
+		Str(dbLocationURI, "gs://bucket/wh/default").
+		Build()).Build()
+	r := hmsCall(t, addr, "create_database", createDB)
+	if r.msgType != thrift.REPLY {
+		t.Fatalf("create_database msgType=%d result=%+v", r.msgType, r.result)
+	}
+
+	// create_database again -> AlreadyExistsException (field 1)
+	r = hmsCall(t, addr, "create_database", createDB)
+	if r.msgType != thrift.REPLY {
+		t.Fatalf("create_database dup msgType=%d", r.msgType)
+	}
+	if f := r.result.Fields; len(f) != 1 || f[0].ID != 1 || f[0].V.T != thrift.STRUCT {
+		t.Fatalf("expected AlreadyExistsException field 1, got %+v", f)
+	}
+
+	// get_database
+	getDB := NewBuilder().Str(1, "default").Build()
+	r = hmsCall(t, addr, "get_database", getDB)
+	if r.msgType != thrift.REPLY {
+		t.Fatalf("get_database msgType=%d", r.msgType)
+	}
+	dbStruct := r.result.Struct(0)
+	if dbStruct == nil || dbStruct.String(dbName) != "default" || dbStruct.String(dbLocationURI) != "gs://bucket/wh/default" {
+		t.Fatalf("get_database wrong: %+v", r.result)
+	}
+
+	// create_table
+	ml1 := "gs://bucket/wh/default/t1/metadata/00001.metadata.json"
+	createTbl := NewBuilder().Struct(1, testTable("default", "t1", ml1)).Build()
+	r = hmsCall(t, addr, "create_table", createTbl)
+	if r.msgType != thrift.REPLY || len(r.result.Fields) != 0 {
+		t.Fatalf("create_table failed: type=%d result=%+v", r.msgType, r.result)
+	}
+
+	// get_table
+	getTbl := NewBuilder().Str(1, "default").Str(2, "t1").Build()
+	r = hmsCall(t, addr, "get_table", getTbl)
+	if r.msgType != thrift.REPLY {
+		t.Fatalf("get_table msgType=%d", r.msgType)
+	}
+	gotTbl := r.result.Struct(0)
+	if gotTbl == nil {
+		t.Fatal("get_table returned no table")
+	}
+	if gotTbl.String(tblTableName) != "t1" || gotTbl.String(tblDBName) != "default" {
+		t.Fatalf("get_table identity wrong: %+v", gotTbl)
+	}
+	if m := gotTbl.MapStrStr(9); m["metadata_location"] != ml1 {
+		t.Fatalf("get_table params lost metadata_location: %v", m)
+	}
+	// the round-tripped table must echo every field, incl. sd.serdeInfo.
+	if sd := gotTbl.Struct(7); sd == nil || sd.String(3) != "org.apache.hadoop.mapred.FileInputFormat" {
+		t.Fatalf("get_table sd lost: %+v", sd)
+	}
+
+	// get_all_tables
+	r = hmsCall(t, addr, "get_all_tables", NewBuilder().Str(1, "default").Build())
+	if names := r.result.List(0); len(names) != 1 || names[0].Str != "t1" {
+		t.Fatalf("get_all_tables wrong: %+v", r.result)
+	}
+
+	// get_table_objects_by_name (Iceberg listTables critical path)
+	r = hmsCall(t, addr, "get_table_objects_by_name", NewBuilder().Str(1, "default").Add(2, ListV(thrift.STRING, strList([]string{"t1"}))).Build())
+	if tables := r.result.List(0); len(tables) != 1 || tables[0].S == nil || tables[0].S.String(tblTableName) != "t1" {
+		t.Fatalf("get_table_objects_by_name wrong: %+v", r.result)
+	}
+
+	// alter_table — full-Table overwrite with a new metadata_location.
+	ml2 := "gs://bucket/wh/default/t1/metadata/00002.metadata.json"
+	alter := NewBuilder().Str(1, "default").Str(2, "t1").Struct(3, testTable("default", "t1", ml2)).Build()
+	r = hmsCall(t, addr, "alter_table", alter)
+	if r.msgType != thrift.REPLY || len(r.result.Fields) != 0 {
+		t.Fatalf("alter_table failed: type=%d result=%+v", r.msgType, r.result)
+	}
+	r = hmsCall(t, addr, "get_table", getTbl)
+	if m := r.result.Struct(0).MapStrStr(9); m["metadata_location"] != ml2 {
+		t.Fatalf("alter_table did not overwrite metadata_location: %v", m)
+	}
+
+	// rename via alter_table (new table name in the Table struct).
+	renamed := testTable("default", "t1_renamed", ml2)
+	alter = NewBuilder().Str(1, "default").Str(2, "t1").Struct(3, renamed).Build()
+	r = hmsCall(t, addr, "alter_table", alter)
+	if r.msgType != thrift.REPLY || len(r.result.Fields) != 0 {
+		t.Fatalf("rename via alter_table failed: type=%d result=%+v", r.msgType, r.result)
+	}
+	r = hmsCall(t, addr, "get_table", NewBuilder().Str(1, "default").Str(2, "t1_renamed").Build())
+	if r.msgType != thrift.REPLY || r.result.Struct(0) == nil {
+		t.Fatalf("renamed table not found: %+v", r.result)
+	}
+
+	// drop_table
+	dropTbl := NewBuilder().Str(1, "default").Str(2, "t1_renamed").Bool(3, false).Build()
+	r = hmsCall(t, addr, "drop_table", dropTbl)
+	if r.msgType != thrift.REPLY || len(r.result.Fields) != 0 {
+		t.Fatalf("drop_table failed: %+v", r.result)
+	}
+	r = hmsCall(t, addr, "get_table", NewBuilder().Str(1, "default").Str(2, "t1_renamed").Build())
+	if f := r.result.Fields; len(f) != 1 || f[0].ID != 2 { // NoSuchObjectException is field 2
+		t.Fatalf("expected NoSuchObjectException after drop, got %+v", f)
+	}
+}
+
+func TestServerLocks(t *testing.T) {
+	store := hmsstore.NewMemoryStore()
+	addr, stop := startServer(t, store)
+	defer stop()
+
+	// lock
+	comp := NewBuilder().I32(1, 3).I32(2, 2).Str(3, "default").Str(4, "tbl").Build()
+	req := NewBuilder().Add(1, ListV(thrift.STRUCT, []Value{StructV(comp)})).Str(3, "spark").Str(4, "host").Build()
+	r := hmsCall(t, addr, "lock", NewBuilder().Struct(1, req).Build())
+	if r.msgType != thrift.REPLY {
+		t.Fatalf("lock msgType=%d", r.msgType)
+	}
+	resp := r.result.Struct(0)
+	if resp == nil {
+		t.Fatal("lock returned no LockResponse")
+	}
+	lockID := resp.I64(lockRespLockID)
+	if lockID == 0 {
+		t.Fatal("lock returned lockid 0")
+	}
+	if resp.I32(lockRespState) != int32(hmsstore.LockStateAcquired) {
+		t.Fatalf("lock state = %d, want ACQUIRED", resp.I32(lockRespState))
+	}
+
+	// check_lock -> ACQUIRED
+	check := NewBuilder().I64(1, lockID).Build()
+	r = hmsCall(t, addr, "check_lock", NewBuilder().Struct(1, check).Build())
+	if resp := r.result.Struct(0); resp == nil || resp.I32(lockRespState) != int32(hmsstore.LockStateAcquired) {
+		t.Fatalf("check_lock wrong: %+v", r.result)
+	}
+
+	// unlock
+	unlock := NewBuilder().I64(1, lockID).Build()
+	r = hmsCall(t, addr, "unlock", NewBuilder().Struct(1, unlock).Build())
+	if r.msgType != thrift.REPLY || len(r.result.Fields) != 0 {
+		t.Fatalf("unlock failed: %+v", r.result)
+	}
+
+	// check_lock after unlock -> NOT_ACQUIRED (absent, not an error)
+	r = hmsCall(t, addr, "check_lock", NewBuilder().Struct(1, check).Build())
+	if resp := r.result.Struct(0); resp == nil || resp.I32(lockRespState) != int32(hmsstore.LockStateNotAcquired) {
+		t.Fatalf("check_lock after unlock should be NOT_ACQUIRED, got %+v", r.result)
+	}
+}
+
+func TestServerNotificationsAndFunctions(t *testing.T) {
+	store := hmsstore.NewMemoryStore()
+	addr, stop := startServer(t, store)
+	defer stop()
+
+	r := hmsCall(t, addr, "get_current_notificationEventId", &Struct{})
+	if r.msgType != thrift.REPLY {
+		t.Fatalf("get_current_notificationEventId msgType=%d", r.msgType)
+	}
+	if resp := r.result.Struct(0); resp == nil || resp.I64(1) != 0 {
+		t.Fatalf("get_current_notificationEventId wrong: %+v", r.result)
+	}
+
+	r = hmsCall(t, addr, "get_next_notification", &Struct{})
+	if r.msgType != thrift.REPLY || r.result.Struct(0) == nil {
+		t.Fatalf("get_next_notification wrong: %+v", r.result)
+	}
+
+	r = hmsCall(t, addr, "get_functions", NewBuilder().Str(1, "default").Str(2, "").Build())
+	if r.msgType != thrift.REPLY {
+		t.Fatalf("get_functions msgType=%d", r.msgType)
+	}
+	if l := r.result.List(0); len(l) != 0 {
+		t.Fatalf("get_functions should be empty: %+v", l)
+	}
+
+	r = hmsCall(t, addr, "get_function", NewBuilder().Str(1, "default").Str(2, "fn").Build())
+	if f := r.result.Fields; len(f) != 1 || f[0].ID != 2 { // NoSuchObjectException is field 2
+		t.Fatalf("get_function should throw NoSuchObjectException, got %+v", f)
+	}
+}
+
+func TestServerUnknownMethod(t *testing.T) {
+	store := hmsstore.NewMemoryStore()
+	addr, stop := startServer(t, store)
+	defer stop()
+
+	r := hmsCall(t, addr, "definitely_not_a_method", &Struct{})
+	if r.msgType != thrift.EXCEPTION {
+		t.Fatalf("unknown method should be EXCEPTION, got %d", r.msgType)
+	}
+	if r.result == nil || r.result.String(1) == "" {
+		t.Fatalf("unknown method should carry a TApplicationException message, got %+v", r.result)
+	}
+}
+
+func TestServerPartitionStubs(t *testing.T) {
+	store := hmsstore.NewMemoryStore()
+	addr, stop := startServer(t, store)
+	defer stop()
+
+	r := hmsCall(t, addr, "get_partitions", NewBuilder().Str(1, "db").Str(2, "tbl").I16(3, -1).Build())
+	if r.msgType != thrift.REPLY {
+		t.Fatalf("get_partitions msgType=%d", r.msgType)
+	}
+	if l := r.result.List(0); l == nil || len(l) != 0 {
+		t.Fatalf("get_partitions should be empty list, got %+v", r.result)
+	}
+
+	r = hmsCall(t, addr, "get_partition", NewBuilder().Str(1, "db").Str(2, "tbl").Add(3, ListV(thrift.STRING, nil)).Build())
+	if f := r.result.Fields; len(f) != 1 || f[0].ID != 2 { // NoSuchObjectException
+		t.Fatalf("get_partition should throw NoSuchObjectException, got %+v", f)
+	}
+}

--- a/internal/gcp/hms/structs.go
+++ b/internal/gcp/hms/structs.go
@@ -1,0 +1,83 @@
+package hms
+
+import hmsstore "jaiscloud/internal/gcp/store/hms"
+
+// Field IDs and enum values derived from hive_metastore.thrift (Apache Hive
+// branch-2.3, metastore/if/hive_metastore.thrift). Only the fields the serving
+// plane actually reads/builds are named here; the codec itself is schema-free,
+// so every other field round-trips generically.
+
+// Database fields.
+const (
+	dbName        int16 = 1
+	dbDescription int16 = 2
+	dbLocationURI int16 = 3
+	dbParameters  int16 = 4
+	dbOwnerName   int16 = 6
+	dbOwnerType   int16 = 7
+)
+
+// Table fields.
+const (
+	tblTableName int16 = 1
+	tblDBName    int16 = 2
+)
+
+// LockComponent fields.
+const (
+	lcDBName    int16 = 3
+	lcTableName int16 = 4
+)
+
+// LockRequest fields.
+const (
+	lrComponent int16 = 1
+	lrUser      int16 = 3
+	lrHostname  int16 = 4
+)
+
+// LockResponse fields.
+const (
+	lockRespLockID int16 = 1
+	lockRespState  int16 = 2
+)
+
+// Notification structs.
+const (
+	notifEventID int16 = 1
+	notifEvents  int16 = 1
+)
+
+// PrincipalType enum.
+const (
+	principalTypeUser  int32 = 1
+	principalTypeRole  int32 = 2
+	principalTypeGroup int32 = 3
+)
+
+// buildDatabaseStruct renders a store Database as a wire Database struct,
+// emitting fields in ascending field-ID order (1,2,3,4,6,7). ownerType defaults
+// to USER; privileges and catalogName are not persisted and are omitted.
+func buildDatabaseStruct(db hmsstore.Database) *Struct {
+	b := NewBuilder().Str(dbName, db.Name)
+	if db.Description != "" {
+		b.Str(dbDescription, db.Description)
+	}
+	if db.LocationURI != "" {
+		b.Str(dbLocationURI, db.LocationURI)
+	}
+	b.MapStrStr(dbParameters, db.Parameters)
+	if db.Owner != "" {
+		b.Str(dbOwnerName, db.Owner)
+		b.I32(dbOwnerType, principalTypeUser)
+	}
+	return b.Build()
+}
+
+// buildLockResponse renders (lockid, state) as a LockResponse struct.
+func buildLockResponse(lockID int64, state hmsstore.LockState) *Struct {
+	return NewBuilder().
+		I64(lockRespLockID, lockID).
+		I32(lockRespState, int32(state)).
+		Build()
+}

--- a/internal/gcp/hms/types.go
+++ b/internal/gcp/hms/types.go
@@ -1,0 +1,221 @@
+// Package hms implements the DPMS Hive Metastore serving plane over Thrift: a
+// TBinaryProtocol codec + struct layer + method dispatch, backed by
+// internal/gcp/store/hms. It is the GCP analogue of the AWS Glue table-metadata
+// serving path, but over the real Apache Hive Metastore protocol
+// (hive_metastore.thrift) rather than Glue's REST surface.
+//
+// The codec is generic and lossless: every value is decoded into a type-tagged
+// Value (carrying its wire TType), and a struct is an ordered field list. This
+// lets the full Table struct round-trip byte-for-byte through get_table ->
+// alter_table without a schema, which is the load-bearing requirement for
+// Iceberg-on-Hive (F5). Field IDs and the method subset are derived from
+// hive_metastore.thrift (Apache Hive branch-2.3).
+package hms
+
+import (
+	"sort"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+// Value is a decoded Thrift value, tagged with its wire type so a generic
+// struct can round-trip byte-for-byte without a schema. Only the fields
+// relevant to the value's type are populated.
+type Value struct {
+	T       thrift.TType
+	B       bool
+	I8      int8
+	I16     int16
+	I32     int32
+	I64     int64
+	F64     float64
+	Str     string
+	S       *Struct
+	Elem    thrift.TType
+	List    []Value
+	K       thrift.TType
+	V       thrift.TType
+	Entries []MapEntry
+}
+
+// MapEntry is a single map key/value pair (order preserved for round-trip).
+type MapEntry struct {
+	K Value
+	V Value
+}
+
+// Field is one struct field: its ID and value.
+type Field struct {
+	ID int16
+	V  Value
+}
+
+// Struct is a decoded Thrift struct: an ordered field list (order preserved so
+// encode(decode(bytes)) == bytes).
+type Struct struct {
+	Fields []Field
+}
+
+// --- Value constructors ---
+
+func BoolV(v bool) Value      { return Value{T: thrift.BOOL, B: v} }
+func ByteV(v int8) Value      { return Value{T: thrift.BYTE, I8: v} }
+func I16V(v int16) Value      { return Value{T: thrift.I16, I16: v} }
+func I32V(v int32) Value      { return Value{T: thrift.I32, I32: v} }
+func I64V(v int64) Value      { return Value{T: thrift.I64, I64: v} }
+func DoubleV(v float64) Value { return Value{T: thrift.DOUBLE, F64: v} }
+func StringV(v string) Value  { return Value{T: thrift.STRING, Str: v} }
+func StructV(s *Struct) Value { return Value{T: thrift.STRUCT, S: s} }
+func ListV(e thrift.TType, l []Value) Value {
+	return Value{T: thrift.LIST, Elem: e, List: l}
+}
+func SetV(e thrift.TType, l []Value) Value {
+	return Value{T: thrift.SET, Elem: e, List: l}
+}
+func MapV(k, v thrift.TType, entries []MapEntry) Value {
+	return Value{T: thrift.MAP, K: k, V: v, Entries: entries}
+}
+
+// --- Struct accessors ---
+
+// Get returns the field with the given ID and whether it is present. When a
+// field ID appears more than once (not produced by well-formed clients), the
+// first occurrence wins.
+func (s *Struct) Get(id int16) (Value, bool) {
+	if s == nil {
+		return Value{}, false
+	}
+	for i := range s.Fields {
+		if s.Fields[i].ID == id {
+			return s.Fields[i].V, true
+		}
+	}
+	return Value{}, false
+}
+
+func (s *Struct) String(id int16) string {
+	if v, ok := s.Get(id); ok && v.T == thrift.STRING {
+		return v.Str
+	}
+	return ""
+}
+
+func (s *Struct) I32(id int16) int32 {
+	if v, ok := s.Get(id); ok && v.T == thrift.I32 {
+		return v.I32
+	}
+	return 0
+}
+
+func (s *Struct) I64(id int16) int64 {
+	if v, ok := s.Get(id); ok && v.T == thrift.I64 {
+		return v.I64
+	}
+	return 0
+}
+
+func (s *Struct) Bool(id int16) bool {
+	if v, ok := s.Get(id); ok && v.T == thrift.BOOL {
+		return v.B
+	}
+	return false
+}
+
+func (s *Struct) Struct(id int16) *Struct {
+	if v, ok := s.Get(id); ok && v.T == thrift.STRUCT {
+		return v.S
+	}
+	return nil
+}
+
+func (s *Struct) List(id int16) []Value {
+	if v, ok := s.Get(id); ok && (v.T == thrift.LIST || v.T == thrift.SET) {
+		return v.List
+	}
+	return nil
+}
+
+func (s *Struct) MapStrStr(id int16) map[string]string {
+	v, ok := s.Get(id)
+	if !ok || v.T != thrift.MAP {
+		return nil
+	}
+	m := make(map[string]string, len(v.Entries))
+	for _, e := range v.Entries {
+		if e.K.T == thrift.STRING && e.V.T == thrift.STRING {
+			m[e.K.Str] = e.V.Str
+		}
+	}
+	return m
+}
+
+// Set replaces the field with the given ID, appending it if absent.
+func (s *Struct) Set(id int16, v Value) {
+	for i := range s.Fields {
+		if s.Fields[i].ID == id {
+			s.Fields[i].V = v
+			return
+		}
+	}
+	s.Fields = append(s.Fields, Field{ID: id, V: v})
+}
+
+// --- Ordered builder ---
+
+// Builder constructs a Struct with fields in a fixed order. Callers must add
+// fields in ascending field-ID order (matching the Java generated code) so
+// hand-encoded golden fixtures round-trip byte-for-byte.
+type Builder struct{ s *Struct }
+
+// NewBuilder returns an empty struct builder.
+func NewBuilder() *Builder { return &Builder{s: &Struct{}} }
+
+func (b *Builder) Add(id int16, v Value) *Builder {
+	b.s.Fields = append(b.s.Fields, Field{ID: id, V: v})
+	return b
+}
+
+func (b *Builder) Str(id int16, v string) *Builder { return b.Add(id, StringV(v)) }
+func (b *Builder) I16(id int16, v int16) *Builder  { return b.Add(id, I16V(v)) }
+func (b *Builder) I32(id int16, v int32) *Builder  { return b.Add(id, I32V(v)) }
+func (b *Builder) I64(id int16, v int64) *Builder  { return b.Add(id, I64V(v)) }
+func (b *Builder) Bool(id int16, v bool) *Builder  { return b.Add(id, BoolV(v)) }
+func (b *Builder) Struct(id int16, s *Struct) *Builder {
+	return b.Add(id, StructV(s))
+}
+
+func (b *Builder) ListStr(id int16, elems []string) *Builder {
+	vals := make([]Value, 0, len(elems))
+	for _, e := range elems {
+		vals = append(vals, StringV(e))
+	}
+	return b.Add(id, ListV(thrift.STRING, vals))
+}
+
+func (b *Builder) ListStruct(id int16, elems []*Struct) *Builder {
+	vals := make([]Value, 0, len(elems))
+	for _, e := range elems {
+		vals = append(vals, StructV(e))
+	}
+	return b.Add(id, ListV(thrift.STRUCT, vals))
+}
+
+// MapStrStr adds a map<string,string> field with keys sorted for deterministic
+// output.
+func (b *Builder) MapStrStr(id int16, m map[string]string) *Builder {
+	if len(m) == 0 {
+		return b
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	entries := make([]MapEntry, 0, len(keys))
+	for _, k := range keys {
+		entries = append(entries, MapEntry{K: StringV(k), V: StringV(m[k])})
+	}
+	return b.Add(id, MapV(thrift.STRING, thrift.STRING, entries))
+}
+
+func (b *Builder) Build() *Struct { return b.s }

--- a/internal/gcp/provider/metastore/metastore.go
+++ b/internal/gcp/provider/metastore/metastore.go
@@ -136,6 +136,36 @@ func endpointURI(id, location string) string {
 	return fmt.Sprintf("thrift://%s.%s.metastore.jaiscloud.local:9083", id, location)
 }
 
+// endpointProtocolFromBody extracts hiveMetastoreConfig.endpointProtocol
+// (camelCase on the wire) from a CreateService request body, or "" when unset.
+func endpointProtocolFromBody(body map[string]any) string {
+	if body == nil {
+		return ""
+	}
+	hmsCfg, _ := body["hiveMetastoreConfig"].(map[string]any)
+	if hmsCfg == nil {
+		return ""
+	}
+	s, _ := hmsCfg["endpointProtocol"].(string)
+	return s
+}
+
+// validateEndpointProtocol enforces the endpoint_protocol contract (D4/F7):
+// THRIFT (or absent, the proto default) is accepted; GRPC is rejected with
+// InvalidArgument (the gRPC serving plane is deferred), and any other value is
+// rejected as invalid rather than stored verbatim.
+func validateEndpointProtocol(body map[string]any) error {
+	proto := strings.ToUpper(strings.TrimSpace(endpointProtocolFromBody(body)))
+	switch proto {
+	case "", "THRIFT":
+		return nil
+	case "GRPC":
+		return model.NewProviderError("InvalidArgument", "endpointProtocol GRPC is not supported by the emulator (gRPC serving plane is deferred)", 400)
+	default:
+		return model.NewProviderError("InvalidArgument", "invalid endpointProtocol "+proto+": must be THRIFT or GRPC", 400)
+	}
+}
+
 // serviceMap renders a store Service as a metastore.v1.Service wire map. The
 // stored request body is echoed verbatim, then name/state/times/endpointUri are
 // overlaid (output-only) and tier defaults to DEVELOPER.
@@ -310,6 +340,12 @@ func (p *Provider) CreateService(ctx context.Context, nr *model.NormalizedReques
 		return nil, model.NewProviderError("InvalidArgument", "missing location or serviceId", 400)
 	}
 	body, _ := nr.Params["body"].(map[string]any)
+	// D4/F7: parse and validate hiveMetastoreConfig.endpointProtocol. THRIFT is
+	// the default and the only served protocol; GRPC is deferred, so it fails
+	// loud rather than advertising an endpoint nothing listens on.
+	if err := validateEndpointProtocol(body); err != nil {
+		return nil, err
+	}
 	now := clock.Now().UTC()
 	svc := metastorestore.Service{
 		Location:     location,

--- a/internal/gcp/provider/metastore/metastore_test.go
+++ b/internal/gcp/provider/metastore/metastore_test.go
@@ -458,3 +458,47 @@ func TestUpdateService_UnrecognizedNestedMaskFailsLoud(t *testing.T) {
 func hasPrefix(s, prefix string) bool {
 	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
 }
+
+func TestCreateServiceEndpointProtocol(t *testing.T) {
+	ctx := context.Background()
+
+	// Absent endpointProtocol -> THRIFT default, accepted.
+	p := newProvider()
+	if _, err := p.CreateService(ctx, newNR(createServiceParams("us-central1", "svc1", map[string]any{
+		"hiveMetastoreConfig": map[string]any{"version": "3.1.2"},
+	}))); err != nil {
+		t.Fatalf("absent endpointProtocol should default to THRIFT: %v", err)
+	}
+
+	// THRIFT (and lowercase) accepted.
+	p = newProvider()
+	if _, err := p.CreateService(ctx, newNR(createServiceParams("us-central1", "svc2", map[string]any{
+		"hiveMetastoreConfig": map[string]any{"version": "3.1.2", "endpointProtocol": "thrift"},
+	}))); err != nil {
+		t.Fatalf("THRIFT endpointProtocol should be accepted: %v", err)
+	}
+
+	// GRPC rejected with InvalidArgument (gRPC serving plane deferred — D4).
+	p = newProvider()
+	_, err := p.CreateService(ctx, newNR(createServiceParams("us-central1", "svc3", map[string]any{
+		"hiveMetastoreConfig": map[string]any{"version": "3.1.2", "endpointProtocol": "GRPC"},
+	})))
+	if err == nil {
+		t.Fatal("expected GRPC endpointProtocol to be rejected, got nil")
+	}
+	if perr, ok := err.(*model.ProviderError); !ok || perr.Code != "InvalidArgument" {
+		t.Fatalf("expected InvalidArgument for GRPC, got %v", err)
+	}
+
+	// Unknown value rejected with InvalidArgument.
+	p = newProvider()
+	_, err = p.CreateService(ctx, newNR(createServiceParams("us-central1", "svc4", map[string]any{
+		"hiveMetastoreConfig": map[string]any{"endpointProtocol": "BOGUS"},
+	})))
+	if err == nil {
+		t.Fatal("expected invalid endpointProtocol to be rejected, got nil")
+	}
+	if perr, ok := err.(*model.ProviderError); !ok || perr.Code != "InvalidArgument" {
+		t.Fatalf("expected InvalidArgument for invalid value, got %v", err)
+	}
+}

--- a/internal/gcp/store/hms/memory.go
+++ b/internal/gcp/store/hms/memory.go
@@ -1,0 +1,223 @@
+package hms
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"sync/atomic"
+
+	"jaiscloud/internal/gcp/storeutil"
+)
+
+// MemoryStore is an in-memory Store.
+type MemoryStore struct {
+	mu        sync.RWMutex
+	databases map[string]Database
+	tables    map[string]map[string]Table // db -> name -> table
+	locks     map[int64]lockRecord
+	lockSeq   atomic.Int64
+}
+
+type lockRecord struct {
+	state LockState
+}
+
+// NewMemoryStore returns an empty in-memory store.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		databases: make(map[string]Database),
+		tables:    make(map[string]map[string]Table),
+		locks:     make(map[int64]lockRecord),
+	}
+}
+
+// --- Databases ---
+
+func (s *MemoryStore) CreateDatabase(_ context.Context, db Database) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.databases[db.Name]; ok {
+		return ErrDatabaseExists
+	}
+	if db.Parameters == nil {
+		db.Parameters = map[string]string{}
+	}
+	s.databases[db.Name] = db
+	return nil
+}
+
+func (s *MemoryStore) GetDatabase(_ context.Context, name string) (Database, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	db, ok := s.databases[name]
+	if !ok {
+		return Database{}, ErrDatabaseNotFound
+	}
+	return db, nil
+}
+
+func (s *MemoryStore) ListDatabases(_ context.Context) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	names := make([]string, 0, len(s.databases))
+	for name := range s.databases {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func (s *MemoryStore) DropDatabase(_ context.Context, name string, cascade bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.databases[name]; !ok {
+		return ErrDatabaseNotFound
+	}
+	if !cascade && len(s.tables[name]) > 0 {
+		return ErrDatabaseNotEmpty
+	}
+	delete(s.tables, name)
+	delete(s.databases, name)
+	return nil
+}
+
+func (s *MemoryStore) AlterDatabase(_ context.Context, name string, db Database) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.databases[name]; !ok {
+		return ErrDatabaseNotFound
+	}
+	if db.Parameters == nil {
+		db.Parameters = map[string]string{}
+	}
+	db.Name = name
+	s.databases[name] = db
+	return nil
+}
+
+// --- Tables ---
+
+func (s *MemoryStore) CreateTable(_ context.Context, dbName, tableName string, t Table) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.databases[dbName]; !ok {
+		return ErrDatabaseNotFound
+	}
+	if s.tables[dbName] == nil {
+		s.tables[dbName] = make(map[string]Table)
+	}
+	if _, ok := s.tables[dbName][tableName]; ok {
+		return ErrTableExists
+	}
+	t.DBName = dbName
+	t.TableName = tableName
+	s.tables[dbName][tableName] = t
+	return nil
+}
+
+func (s *MemoryStore) GetTable(_ context.Context, dbName, tableName string) (Table, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	t, ok := s.tables[dbName][tableName]
+	if !ok {
+		return Table{}, ErrTableNotFound
+	}
+	return t, nil
+}
+
+func (s *MemoryStore) ListTables(_ context.Context, dbName string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	m := s.tables[dbName]
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func (s *MemoryStore) DropTable(_ context.Context, dbName, tableName string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.tables[dbName][tableName]; !ok {
+		return ErrTableNotFound
+	}
+	delete(s.tables[dbName], tableName)
+	return nil
+}
+
+func (s *MemoryStore) AlterTable(_ context.Context, dbName, tableName string, mutate func(Table) (Table, error)) (Table, error) {
+	return storeutil.AtomicUpdate(&s.mu,
+		func() (Table, bool) { t, ok := s.tables[dbName][tableName]; return t, ok },
+		func(current Table, exists bool) (Table, error) {
+			if !exists {
+				return Table{}, ErrTableNotFound
+			}
+			return mutate(current)
+		},
+		func(next Table) {
+			next.DBName = dbName
+			next.TableName = tableName
+			s.tables[dbName][tableName] = next
+		},
+	)
+}
+
+func (s *MemoryStore) RenameTable(_ context.Context, srcDB, srcName, dstDB, dstName string, t Table) (Table, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.tables[srcDB][srcName]; !ok {
+		return Table{}, ErrTableNotFound
+	}
+	if _, ok := s.databases[dstDB]; !ok {
+		return Table{}, ErrDatabaseNotFound
+	}
+	if _, exists := s.tables[dstDB][dstName]; exists {
+		return Table{}, ErrTableExists
+	}
+	delete(s.tables[srcDB], srcName)
+	if s.tables[dstDB] == nil {
+		s.tables[dstDB] = make(map[string]Table)
+	}
+	t.DBName = dstDB
+	t.TableName = dstName
+	s.tables[dstDB][dstName] = t
+	return t, nil
+}
+
+// --- Locks ---
+
+func (s *MemoryStore) Lock(_ context.Context, _ Lock) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := s.lockSeq.Add(1)
+	s.locks[id] = lockRecord{state: LockStateAcquired}
+	return id, nil
+}
+
+func (s *MemoryStore) CheckLock(_ context.Context, id int64) (LockState, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	rec, ok := s.locks[id]
+	if !ok {
+		return LockStateNotAcquired, nil
+	}
+	return rec.state, nil
+}
+
+func (s *MemoryStore) Unlock(_ context.Context, id int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.locks, id)
+	return nil
+}
+
+func (s *MemoryStore) Reset(_ context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.databases = make(map[string]Database)
+	s.tables = make(map[string]map[string]Table)
+	s.locks = make(map[int64]lockRecord)
+	s.lockSeq.Store(0)
+}

--- a/internal/gcp/store/hms/postgres.go
+++ b/internal/gcp/store/hms/postgres.go
@@ -1,0 +1,357 @@
+package hms
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sort"
+
+	"jaiscloud/internal/clock"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgresStore implements Store against jc_hms_databases / jc_hms_tables /
+// jc_hms_locks.
+type PostgresStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresStore returns a Postgres-backed store.
+func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore {
+	return &PostgresStore{pool: pool}
+}
+
+func jsonObj(v any) any {
+	if v == nil {
+		return json.RawMessage("{}")
+	}
+	b, _ := json.Marshal(v)
+	return json.RawMessage(b)
+}
+
+// --- Databases ---
+
+func (s *PostgresStore) CreateDatabase(ctx context.Context, db Database) error {
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO jc_hms_databases (name, location_uri, parameters, description, owner)
+		VALUES ($1,$2,$3,$4,$5)
+	`, db.Name, db.LocationURI, jsonObj(db.Parameters), db.Description, db.Owner)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrDatabaseExists
+		}
+		return err
+	}
+	return nil
+}
+
+func scanDatabase(row pgx.Row) (Database, error) {
+	var db Database
+	var params []byte
+	err := row.Scan(&db.Name, &db.LocationURI, &params, &db.Description, &db.Owner)
+	if err != nil {
+		return Database{}, err
+	}
+	db.Parameters = scanStrMap(params)
+	return db, nil
+}
+
+func scanStrMap(b []byte) map[string]string {
+	if len(b) == 0 {
+		return map[string]string{}
+	}
+	m := map[string]string{}
+	_ = json.Unmarshal(b, &m)
+	if m == nil {
+		m = map[string]string{}
+	}
+	return m
+}
+
+const dbColumns = `name, location_uri, parameters, description, owner`
+
+func (s *PostgresStore) GetDatabase(ctx context.Context, name string) (Database, error) {
+	db, err := scanDatabase(s.pool.QueryRow(ctx, `
+		SELECT `+dbColumns+` FROM jc_hms_databases WHERE name=$1
+	`, name))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Database{}, ErrDatabaseNotFound
+	}
+	return db, err
+}
+
+func (s *PostgresStore) ListDatabases(ctx context.Context) ([]string, error) {
+	rows, err := s.pool.Query(ctx, `SELECT name FROM jc_hms_databases ORDER BY name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			return nil, err
+		}
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names, rows.Err()
+}
+
+func (s *PostgresStore) DropDatabase(ctx context.Context, name string, cascade bool) error {
+	// Non-cascade drop relies on the FK (ON DELETE RESTRICT) for atomicity:
+	// a DELETE on a database still referenced by a table fails with 23503,
+	// closing the check-then-act race. Cascade drops tables first in a
+	// transaction, then the database.
+	if cascade {
+		tx, err := s.pool.Begin(ctx)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback(ctx)
+		if _, err := tx.Exec(ctx, `DELETE FROM jc_hms_tables WHERE db_name=$1`, name); err != nil {
+			return err
+		}
+		tag, err := tx.Exec(ctx, `DELETE FROM jc_hms_databases WHERE name=$1`, name)
+		if err != nil {
+			return err
+		}
+		if tag.RowsAffected() == 0 {
+			return ErrDatabaseNotFound
+		}
+		return tx.Commit(ctx)
+	}
+	tag, err := s.pool.Exec(ctx, `DELETE FROM jc_hms_databases WHERE name=$1`, name)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+			return ErrDatabaseNotEmpty
+		}
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrDatabaseNotFound
+	}
+	return nil
+}
+
+func (s *PostgresStore) AlterDatabase(ctx context.Context, name string, db Database) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE jc_hms_databases SET location_uri=$2, parameters=$3, description=$4, owner=$5
+		WHERE name=$1
+	`, name, db.LocationURI, jsonObj(db.Parameters), db.Description, db.Owner)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrDatabaseNotFound
+	}
+	return nil
+}
+
+// --- Tables ---
+
+func (s *PostgresStore) CreateTable(ctx context.Context, dbName, tableName string, t Table) error {
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO jc_hms_tables (db_name, table_name, table_json)
+		VALUES ($1,$2,$3)
+	`, dbName, tableName, jsonObj(json.RawMessage(t.TableJSON)))
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrTableExists
+		}
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+			return ErrDatabaseNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+func scanTable(row pgx.Row) (Table, error) {
+	var t Table
+	var b []byte
+	err := row.Scan(&t.DBName, &t.TableName, &b)
+	if err != nil {
+		return Table{}, err
+	}
+	t.TableJSON = json.RawMessage(b)
+	return t, nil
+}
+
+const tableColumns = `db_name, table_name, table_json`
+
+func (s *PostgresStore) GetTable(ctx context.Context, dbName, tableName string) (Table, error) {
+	t, err := scanTable(s.pool.QueryRow(ctx, `
+		SELECT `+tableColumns+` FROM jc_hms_tables WHERE db_name=$1 AND table_name=$2
+	`, dbName, tableName))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Table{}, ErrTableNotFound
+	}
+	return t, err
+}
+
+func (s *PostgresStore) ListTables(ctx context.Context, dbName string) ([]string, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT table_name FROM jc_hms_tables WHERE db_name=$1 ORDER BY table_name
+	`, dbName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			return nil, err
+		}
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names, rows.Err()
+}
+
+func (s *PostgresStore) DropTable(ctx context.Context, dbName, tableName string) error {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM jc_hms_tables WHERE db_name=$1 AND table_name=$2`, dbName, tableName)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrTableNotFound
+	}
+	return nil
+}
+
+// AlterTable mirrors MemoryStore's version: a Serializable transaction with
+// SELECT ... FOR UPDATE row-locks the table for the duration of mutate, so a
+// concurrent commit to the same table blocks instead of silently losing the
+// other's update.
+func (s *PostgresStore) AlterTable(ctx context.Context, dbName, tableName string, mutate func(Table) (Table, error)) (Table, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return Table{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	current, err := scanTable(tx.QueryRow(ctx, `
+		SELECT `+tableColumns+` FROM jc_hms_tables WHERE db_name=$1 AND table_name=$2 FOR UPDATE
+	`, dbName, tableName))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Table{}, ErrTableNotFound
+	}
+	if err != nil {
+		return Table{}, err
+	}
+
+	next, err := mutate(current)
+	if err != nil {
+		return Table{}, err
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE jc_hms_tables SET table_json=$3 WHERE db_name=$1 AND table_name=$2
+	`, dbName, tableName, jsonObj(json.RawMessage(next.TableJSON))); err != nil {
+		return Table{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Table{}, err
+	}
+	next.DBName = dbName
+	next.TableName = tableName
+	return next, nil
+}
+
+// RenameTable is atomic: a Serializable transaction row-locks the source (and
+// probes the destination) so a concurrent commit/rename can't race it.
+func (s *PostgresStore) RenameTable(ctx context.Context, srcDB, srcName, dstDB, dstName string, t Table) (Table, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return Table{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	var one int
+	if err := tx.QueryRow(ctx, `SELECT 1 FROM jc_hms_tables WHERE db_name=$1 AND table_name=$2 FOR UPDATE`, srcDB, srcName).Scan(&one); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Table{}, ErrTableNotFound
+		}
+		return Table{}, err
+	}
+	var dbOne int
+	if err := tx.QueryRow(ctx, `SELECT 1 FROM jc_hms_databases WHERE name=$1 FOR UPDATE`, dstDB).Scan(&dbOne); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Table{}, ErrDatabaseNotFound
+		}
+		return Table{}, err
+	}
+
+	err = tx.QueryRow(ctx, `SELECT 1 FROM jc_hms_tables WHERE db_name=$1 AND table_name=$2 FOR UPDATE`, dstDB, dstName).Scan(&one)
+	if err == nil {
+		return Table{}, ErrTableExists
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return Table{}, err
+	}
+
+	if _, err := tx.Exec(ctx, `DELETE FROM jc_hms_tables WHERE db_name=$1 AND table_name=$2`, srcDB, srcName); err != nil {
+		return Table{}, err
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO jc_hms_tables (db_name, table_name, table_json)
+		VALUES ($1,$2,$3)
+	`, dstDB, dstName, jsonObj(json.RawMessage(t.TableJSON))); err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return Table{}, ErrTableExists
+		}
+		return Table{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Table{}, err
+	}
+	t.DBName = dstDB
+	t.TableName = dstName
+	return t, nil
+}
+
+// --- Locks ---
+
+func (s *PostgresStore) Lock(ctx context.Context, l Lock) (int64, error) {
+	var id int64
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO jc_hms_locks (state, db_name, table_name, user_name, hostname, create_time)
+		VALUES ($1,$2,$3,$4,$5,$6) RETURNING lock_id
+	`, int32(LockStateAcquired), l.DBName, l.TableName, l.User, l.Hostname, clock.Now()).Scan(&id)
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+func (s *PostgresStore) CheckLock(ctx context.Context, id int64) (LockState, error) {
+	var state int32
+	err := s.pool.QueryRow(ctx, `SELECT state FROM jc_hms_locks WHERE lock_id=$1`, id).Scan(&state)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return LockStateNotAcquired, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return LockState(state), nil
+}
+
+func (s *PostgresStore) Unlock(ctx context.Context, id int64) error {
+	_, err := s.pool.Exec(ctx, `DELETE FROM jc_hms_locks WHERE lock_id=$1`, id)
+	return err
+}
+
+func (s *PostgresStore) Reset(ctx context.Context) {
+	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_hms_tables`)
+	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_hms_databases`)
+	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_hms_locks`)
+}

--- a/internal/gcp/store/hms/postgres_test.go
+++ b/internal/gcp/store/hms/postgres_test.go
@@ -1,0 +1,83 @@
+//go:build gcp_persistence
+
+package hms
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	gcpstore "jaiscloud/internal/gcp/store"
+	"jaiscloud/internal/store"
+)
+
+// TestPostgresStore runs the shared store matrix against Postgres.
+func TestPostgresStore(t *testing.T) {
+	dsn := os.Getenv("JAISCLOUD_DSN")
+	if dsn == "" {
+		t.Skip("JAISCLOUD_DSN not set — skipping Postgres store test")
+	}
+	ctx := context.Background()
+
+	pg, err := store.NewPostgresResourceStore(ctx, dsn, "gcp")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pg.Close()
+	if err := store.RunMigrations(ctx, pg.Pool(), "gcp", gcpstore.MigrationFS, "gcp"); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	s := NewPostgresStore(pg.Pool())
+	s.Reset(ctx)
+	runStoreTests(t, s)
+}
+
+// TestPostgresTableJSONVerbatim verifies the full Table JSON survives a
+// Postgres Snapshot/Restore round trip byte-for-byte.
+func TestPostgresTableJSONVerbatim(t *testing.T) {
+	dsn := os.Getenv("JAISCLOUD_DSN")
+	if dsn == "" {
+		t.Skip("JAISCLOUD_DSN not set — skipping Postgres snapshot test")
+	}
+	ctx := context.Background()
+
+	pg, err := store.NewPostgresResourceStore(ctx, dsn, "gcp")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pg.Close()
+	if err := store.RunMigrations(ctx, pg.Pool(), "gcp", gcpstore.MigrationFS, "gcp"); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	s := NewPostgresStore(pg.Pool())
+	s.Reset(ctx)
+
+	const tblJSON = `["o",[[1,["s","t1"]],[2,["s","default"]],[9,["m",11,11,[[["s","metadata_location"],["s","gs://bucket/wh/default/t1/metadata/00001.metadata.json"]],["s","table_type"],["s","ICEBERG"]]]]]]`
+	if err := s.CreateDatabase(ctx, Database{Name: "default", LocationURI: "gs://bucket/wh/default"}); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+	if err := s.CreateTable(ctx, "default", "t1", Table{DBName: "default", TableName: "t1", TableJSON: json.RawMessage(tblJSON)}); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := s.Snapshot(ctx, &buf); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	s.Reset(ctx)
+	if err := s.Restore(ctx, &buf); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	got, err := s.GetTable(ctx, "default", "t1")
+	if err != nil {
+		t.Fatalf("get table after restore: %v", err)
+	}
+	if string(got.TableJSON) != tblJSON {
+		t.Fatalf("table JSON not verbatim after restore:\n got  %s\n want %s", got.TableJSON, tblJSON)
+	}
+}

--- a/internal/gcp/store/hms/snapshot.go
+++ b/internal/gcp/store/hms/snapshot.go
@@ -1,0 +1,170 @@
+package hms
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+)
+
+// Snapshot/restore covers only catalog metadata (databases + tables). Locks are
+// transient concurrency state — like the GCS generation counter — and are
+// deliberately excluded so a periodic snapshot never persists a held lock.
+
+// --- Memory store ---
+
+func (s *MemoryStore) IsEmpty(_ context.Context) (bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.databases) == 0 && len(s.tables) == 0, nil
+}
+
+func (s *MemoryStore) Snapshot(_ context.Context, w io.Writer) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return json.NewEncoder(w).Encode(map[string]any{
+		"databases": s.databases,
+		"tables":    s.tables,
+	})
+}
+
+func (s *MemoryStore) Restore(_ context.Context, r io.Reader) error {
+	var snap struct {
+		Databases map[string]Database         `json:"databases"`
+		Tables    map[string]map[string]Table `json:"tables"`
+	}
+	if err := json.NewDecoder(r).Decode(&snap); err != nil {
+		return err
+	}
+	if snap.Databases == nil {
+		snap.Databases = map[string]Database{}
+	}
+	if snap.Tables == nil {
+		snap.Tables = map[string]map[string]Table{}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.databases = snap.Databases
+	s.tables = snap.Tables
+	return nil
+}
+
+// --- Postgres store ---
+
+func (s *PostgresStore) IsEmpty(ctx context.Context) (bool, error) {
+	var n int
+	for _, tbl := range []string{"jc_hms_databases", "jc_hms_tables"} {
+		if err := s.pool.QueryRow(ctx, `SELECT count(*) FROM `+tbl).Scan(&n); err != nil {
+			return false, err
+		}
+		if n > 0 {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (s *PostgresStore) Snapshot(ctx context.Context, w io.Writer) error {
+	type databaseRow struct {
+		Name     string   `json:"name"`
+		Database Database `json:"database"`
+	}
+	type tableRow struct {
+		DBName    string `json:"dbName"`
+		TableName string `json:"tableName"`
+		TableJSON []byte `json:"table"`
+	}
+
+	databases := make([]databaseRow, 0)
+	tables := make([]tableRow, 0)
+
+	drows, err := s.pool.Query(ctx, `
+		SELECT name, location_uri, parameters, description, owner
+		FROM jc_hms_databases ORDER BY name
+	`)
+	if err != nil {
+		return err
+	}
+	for drows.Next() {
+		var r databaseRow
+		var params []byte
+		if err := drows.Scan(&r.Name, &r.Database.LocationURI, &params, &r.Database.Description, &r.Database.Owner); err != nil {
+			drows.Close()
+			return err
+		}
+		r.Database.Name = r.Name
+		r.Database.Parameters = scanStrMap(params)
+		databases = append(databases, r)
+	}
+	drows.Close()
+	if err := drows.Err(); err != nil {
+		return err
+	}
+
+	trows, err := s.pool.Query(ctx, `
+		SELECT db_name, table_name, table_json FROM jc_hms_tables ORDER BY db_name, table_name
+	`)
+	if err != nil {
+		return err
+	}
+	for trows.Next() {
+		var r tableRow
+		if err := trows.Scan(&r.DBName, &r.TableName, &r.TableJSON); err != nil {
+			trows.Close()
+			return err
+		}
+		tables = append(tables, r)
+	}
+	trows.Close()
+	if err := trows.Err(); err != nil {
+		return err
+	}
+
+	return json.NewEncoder(w).Encode(map[string]any{
+		"databases": databases,
+		"tables":    tables,
+	})
+}
+
+func (s *PostgresStore) Restore(ctx context.Context, r io.Reader) error {
+	var snap struct {
+		Databases []struct {
+			Name     string   `json:"name"`
+			Database Database `json:"database"`
+		} `json:"databases"`
+		Tables []struct {
+			DBName    string `json:"dbName"`
+			TableName string `json:"tableName"`
+			TableJSON []byte `json:"table"`
+		} `json:"tables"`
+	}
+	if err := json.NewDecoder(r).Decode(&snap); err != nil {
+		return err
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	for _, tbl := range []string{"jc_hms_tables", "jc_hms_databases"} {
+		if _, err := tx.Exec(ctx, `DELETE FROM `+tbl); err != nil {
+			return err
+		}
+	}
+	for _, dr := range snap.Databases {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO jc_hms_databases (name, location_uri, parameters, description, owner)
+			VALUES ($1,$2,$3,$4,$5)
+		`, dr.Database.Name, dr.Database.LocationURI, jsonObj(dr.Database.Parameters), dr.Database.Description, dr.Database.Owner); err != nil {
+			return err
+		}
+	}
+	for _, tr := range snap.Tables {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO jc_hms_tables (db_name, table_name, table_json)
+			VALUES ($1,$2,$3)
+		`, tr.DBName, tr.TableName, jsonObj(json.RawMessage(tr.TableJSON))); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}

--- a/internal/gcp/store/hms/store.go
+++ b/internal/gcp/store/hms/store.go
@@ -1,0 +1,122 @@
+// Package hms provides the DPMS Hive Metastore serving-plane store. It is the
+// GCP analogue of the AWS Glue table-metadata store, but for the Hive
+// Metastore protocol (hive_metastore.thrift) rather than Glue's REST surface.
+//
+// The serving plane is a single global catalog: databases and tables are keyed
+// by name only, not by projects/{p}/locations/{l}/services/{s} (the per-Service
+// endpoint_uri emitted by the control plane is cosmetic — see
+// gcp-dpms-hms-thrift.md §2.4/F6). Databases are decomposed columns; tables are
+// stored as the full, round-trippable Hive Table JSON blob (F5). Locks are the
+// minimal jc_hms_locks state machine that backs Iceberg's lock/check_lock/
+// unlock flow (D2).
+package hms
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+)
+
+var (
+	// ErrDatabaseExists is returned when creating a database that already
+	// exists.
+	ErrDatabaseExists = errors.New("DatabaseExists")
+	// ErrDatabaseNotFound is returned when addressing a missing database.
+	ErrDatabaseNotFound = errors.New("DatabaseNotFound")
+	// ErrDatabaseNotEmpty is returned when dropping a database that still
+	// holds tables (and cascade was not requested).
+	ErrDatabaseNotEmpty = errors.New("DatabaseNotEmpty")
+	// ErrTableExists is returned when creating a table that already exists or
+	// renaming onto an existing destination.
+	ErrTableExists = errors.New("TableExists")
+	// ErrTableNotFound is returned when addressing a missing table.
+	ErrTableNotFound = errors.New("TableNotFound")
+)
+
+// LockState is the on-wire Hive LockState enum value (hive_metastore.thrift).
+// ACQUIRED=1, WAITING=2, ABORT=3, NOT_ACQUIRED=4.
+type LockState int32
+
+const (
+	LockStateAcquired    LockState = 1
+	LockStateWaiting     LockState = 2
+	LockStateAbort       LockState = 3
+	LockStateNotAcquired LockState = 4
+)
+
+// Database is a Hive database record. Parameters and owner map directly to the
+// wire Database fields name(1)/description(2)/locationUri(3)/parameters(4)/
+// ownerName(6); ownerType/catalogName/privileges are not persisted (the
+// Iceberg-on-Hive critical path only reads locationUri and parameters).
+type Database struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	LocationURI string            `json:"locationUri"`
+	Parameters  map[string]string `json:"parameters"`
+	Owner       string            `json:"owner"`
+}
+
+// Table is a Hive table record: the full Hive Table struct encoded as the
+// codec's canonical (type-tagged, lossless) JSON. The codec owns the JSON
+// shape; the store persists and returns it verbatim so get_table -> alter_table
+// round-trips every field the client sent (F5).
+type Table struct {
+	DBName    string          `json:"dbName"`
+	TableName string          `json:"tableName"`
+	TableJSON json.RawMessage `json:"table"`
+}
+
+// Lock is the minimal record a lock() call captures: the first LockComponent's
+// db/table plus the request's user/hostname.
+type Lock struct {
+	DBName    string
+	TableName string
+	User      string
+	Hostname  string
+}
+
+// Store is the Hive Metastore serving-plane store. Both the memory and postgres
+// backends implement it, plus Reset/Snapshot/Restore/IsEmpty.
+type Store interface {
+	CreateDatabase(ctx context.Context, db Database) error
+	GetDatabase(ctx context.Context, name string) (Database, error)
+	// ListDatabases returns every database name in sorted order.
+	ListDatabases(ctx context.Context) ([]string, error)
+	// DropDatabase removes a database. With cascade it also removes the
+	// database's tables; without cascade a non-empty database returns
+	// ErrDatabaseNotEmpty.
+	DropDatabase(ctx context.Context, name string, cascade bool) error
+	// AlterDatabase unconditionally overwrites a database (missing database ->
+	// ErrDatabaseNotFound).
+	AlterDatabase(ctx context.Context, name string, db Database) error
+
+	CreateTable(ctx context.Context, dbName, tableName string, t Table) error
+	GetTable(ctx context.Context, dbName, tableName string) (Table, error)
+	// ListTables returns every table name in a database in sorted order.
+	ListTables(ctx context.Context, dbName string) ([]string, error)
+	DropTable(ctx context.Context, dbName, tableName string) error
+	// AlterTable atomically applies mutate to the table identified by
+	// (dbName, tableName), returning the committed Table. The mutate closure is
+	// evaluated against the current table under the store's lock (or within a
+	// Serializable transaction), and an error returned from mutate aborts
+	// without writing. Missing table -> ErrTableNotFound. This is a plain
+	// overwrite inside the closure (D5) — the lock is the only concurrency
+	// control, matching real Hive alter_table.
+	AlterTable(ctx context.Context, dbName, tableName string, mutate func(Table) (Table, error)) (Table, error)
+	// RenameTable atomically moves a table to a new (dbName, tableName).
+	// Missing source -> ErrTableNotFound; existing destination ->
+	// ErrTableExists; missing destination database -> ErrDatabaseNotFound.
+	RenameTable(ctx context.Context, srcDB, srcName, dstDB, dstName string, t Table) (Table, error)
+
+	// Lock persists a row with state=ACQUIRED and returns its monotonically
+	// increasing lock id.
+	Lock(ctx context.Context, l Lock) (int64, error)
+	// CheckLock returns the stored lock state, or LockStateNotAcquired if the
+	// lock is absent (D2 — the client's polling check_lock must receive a sane
+	// value, not an error).
+	CheckLock(ctx context.Context, id int64) (LockState, error)
+	// Unlock deletes the lock idempotently.
+	Unlock(ctx context.Context, id int64) error
+
+	Reset(ctx context.Context)
+}

--- a/internal/gcp/store/hms/store_test.go
+++ b/internal/gcp/store/hms/store_test.go
@@ -1,0 +1,271 @@
+package hms
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+)
+
+// runStoreTests exercises a Store against the shared test matrix. Backend tests
+// (memory/postgres) call this so both implement the identical contract.
+func runStoreTests(t *testing.T, s Store) {
+	ctx := context.Background()
+	defer s.Reset(ctx)
+
+	// --- Databases ---
+	if _, err := s.GetDatabase(ctx, "nope"); err != ErrDatabaseNotFound {
+		t.Fatalf("expected ErrDatabaseNotFound, got %v", err)
+	}
+	db := Database{Name: "default", LocationURI: "gs://w/default", Parameters: map[string]string{"a": "b"}, Description: "d", Owner: "me"}
+	if err := s.CreateDatabase(ctx, db); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+	if err := s.CreateDatabase(ctx, db); err != ErrDatabaseExists {
+		t.Fatalf("expected ErrDatabaseExists, got %v", err)
+	}
+	got, err := s.GetDatabase(ctx, "default")
+	if err != nil || got.LocationURI != "gs://w/default" || got.Parameters["a"] != "b" || got.Owner != "me" {
+		t.Fatalf("get database: %v %+v", err, got)
+	}
+	names, err := s.ListDatabases(ctx)
+	if err != nil || len(names) != 1 || names[0] != "default" {
+		t.Fatalf("list databases: %v %v", err, names)
+	}
+
+	// AlterDatabase.
+	if err := s.AlterDatabase(ctx, "default", Database{Name: "default", LocationURI: "gs://w/default2", Parameters: map[string]string{"x": "y"}, Owner: "me"}); err != nil {
+		t.Fatalf("alter database: %v", err)
+	}
+	got, _ = s.GetDatabase(ctx, "default")
+	if got.LocationURI != "gs://w/default2" || got.Parameters["x"] != "y" {
+		t.Fatalf("alter database lost fields: %+v", got)
+	}
+	if err := s.AlterDatabase(ctx, "nope", db); err != ErrDatabaseNotFound {
+		t.Fatalf("expected ErrDatabaseNotFound on alter, got %v", err)
+	}
+
+	// --- Tables ---
+	if _, err := s.GetTable(ctx, "default", "t1"); err != ErrTableNotFound {
+		t.Fatalf("expected ErrTableNotFound, got %v", err)
+	}
+	tblJSON := json.RawMessage(`["o",[[1,["s","t1"]],[2,["s","default"]],[9,["m",11,11,[[["s","metadata_location"],["s","loc1"]]]]]]]`)
+	t1 := Table{DBName: "default", TableName: "t1", TableJSON: tblJSON}
+	if err := s.CreateTable(ctx, "default", "t1", t1); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if err := s.CreateTable(ctx, "default", "t1", t1); err != ErrTableExists {
+		t.Fatalf("expected ErrTableExists, got %v", err)
+	}
+	if err := s.CreateTable(ctx, "missing_db", "t1", t1); err != ErrDatabaseNotFound {
+		t.Fatalf("expected ErrDatabaseNotFound on create table, got %v", err)
+	}
+	gotTbl, err := s.GetTable(ctx, "default", "t1")
+	if err != nil || gotTbl.DBName != "default" || gotTbl.TableName != "t1" || string(gotTbl.TableJSON) != string(tblJSON) {
+		t.Fatalf("get table: %v %+v", err, gotTbl)
+	}
+	tn, err := s.ListTables(ctx, "default")
+	if err != nil || len(tn) != 1 || tn[0] != "t1" {
+		t.Fatalf("list tables: %v %v", err, tn)
+	}
+
+	// AlterTable — plain overwrite (D5).
+	newJSON := json.RawMessage(`["o",[[1,["s","t1"]],[2,["s","default"]],[9,["m",11,11,[[["s","metadata_location"],["s","loc2"]]]]]]]`)
+	updated, err := s.AlterTable(ctx, "default", "t1", func(current Table) (Table, error) {
+		// Ignore current entirely — plain overwrite.
+		return Table{DBName: "default", TableName: "t1", TableJSON: newJSON}, nil
+	})
+	if err != nil || string(updated.TableJSON) != string(newJSON) {
+		t.Fatalf("alter table: %v %+v", err, updated)
+	}
+	gotTbl, _ = s.GetTable(ctx, "default", "t1")
+	if string(gotTbl.TableJSON) != string(newJSON) {
+		t.Fatalf("alter table did not overwrite: %s", gotTbl.TableJSON)
+	}
+	if _, err := s.AlterTable(ctx, "default", "nope", func(Table) (Table, error) { return Table{}, nil }); err != ErrTableNotFound {
+		t.Fatalf("expected ErrTableNotFound on alter, got %v", err)
+	}
+
+	// AlterTable mutate error aborts without writing.
+	if _, err := s.AlterTable(ctx, "default", "t1", func(Table) (Table, error) { return Table{}, errTestMutate }); err != errTestMutate {
+		t.Fatalf("expected mutate error to propagate, got %v", err)
+	}
+	gotTbl, _ = s.GetTable(ctx, "default", "t1")
+	if string(gotTbl.TableJSON) != string(newJSON) {
+		t.Fatal("mutate error should not have written")
+	}
+
+	// DropDatabase without cascade fails on a non-empty database.
+	if err := s.DropDatabase(ctx, "default", false); err != ErrDatabaseNotEmpty {
+		t.Fatalf("expected ErrDatabaseNotEmpty, got %v", err)
+	}
+	// With cascade it drops the table too.
+	if err := s.DropDatabase(ctx, "default", true); err != nil {
+		t.Fatalf("drop database cascade: %v", err)
+	}
+	if _, err := s.GetTable(ctx, "default", "t1"); err != ErrTableNotFound {
+		t.Fatalf("expected table gone after cascade drop, got %v", err)
+	}
+	if _, err := s.GetDatabase(ctx, "default"); err != ErrDatabaseNotFound {
+		t.Fatalf("expected database gone, got %v", err)
+	}
+
+	// DropTable + rename.
+	if err := s.CreateDatabase(ctx, Database{Name: "db2"}); err != nil {
+		t.Fatalf("create db2: %v", err)
+	}
+	if err := s.CreateTable(ctx, "db2", "a", Table{DBName: "db2", TableName: "a", TableJSON: tblJSON}); err != nil {
+		t.Fatalf("create table a: %v", err)
+	}
+	if err := s.CreateTable(ctx, "db2", "b", Table{DBName: "db2", TableName: "b", TableJSON: tblJSON}); err != nil {
+		t.Fatalf("create table b: %v", err)
+	}
+	if err := s.DropTable(ctx, "db2", "a"); err != nil {
+		t.Fatalf("drop table: %v", err)
+	}
+	if err := s.DropTable(ctx, "db2", "a"); err != ErrTableNotFound {
+		t.Fatalf("expected ErrTableNotFound on re-drop, got %v", err)
+	}
+	if _, err := s.RenameTable(ctx, "db2", "b", "db2", "c", Table{DBName: "db2", TableName: "c", TableJSON: tblJSON}); err != nil {
+		t.Fatalf("rename table: %v", err)
+	}
+	if _, err := s.GetTable(ctx, "db2", "b"); err != ErrTableNotFound {
+		t.Fatalf("expected old name gone, got %v", err)
+	}
+	if _, err := s.GetTable(ctx, "db2", "c"); err != nil {
+		t.Fatalf("expected new name present, got %v", err)
+	}
+	if _, err := s.RenameTable(ctx, "db2", "nope", "db2", "d", Table{}); err != ErrTableNotFound {
+		t.Fatalf("expected ErrTableNotFound on rename, got %v", err)
+	}
+
+	// --- Locks ---
+	id, err := s.Lock(ctx, Lock{DBName: "db2", TableName: "c", User: "u", Hostname: "h"})
+	if err != nil {
+		t.Fatalf("lock: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("lock returned 0")
+	}
+	if st, _ := s.CheckLock(ctx, id); st != LockStateAcquired {
+		t.Fatalf("check lock state = %d, want ACQUIRED", st)
+	}
+	if err := s.Unlock(ctx, id); err != nil {
+		t.Fatalf("unlock: %v", err)
+	}
+	if st, _ := s.CheckLock(ctx, id); st != LockStateNotAcquired {
+		t.Fatalf("check lock after unlock = %d, want NOT_ACQUIRED", st)
+	}
+	if err := s.Unlock(ctx, id); err != nil {
+		t.Fatalf("unlock should be idempotent: %v", err)
+	}
+}
+
+var errTestMutate = context.Canceled // arbitrary sentinel distinct from store errors
+
+// TestMemoryStore runs the shared matrix against the in-memory backend.
+func TestMemoryStore(t *testing.T) {
+	runStoreTests(t, NewMemoryStore())
+}
+
+// TestAlterTableAtomicity verifies the mutate-closure runs under one lock: two
+// concurrent AlterTable calls each observe a serializable read-modify-write and
+// neither update is lost.
+func TestAlterTableAtomicity(t *testing.T) {
+	s := NewMemoryStore()
+	ctx := context.Background()
+	defer s.Reset(ctx)
+
+	if err := s.CreateDatabase(ctx, Database{Name: "db"}); err != nil {
+		t.Fatal(err)
+	}
+	init := Table{DBName: "db", TableName: "t", TableJSON: json.RawMessage(`["o",[]]`)}
+	if err := s.CreateTable(ctx, "db", "t", init); err != nil {
+		t.Fatal(err)
+	}
+
+	const writers = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, writers)
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Each writer appends a distinct marker field to the table JSON's
+			// field list and relies on AtomicUpdate's read-modify-write lock so
+			// no two writers interleave.
+			_, err := s.AlterTable(ctx, "db", "t", func(cur Table) (Table, error) {
+				var fields []any
+				if err := json.Unmarshal(cur.TableJSON, &fields); err != nil {
+					return Table{}, err
+				}
+				// fields = ["o", [...]]; append one more marker into the inner list.
+				inner := fields[1].([]any)
+				marker := float64(len(inner))
+				inner = append(inner, []any{marker, []any{"s", "x"}})
+				fields[1] = inner
+				b, err := json.Marshal(fields)
+				if err != nil {
+					return Table{}, err
+				}
+				return Table{DBName: "db", TableName: "t", TableJSON: b}, nil
+			})
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("alter table: %v", err)
+		}
+	}
+
+	got, err := s.GetTable(ctx, "db", "t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields []any
+	if err := json.Unmarshal(got.TableJSON, &fields); err != nil {
+		t.Fatal(err)
+	}
+	if inner := fields[1].([]any); len(inner) != writers {
+		t.Fatalf("lost update: expected %d markers, got %d", writers, len(inner))
+	}
+}
+
+// TestSnapshotRestore verifies memory snapshot/restore round-trips catalog
+// metadata (locks are deliberately excluded).
+func TestSnapshotRestore(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	defer s.Reset(ctx)
+	if err := s.CreateDatabase(ctx, Database{Name: "db", LocationURI: "loc"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateTable(ctx, "db", "t", Table{DBName: "db", TableName: "t", TableJSON: json.RawMessage(`["o",[[1,["s","t"]]]]`)}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Lock(ctx, Lock{}); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := s.Snapshot(ctx, &buf); err != nil {
+		t.Fatal(err)
+	}
+	s.Reset(ctx)
+	if empty, _ := s.IsEmpty(ctx); !empty {
+		t.Fatal("store should be empty after reset")
+	}
+	if err := s.Restore(ctx, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.GetDatabase(ctx, "db"); err != nil {
+		t.Fatalf("database lost in restore: %v", err)
+	}
+	if got, err := s.GetTable(ctx, "db", "t"); err != nil || string(got.TableJSON) != `["o",[[1,["s","t"]]]]` {
+		t.Fatalf("table lost in restore: %v %+v", err, got)
+	}
+}

--- a/internal/gcp/store/migrations/031_hms.sql
+++ b/internal/gcp/store/migrations/031_hms.sql
@@ -1,0 +1,58 @@
+-- DPMS Hive Metastore serving plane (Thrift). This is the GCP analogue of the
+-- AWS Glue table-metadata serving path, but over the real Apache Hive
+-- Metastore protocol (hive_metastore.thrift, TBinaryProtocol over a raw
+-- non-framed TSocket), not Glue's REST/JSON surface. Unlike the project-scoped
+-- GCP v1 services, the serving plane is a single global catalog: databases and
+-- tables are keyed by name only (the per-Service endpoint_uri emitted by the
+-- control plane is cosmetic — see gcp-dpms-hms-thrift.md §2.4/F6).
+--
+-- Three logical tables:
+--
+--   jc_hms_databases — (name) -> location_uri, parameters map (JSONB),
+--                      description, owner.
+--   jc_hms_tables    — (db_name, table_name) -> full Hive Table JSON (JSONB).
+--                      The table is stored as the complete, round-trippable
+--                      Table struct, not a decomposed column set, because
+--                      Iceberg's alter_table is a full-Table round-trip (read
+--                      whole table, mutate `parameters`, write whole table) and
+--                      every field the client originally sent must be echoed
+--                      back verbatim (F5).
+--   jc_hms_locks     — (lock_id) -> lock state for lock/check_lock/unlock.
+--
+-- Partitions are deliberately NOT stored: the Iceberg-on-Hive critical path
+-- never calls partition methods (Iceberg partitions its own metadata), so every
+-- partition method is stubbed to empty / NoSuchObjectException at the handler
+-- layer (D3).
+
+CREATE TABLE IF NOT EXISTS jc_hms_databases (
+    name         TEXT        NOT NULL,
+    location_uri TEXT        NOT NULL DEFAULT '',
+    parameters   JSONB       NOT NULL DEFAULT '{}',
+    description  TEXT        NOT NULL DEFAULT '',
+    owner        TEXT        NOT NULL DEFAULT '',
+    PRIMARY KEY (name)
+);
+
+CREATE TABLE IF NOT EXISTS jc_hms_tables (
+    db_name    TEXT  NOT NULL,
+    table_name TEXT  NOT NULL,
+    table_json JSONB NOT NULL DEFAULT '{}',
+    PRIMARY KEY (db_name, table_name),
+    -- Enforce database existence and "no tables -> droppable" at the DB level,
+    -- so DropDatabase/CreateTable/RenameTable are atomic against concurrent
+    -- database drops (mirrors the 030_iceberg.sql FK and the OCC-fix series'
+    -- atomic-write discipline).
+    CONSTRAINT jc_hms_tables_db_fk FOREIGN KEY (db_name)
+        REFERENCES jc_hms_databases (name) ON DELETE RESTRICT
+);
+
+CREATE TABLE IF NOT EXISTS jc_hms_locks (
+    lock_id     BIGSERIAL   NOT NULL,
+    state       INTEGER     NOT NULL DEFAULT 1,
+    db_name     TEXT        NOT NULL DEFAULT '',
+    table_name  TEXT        NOT NULL DEFAULT '',
+    user_name   TEXT        NOT NULL DEFAULT '',
+    hostname    TEXT        NOT NULL DEFAULT '',
+    create_time TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (lock_id)
+);


### PR DESCRIPTION
## Summary

The DPMS Hive Metastore **Thrift serving plane** (Phase 4) — a real `:9083` Thrift endpoint speaking the Apache Hive Metastore protocol (`TBinaryProtocol` over `TSocket`), backed by a new `jc_hms_*` store, so external Spark can attach `HiveCatalog`/`SparkCatalog` (`type=hive`, `uri=thrift://…:9083`). This is the Hive/Hadoop-migration path the BigLake REST catalog (#52) does not cover.

Implements Raj's resolved decisions (`plan_docs/gcp-dpms-hms-thrift.md` §5):
- **D1** — `apache/thrift` lib for `TServerSocket`/`TBinaryProtocol` primitives only; hand-written struct codec derived from `hive_metastore.thrift` (Hive branch-2.3) field IDs; golden-byte round-trip tests mandatory.
- **D2** — minimal `jc_hms_locks` state machine (`lock()`→ACQUIRED, `check_lock()`→state, `unlock()`→idempotent delete).
- **D3** — final method subset; all partition methods stubbed; unknown → `TApplicationException`.
- **D4** — `CreateService` validates `endpointProtocol` ∈ {THRIFT, GRPC}, **rejects GRPC with `InvalidArgument`** (gRPC deferred).
- **D5** — `alter_table` is a plain unconditional overwrite (no `metadata_location` CAS); the lock is the only concurrency control.

## Faithfulness corrections found during implementation (verified against real IDL, not the doc)

- **`LockState` enum**: real `hive_metastore.thrift` has `ACQUIRED=1, WAITING=2, ABORT=3, NOT_ACQUIRED=4` — the doc's `NOT_HEARTBEATED=4, NO_WAIT=5` values don't exist. `check_lock` on an absent lock returns `NOT_ACQUIRED` (4).
- **`rename_table` / `get_table_by_name` are not real Thrift methods** — `rename_table` is implemented through `alter_table` (atomic rename on db/table-name change, exactly Iceberg 1.5.2's `MetastoreUtil.alterTable`); `get_table_by_name` is an alias of `get_table`.
- **Added `get_table_objects_by_name`** — on Iceberg `HiveCatalog.listTables`'s critical path, so it's implemented rather than stubbed.
- `heartbeat`/ACID → `TApplicationException` (honest failure, no invented ACID behavior).

## Layout

- `internal/gcp/hms/` — Thrift codec (schema-free TBinaryProtocol over apache/thrift primitives), struct layer, dispatch + handlers, `TServerSocket` listener.
- `internal/gcp/store/hms/` + migration `031_hms.sql` — `jc_hms_databases` / `jc_hms_tables` (full `Table` JSONB, lossless round-trip) / `jc_hms_locks`; `AlterTable`/`RenameTable` mutate-closure via `storeutil.AtomicUpdate` (memory) / Serializable `SELECT … FOR UPDATE` (postgres); Snapshotter/Resetter (locks excluded as transient state).
- `internal/gcp/provider/metastore/metastore.go` — `endpointProtocol` validation.
- `cmd/jaiscloud-gcp/main.go` — `--hms-port` (default 9083) + serve goroutine + wiring.

## Testing

Golden-byte round-trips for every struct; a Go Thrift test client driving `create_database → create_table → get_table → alter_table → drop_table` + `lock → check_lock → unlock` over a real socket; store matrix (memory + postgres, `gcp_persistence`-gated) incl. concurrent-commit no-lost-update; control-plane GRPC-rejection test.

## Verification

`go build ./...`, `go vet ./internal/gcp/...`, `go vet -tags gcp_persistence`, `go test -race` (store/hms/provider/metastore), `gofmt -l` empty, `paginationcheck` clean, `go mod tidy` clean (`+apache/thrift v0.24.0`).

## Notes

- `endpointProtocol` is validated at `CreateService` only (not `UpdateService`), matching the doc's F7.
- Locks are excluded from snapshot/restore (transient concurrency state).
- Phase 5 (Iceberg-on-Dataproc E2E) depends on this PR's `:9083` listener — see `plan_docs/gcp-iceberg-dataproc-e2e.md`.