### PR TITLE
feat(gcp/dataproc): Iceberg-on-Dataproc E2E (external Spark + Hive Metastore Thrift + GCS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ SPARK_IMAGE             ?= apache/spark:3.5.0
 LAMBDA_IMAGE            ?= public.ecr.aws/lambda/python:3.12
 # Custom Iceberg-enabled Spark image (must be built locally before use)
 SPARK_E2E_ICEBERG_IMAGE ?= spark-iceberg-test
+# GCP variant: apache/spark:3.5.0 + iceberg-spark-runtime + gcs-connector (hadoop3),
+# NO iceberg-gcp-bundle (HadoopFileIO data path — plan_docs/gcp-iceberg-dataproc-e2e.md §7 D1).
+SPARK_E2E_ICEBERG_GCP_IMAGE ?= spark-iceberg-gcp-test
 
 # ─── K8s configuration ────────────────────────────────────────────────────────
 K8S_NAMESPACE           ?= jaiscloud
@@ -64,11 +67,11 @@ JAISCLOUD_IMAGE   ?= jaisraj/jaiscloud-aws:latest
         test-e2e-lambda-docker test-e2e-lambda-k8s \
         test-e2e-cloudformation test-e2e-kms test-e2e-ssm test-e2e-dynamodb test-e2e-persistence \
         test-e2e-s3-streaming test-e2e-kinesis test-e2e-ecr test-e2e-sfn \
-        test-e2e-gcp-persistence test-e2e-iceberg \
+        test-e2e-gcp-persistence test-e2e-iceberg test-e2e-iceberg-gcp \
         test-e2e-docker-all test-e2e-k8s-all test-e2e test-all test-all-gcp \
         _build-for-e2e _restart-server-memory _wait-docker _wait-postgres \
         _start-k8s _stop-k8s \
-        _check-docker-prereq _check-k8s-prereq _check-iceberg-prereq
+        _check-docker-prereq _check-k8s-prereq _check-iceberg-prereq _check-iceberg-gcp-prereq
 
 # ─── Help ─────────────────────────────────────────────────────────────────────
 # NOTE: 'make --help' and 'make -h' show GNU Make's own flags (cannot be overridden).
@@ -506,6 +509,22 @@ test-e2e-iceberg: _check-iceberg-prereq ## Iceberg Glue Catalog tests — tests/
 	  go test -v -tags iceberg_e2e -timeout 30m ./tests/persistent_mode/aws/iceberg/
 	$(MAKE) down-docker
 
+# Iceberg-on-Dataproc E2E — external Docker Spark against the emulator's Hive
+# Metastore Thrift listener (:9083, Phase 4) + GCS (:8080). Blocked on Phase 4:
+# the tests compile under the iceberg_e2e tag but will not pass until the Thrift
+# listener merges (plan_docs/gcp-iceberg-dataproc-e2e.md §7 D3).
+test-e2e-iceberg-gcp: _check-iceberg-gcp-prereq build-gcp ## Iceberg-on-Hive tests — tests/persistent_mode/gcp/iceberg/ (tag: iceberg_e2e)
+	@echo "Starting jaiscloud-gcp (ephemeral)..."
+	@./jaiscloud-gcp start --port 8080 --grpc-port 8081 --ephemeral > /tmp/jaiscloud-gcp-iceberg.log 2>&1 & \
+	  n=0; until curl -sf http://localhost:8080/_jaiscloud/health >/dev/null 2>&1; do \
+	    n=$$((n+1)); if [ $$n -ge 30 ]; then echo "ERROR: jaiscloud-gcp not healthy"; cat /tmp/jaiscloud-gcp-iceberg.log; exit 1; fi; sleep 1; \
+	  done; echo "  ready (REST :8080)"
+	go clean -testcache
+	SPARK_E2E_ICEBERG_GCP_IMAGE=$(SPARK_E2E_ICEBERG_GCP_IMAGE) JAISCLOUD_HOST=http://localhost:8080 \
+	  go test -v -tags iceberg_e2e -timeout 30m ./tests/persistent_mode/gcp/iceberg/
+	@echo "Stopping jaiscloud-gcp..."
+	@pkill -f "jaiscloud-gcp start" 2>/dev/null || true
+
 ##@ Aggregate test targets
 
 test-e2e-docker-all: test-e2e-emr-docker test-e2e-dpc-docker test-e2e-lambda-docker test-e2e-eventbridge ## All Docker-based e2e suites
@@ -579,3 +598,7 @@ _check-k8s-prereq:
 _check-iceberg-prereq:
 	@docker image inspect $(SPARK_E2E_ICEBERG_IMAGE) > /dev/null 2>&1 || \
 	  (echo "ERROR: image '$(SPARK_E2E_ICEBERG_IMAGE)' not found — build or pull it first"; exit 1)
+
+_check-iceberg-gcp-prereq:
+	@docker image inspect $(SPARK_E2E_ICEBERG_GCP_IMAGE) > /dev/null 2>&1 || \
+	  (echo "ERROR: image '$(SPARK_E2E_ICEBERG_GCP_IMAGE)' not found — build or pull it first"; exit 1)

--- a/tests/persistent_mode/gcp/iceberg/append_update_test.go
+++ b/tests/persistent_mode/gcp/iceberg/append_update_test.go
@@ -1,0 +1,230 @@
+//go:build iceberg_e2e
+
+package iceberg_test
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestIceberg_HiveCatalog_AppendMultipleBatches verifies that Iceberg accumulates
+// data correctly across multiple INSERT batches without overwriting prior data.
+// Three batches of 100 rows each should yield 300 total rows.
+func TestIceberg_HiveCatalog_AppendMultipleBatches(t *testing.T) {
+	requireIcebergEnv(t)
+
+	host := jaiscloudHost()
+
+	// Job 1 — Create table and insert batch 1 (ids 1–100).
+	runSparkSQL(t, SparkJob{
+		Name: "ledger-batch1",
+		SQL: fmt.Sprintf(`
+%s
+CREATE TABLE IF NOT EXISTS hms.%s.ledger (
+  id       INT,
+  batch    INT,
+  amount   DOUBLE
+)
+USING iceberg
+LOCATION '%s';
+
+INSERT INTO hms.%s.ledger
+SELECT id, 1, CAST(id AS DOUBLE) * 1.0
+FROM range(1, 101);
+`, ensureDatabaseSQL(), icebergDB(), tableLocation("ledger"), icebergDB()),
+	})
+
+	// Verify count after batch 1.
+	runSparkSQL(t, SparkJob{
+		Name: "ledger-count1",
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT COUNT(*) AS cnt FROM hms.%s.ledger;
+`, outputLoc("ledger-count1"), icebergDB()),
+	})
+	cnt1 := findGCSJSON(t, host, "iceberg-warehouse", outputPrefix("ledger-count1"))
+	if v, _ := cnt1["cnt"].(float64); int(v) != 100 {
+		t.Errorf("after batch 1: expected cnt=100, got %v", cnt1["cnt"])
+	}
+
+	// Job 2 — Append batch 2 (ids 101–200).
+	runSparkSQL(t, SparkJob{
+		Name: "ledger-batch2",
+		SQL: fmt.Sprintf(`
+INSERT INTO hms.%s.ledger
+SELECT id + 100, 2, CAST(id AS DOUBLE) * 2.0
+FROM range(1, 101);
+`, icebergDB()),
+	})
+
+	// Verify count after batch 2.
+	runSparkSQL(t, SparkJob{
+		Name: "ledger-count2",
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT COUNT(*) AS cnt FROM hms.%s.ledger;
+`, outputLoc("ledger-count2"), icebergDB()),
+	})
+	cnt2 := findGCSJSON(t, host, "iceberg-warehouse", outputPrefix("ledger-count2"))
+	if v, _ := cnt2["cnt"].(float64); int(v) != 200 {
+		t.Errorf("after batch 2: expected cnt=200, got %v", cnt2["cnt"])
+	}
+
+	// Job 3 — Append batch 3 (ids 201–300).
+	runSparkSQL(t, SparkJob{
+		Name: "ledger-batch3",
+		SQL: fmt.Sprintf(`
+INSERT INTO hms.%s.ledger
+SELECT id + 200, 3, CAST(id AS DOUBLE) * 3.0
+FROM range(1, 101);
+`, icebergDB()),
+	})
+
+	// ── Final assertions ──────────────────────────────────────────────────────
+
+	// a. Total count = 300.
+	runSparkSQL(t, SparkJob{
+		Name: "ledger-count-total",
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT COUNT(*) AS cnt FROM hms.%s.ledger;
+`, outputLoc("ledger-total"), icebergDB()),
+	})
+	total := findGCSJSON(t, host, "iceberg-warehouse", outputPrefix("ledger-total"))
+	if v, _ := total["cnt"].(float64); int(v) != 300 {
+		t.Errorf("expected total cnt=300, got %v", total["cnt"])
+	}
+
+	// b. Per-batch counts — each batch contributes exactly 100 rows.
+	runSparkSQL(t, SparkJob{
+		Name: "ledger-by-batch",
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT batch, COUNT(*) AS cnt
+FROM hms.%s.ledger
+GROUP BY batch
+ORDER BY batch;
+`, outputLoc("ledger-by-batch"), icebergDB()),
+	})
+	// Verify GCS has at least one data file for the per-batch output.
+	if !hasGCSObjects(t, host, "iceberg-warehouse", outputPrefix("ledger-by-batch")) {
+		t.Error("expected per-batch count output in GCS")
+	}
+
+	// c. Table has 3 snapshot metadata files (one per commit).
+	metaCount := countGCSObjects(t, host, "iceberg-warehouse", tablePrefix("ledger", "metadata/"))
+	if metaCount < 3 {
+		t.Errorf("expected at least 3 metadata files (one per commit), got %d", metaCount)
+	}
+}
+
+// TestIceberg_HiveCatalog_SchemaAndDataUpdate verifies Iceberg's support for
+// in-place schema changes (ALTER TABLE ADD COLUMN) combined with data updates
+// (UPDATE SET) on existing rows.
+func TestIceberg_HiveCatalog_SchemaAndDataUpdate(t *testing.T) {
+	requireIcebergEnv(t)
+
+	host := jaiscloudHost()
+
+	// Job 1 — Create table with initial schema (id, product, quantity) and
+	// insert 100 rows. No price column yet.
+	runSparkSQL(t, SparkJob{
+		Name: "inventory-initial",
+		SQL: fmt.Sprintf(`
+%s
+CREATE TABLE IF NOT EXISTS hms.%s.inventory (
+  id       INT,
+  product  STRING,
+  quantity INT
+)
+USING iceberg
+LOCATION '%s';
+
+INSERT INTO hms.%s.inventory
+SELECT id, CONCAT('item-', CAST(id AS STRING)), id * 10
+FROM range(1, 101);
+`, ensureDatabaseSQL(), icebergDB(), tableLocation("inventory"), icebergDB()),
+	})
+
+	// Job 2 — Add the 'price' column (schema evolution) and set it for the
+	// first 50 rows via UPDATE. The remaining 50 rows keep price = NULL.
+	runSparkSQL(t, SparkJob{
+		Name: "inventory-evolve-and-update",
+		SQL: fmt.Sprintf(`
+ALTER TABLE hms.%s.inventory ADD COLUMN price DOUBLE;
+
+UPDATE hms.%s.inventory
+SET price = CAST(id AS DOUBLE) * 9.99
+WHERE id <= 50;
+`, icebergDB(), icebergDB()),
+	})
+
+	// ── Assertions ────────────────────────────────────────────────────────────
+
+	// a. Total count still 100 (no rows deleted by UPDATE).
+	runSparkSQL(t, SparkJob{
+		Name: "inventory-count-total",
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT COUNT(*) AS cnt FROM hms.%s.inventory;
+`, outputLoc("inventory-total"), icebergDB()),
+	})
+	totalResult := findGCSJSON(t, host, "iceberg-warehouse", outputPrefix("inventory-total"))
+	if v, _ := totalResult["cnt"].(float64); int(v) != 100 {
+		t.Errorf("expected total cnt=100, got %v", totalResult["cnt"])
+	}
+
+	// b. Exactly 50 rows have a non-NULL price (the updated rows, id 1–50).
+	runSparkSQL(t, SparkJob{
+		Name: "inventory-count-priced",
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT COUNT(*) AS cnt
+FROM hms.%s.inventory
+WHERE price IS NOT NULL;
+`, outputLoc("inventory-priced"), icebergDB()),
+	})
+	pricedResult := findGCSJSON(t, host, "iceberg-warehouse", outputPrefix("inventory-priced"))
+	if v, _ := pricedResult["cnt"].(float64); int(v) != 50 {
+		t.Errorf("expected 50 priced rows, got %v", pricedResult["cnt"])
+	}
+
+	// c. Exactly 50 rows still have NULL price (the un-updated rows, id 51–100).
+	runSparkSQL(t, SparkJob{
+		Name: "inventory-count-unpriced",
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT COUNT(*) AS cnt
+FROM hms.%s.inventory
+WHERE price IS NULL;
+`, outputLoc("inventory-unpriced"), icebergDB()),
+	})
+	unpricedResult := findGCSJSON(t, host, "iceberg-warehouse", outputPrefix("inventory-unpriced"))
+	if v, _ := unpricedResult["cnt"].(float64); int(v) != 50 {
+		t.Errorf("expected 50 un-priced rows, got %v", unpricedResult["cnt"])
+	}
+
+	// d. Price values match expected: price for id=1 should be 1*9.99=9.99.
+	// Write a specific row lookup to verify UPDATE correctness.
+	runSparkSQL(t, SparkJob{
+		Name: "inventory-price-check",
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT id, price
+FROM hms.%s.inventory
+WHERE id = 1;
+`, outputLoc("inventory-price-check"), icebergDB()),
+	})
+	priceCheck := findGCSJSON(t, host, "iceberg-warehouse", outputPrefix("inventory-price-check"))
+	if price, _ := priceCheck["price"].(float64); price < 9.98 || price > 10.0 {
+		t.Errorf("expected price≈9.99 for id=1, got %v", priceCheck["price"])
+	}
+}

--- a/tests/persistent_mode/gcp/iceberg/helpers_test.go
+++ b/tests/persistent_mode/gcp/iceberg/helpers_test.go
@@ -1,0 +1,474 @@
+//go:build iceberg_e2e
+
+package iceberg_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"jaiscloud/internal/clock"
+)
+
+// ─── env / config helpers ────────────────────────────────────────────────────
+
+func jaiscloudHost() string {
+	if h := os.Getenv("JAISCLOUD_HOST"); h != "" {
+		return h
+	}
+	return "http://localhost:8080"
+}
+
+func icebergImage() string {
+	return os.Getenv("SPARK_E2E_ICEBERG_GCP_IMAGE")
+}
+
+func requireIcebergEnv(t *testing.T) {
+	t.Helper()
+	if icebergImage() == "" {
+		t.Skip("SPARK_E2E_ICEBERG_GCP_IMAGE not set — skipping Iceberg e2e test")
+	}
+}
+
+// hmsEndpoint returns the Thrift Hive Metastore endpoint Spark's HiveCatalog
+// connects to (Phase 4's :9083 listener). Overridable via SPARK_E2E_HMS_ENDPOINT
+// (without a scheme — the harness prefixes it with thrift://).
+func hmsEndpoint() string {
+	if v := os.Getenv("SPARK_E2E_HMS_ENDPOINT"); v != "" {
+		return v
+	}
+	return "host.docker.internal:9083"
+}
+
+// gcsProjectID returns the GCS project id used for anonymous auth
+// (fs.gs.project.id). Overridable via GCP_PROJECT_ID.
+func gcsProjectID() string {
+	if v := os.Getenv("GCP_PROJECT_ID"); v != "" {
+		return v
+	}
+	return "test-project"
+}
+
+func jobTimeout() time.Duration {
+	if v := os.Getenv("SPARK_E2E_JOB_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return 10 * time.Minute
+}
+
+// ─── run-scoped naming helpers ────────────────────────────────────────────────
+
+// icebergDB returns the Hive database name for this test run.
+// Each invocation of `go test` gets a unique 6-hex-char suffix so that
+// concurrent or back-to-back runs never conflict on the same database name.
+func icebergDB() string { return "iceberg_test_" + testRunID }
+
+// tableLocation returns the gs:// LOCATION clause value for an Iceberg table in
+// this run.
+func tableLocation(table string) string {
+	return fmt.Sprintf("gs://iceberg-warehouse/%s/%s", testRunID, table)
+}
+
+// outputLoc returns the gs:// URI used in INSERT OVERWRITE DIRECTORY for this run.
+func outputLoc(dir string) string {
+	return fmt.Sprintf("gs://iceberg-warehouse/%s/%s/", testRunID, dir)
+}
+
+// outputPrefix returns the GCS object prefix for assertions on output
+// directories (bucket is always "iceberg-warehouse").
+func outputPrefix(dir string) string {
+	return fmt.Sprintf("%s/%s/", testRunID, dir)
+}
+
+// tablePrefix returns the GCS object prefix for a table's sub-directory (e.g.
+// "metadata/" or "data/") — used with countGCSObjects / hasGCSObjects.
+func tablePrefix(table, subdir string) string {
+	return fmt.Sprintf("%s/%s/%s", testRunID, table, subdir)
+}
+
+// ensureDatabaseSQL returns the SQL to create the Hive database for this run.
+//
+// Divergence from the AWS harness (which pre-creates the Glue DB via the Go
+// Glue SDK in TestMain): there is no Go-side Hive metastore client, and
+// HiveCatalog (unlike GlueCatalog) does not auto-create the namespace. So the
+// run-scoped database is created from Spark SQL instead (idempotent). See
+// plan_docs/gcp-iceberg-dataproc-e2e.md §7 D4.
+func ensureDatabaseSQL() string {
+	return fmt.Sprintf("CREATE DATABASE IF NOT EXISTS hms.%s;", icebergDB())
+}
+
+// ─── Spark SQL job runner ─────────────────────────────────────────────────────
+
+// SparkJob holds parameters for a Docker-based spark-sql job.
+type SparkJob struct {
+	// Name is used for logging.
+	Name string
+	// SQL is the Spark SQL script to execute.
+	SQL string
+	// ExtraConf holds additional --conf flags (e.g. "spark.driver.memory=1g").
+	ExtraConf []string
+}
+
+// runSparkSQL submits a Spark SQL job via Docker using the default JaisCloud host.
+func runSparkSQL(t *testing.T, job SparkJob) {
+	t.Helper()
+	runSparkSQLOnHost(t, jaiscloudHost(), job)
+}
+
+// runSparkSQLOnHost submits a Spark SQL job via Docker pointing at a specific
+// JaisCloud host. The SQL is written to a temp file and mounted read-only into
+// the container.
+func runSparkSQLOnHost(t *testing.T, host string, job SparkJob) {
+	t.Helper()
+	requireIcebergEnv(t)
+
+	sqlFile, err := os.CreateTemp("", fmt.Sprintf("iceberg-%s-*.sql", job.Name))
+	if err != nil {
+		t.Fatalf("create temp SQL file: %v", err)
+	}
+	defer os.Remove(sqlFile.Name())
+	if _, err := sqlFile.WriteString(job.SQL); err != nil {
+		t.Fatalf("write SQL: %v", err)
+	}
+	sqlFile.Close()
+
+	args := []string{
+		"docker", "run", "--rm",
+		"--add-host=host.docker.internal:host-gateway",
+		// No GCP env vars are required: the harness uses anonymous auth
+		// (fs.gs.auth.null.enable=true + fs.gs.project.id) and the explicit
+		// fs.gs.storage.root.url — no Workload Identity, no
+		// GOOGLE_APPLICATION_CREDENTIALS (plan_docs §7 D5).
+		"-v", sqlFile.Name() + ":/tmp/job.sql:ro",
+		icebergImage(),
+		"/opt/spark/bin/spark-sql",
+		"--master", "local[2]",
+	}
+	for _, c := range icebergSparkConfForHost(host) {
+		args = append(args, "--conf", c)
+	}
+	for _, c := range job.ExtraConf {
+		args = append(args, "--conf", c)
+	}
+	args = append(args, "-f", "/tmp/job.sql")
+
+	t.Logf("running spark-sql job %q on %s", job.Name, host)
+	ctx, cancel := context.WithTimeout(context.Background(), jobTimeout())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Stdout = &testWriter{t: t, prefix: job.Name + ": "}
+	cmd.Stderr = &testWriter{t: t, prefix: job.Name + " ERR: "}
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("spark-sql job %q: %v", job.Name, err)
+	}
+}
+
+// testWriter streams command output to t.Log line by line.
+type testWriter struct {
+	t      *testing.T
+	prefix string
+	buf    string
+}
+
+func (w *testWriter) Write(p []byte) (int, error) {
+	w.buf += string(p)
+	for {
+		idx := strings.IndexByte(w.buf, '\n')
+		if idx < 0 {
+			break
+		}
+		w.t.Log(w.prefix + w.buf[:idx])
+		w.buf = w.buf[idx+1:]
+	}
+	return len(p), nil
+}
+
+// icebergSparkConf returns the standard Spark conf for Iceberg on the default
+// JaisCloud host.
+func icebergSparkConf() []string {
+	return icebergSparkConfForHost(jaiscloudHost())
+}
+
+// icebergSparkConfForHost returns Spark conf for Iceberg pointing at a specific
+// JaisCloud host. Replaces localhost with host.docker.internal so the Docker
+// container can reach the host's GCS HTTP surface (:8080).
+//
+// Two destinations are wired:
+//   - Hive Metastore (Thrift, :9083) — Iceberg's HiveCatalog via SparkCatalog.
+//   - GCS (JSON API, :8080) — both Iceberg's HadoopFileIO data path AND Spark's
+//     INSERT OVERWRITE DIRECTORY use the gcs-connector's gs:// filesystem.
+//
+// The conf block is the §3.4 block from plan_docs/gcp-iceberg-dataproc-e2e.md,
+// with one deliberate omission: lock-enabled is left at its default (true) so
+// Spark runs on the real jc_hms_locks path (Phase 4) — see §7 D2.
+func icebergSparkConfForHost(host string) []string {
+	dockerHost := strings.Replace(host, "localhost", "host.docker.internal", 1)
+	return []string{
+		"spark.sql.catalog.hms=org.apache.iceberg.spark.SparkCatalog",
+		"spark.sql.catalog.hms.catalog-impl=org.apache.iceberg.hive.HiveCatalog",
+		"spark.sql.catalog.hms.uri=thrift://" + hmsEndpoint(),
+		fmt.Sprintf("spark.sql.catalog.hms.warehouse=gs://iceberg-warehouse/%s/", testRunID),
+		"spark.sql.catalog.hms.io-impl=org.apache.iceberg.hadoop.HadoopFileIO",
+		// NOTE: no lock-enabled override. Running on the default
+		// iceberg.engine.hive.lock-enabled=true path, backed by Phase 4's real
+		// jc_hms_locks state machine. lock-enabled=false is documented as a
+		// fallback only (plan_docs/gcp-iceberg-dataproc-e2e.md §7 D2).
+
+		// GCS Hadoop connector (gs:// filesystem) — HadoopFileIO data path AND
+		// INSERT OVERWRITE DIRECTORY both flow through here.
+		"spark.hadoop.fs.gs.impl=com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystem",
+		"spark.hadoop.fs.AbstractFileSystem.gs.impl=com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS",
+		"spark.hadoop.fs.gs.project.id=" + gcsProjectID(),
+		"spark.hadoop.fs.gs.auth.service.account.enable=false",
+		"spark.hadoop.fs.gs.auth.null.enable=true",
+		// The gcs-connector's gcsio layer does not honour STORAGE_EMULATOR_HOST;
+		// it needs the explicit JSON-API root URL.
+		"spark.hadoop.fs.gs.storage.root.url=" + dockerHost,
+	}
+}
+
+// ─── GCS REST assertion helpers ───────────────────────────────────────────────
+//
+// Modeled on tests/persistent_mode/gcp/storage/persistence_test.go (raw HTTP
+// against /storage/v1/...) rather than the AWS S3 SDK. There is deliberately no
+// Go-side Hive metastore client: metadata_location/table_type assertions are
+// replaced by GCS object-count assertions (plan_docs/gcp-iceberg-dataproc-e2e.md
+// §7 D4).
+
+// gcsRequest performs a raw HTTP request against the emulator's GCS REST surface.
+func gcsRequest(host, method, path, body string) (int, []byte, error) {
+	var rd io.Reader
+	if body != "" {
+		rd = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, host+path, rd)
+	if err != nil {
+		return 0, nil, err
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+	return resp.StatusCode, data, nil
+}
+
+// gcsObjectPath percent-encodes each path segment of an object name while
+// leaving the "/" separators literal (the codec splits on "/" and re-joins).
+func gcsObjectPath(object string) string {
+	segs := strings.Split(object, "/")
+	for i, s := range segs {
+		segs[i] = url.PathEscape(s)
+	}
+	return strings.Join(segs, "/")
+}
+
+// listGCSObjects returns the "items" array from the GCS JSON list endpoint for
+// a bucket+prefix.
+func listGCSObjects(t *testing.T, host, bucket, prefix string) []map[string]any {
+	t.Helper()
+	path := fmt.Sprintf("/storage/v1/b/%s/o?prefix=%s",
+		url.PathEscape(bucket), url.QueryEscape(prefix))
+	status, data, err := gcsRequest(host, http.MethodGet, path, "")
+	if err != nil {
+		t.Fatalf("list gs://%s/%s: %v", bucket, prefix, err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("list gs://%s/%s: HTTP %d: %s", bucket, prefix, status, data)
+	}
+	var parsed struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("parse list gs://%s/%s: %v", bucket, prefix, err)
+	}
+	return parsed.Items
+}
+
+// countGCSObjects counts objects under a prefix.
+func countGCSObjects(t *testing.T, host, bucket, prefix string) int {
+	t.Helper()
+	return len(listGCSObjects(t, host, bucket, prefix))
+}
+
+// hasGCSObjects returns true if any object exists under the given prefix.
+func hasGCSObjects(t *testing.T, host, bucket, prefix string) bool {
+	return countGCSObjects(t, host, bucket, prefix) > 0
+}
+
+// readGCSBytes fetches an object's bytes via alt=media.
+func readGCSBytes(t *testing.T, host, bucket, object string) []byte {
+	t.Helper()
+	path := fmt.Sprintf("/storage/v1/b/%s/o/%s?alt=media",
+		url.PathEscape(bucket), gcsObjectPath(object))
+	status, data, err := gcsRequest(host, http.MethodGet, path, "")
+	if err != nil {
+		t.Fatalf("get gs://%s/%s: %v", bucket, object, err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("get gs://%s/%s: HTTP %d: %s", bucket, object, status, data)
+	}
+	return data
+}
+
+// findGCSObjectName lists objects under prefix and returns the name of the first
+// data object (skipping _SUCCESS and hidden files). Spark's INSERT OVERWRITE
+// DIRECTORY writes UUID-named files (e.g. part-00000-<uuid>.c000.json), so this
+// is more robust than a hardcoded key.
+func findGCSObjectName(t *testing.T, host, bucket, prefix string) string {
+	t.Helper()
+	items := listGCSObjects(t, host, bucket, prefix)
+	for _, obj := range items {
+		name, _ := obj["name"].(string)
+		lastSlash := strings.LastIndex(name, "/")
+		base := name[lastSlash+1:]
+		if strings.HasPrefix(base, "_") || strings.HasPrefix(base, ".") || base == "" {
+			continue
+		}
+		return name
+	}
+	t.Fatalf("no data objects found at gs://%s/%s (found %d total)", bucket, prefix, len(items))
+	return ""
+}
+
+// findGCSText lists objects under prefix and returns the first data file's
+// content as a trimmed string.
+func findGCSText(t *testing.T, host, bucket, prefix string) string {
+	t.Helper()
+	name := findGCSObjectName(t, host, bucket, prefix)
+	return strings.TrimSpace(string(readGCSBytes(t, host, bucket, name)))
+}
+
+// findGCSJSON lists objects under prefix, reads the first data file, and decodes
+// it as a single JSON object.
+func findGCSJSON(t *testing.T, host, bucket, prefix string) map[string]any {
+	t.Helper()
+	name := findGCSObjectName(t, host, bucket, prefix)
+	body := readGCSBytes(t, host, bucket, name)
+	var result map[string]any
+	if err := json.Unmarshal(body, &result); err != nil {
+		t.Fatalf("parse JSON from gs://%s/%s: %v\nbody: %s", bucket, name, err, body)
+	}
+	return result
+}
+
+// createGCSBucket creates a bucket via the GCS REST API (idempotent; errors are
+// ignored because the bucket may already exist). Used by TestMain and the
+// persistence test, which have no *testing.T in scope for the setup step.
+func createGCSBucket(host, bucket string) {
+	body := fmt.Sprintf(`{"name":%q}`, bucket)
+	_, _, _ = gcsRequest(host, http.MethodPost, "/storage/v1/b?project=proj", body)
+}
+
+// ─── persistence server helpers ──────────────────────────────────────────────
+
+// gcpBin returns the path to the jaiscloud-gcp binary. Tests run with the
+// working directory set to tests/persistent_mode/gcp/iceberg/, so the project
+// root binary is four levels up. JAISCLOUD_GCP_BIN overrides.
+func gcpBin() string {
+	if b := os.Getenv("JAISCLOUD_GCP_BIN"); b != "" {
+		return b
+	}
+	const rel = "../../../../jaiscloud-gcp"
+	if _, err := os.Stat(rel); err == nil {
+		return rel
+	}
+	return "jaiscloud-gcp"
+}
+
+// persistPort returns the port used by the managed JaisCloud GCP process in the
+// persistence test.
+func persistPort() int {
+	if v := os.Getenv("JAISCLOUD_GCP_PERSIST_PORT"); v != "" {
+		if p, err := strconv.Atoi(v); err == nil {
+			return p
+		}
+	}
+	return 8098
+}
+
+// startGCPProcess starts a managed jaiscloud-gcp subprocess and returns the
+// exec.Cmd. Callers are responsible for killing it when done.
+//
+// There is deliberately no --mode flag: the GCP binary persists via --dsn +
+// --blob-dir (the AWS --mode full invocation is dead code on its own binary —
+// plan_docs/gcp-iceberg-dataproc-e2e.md finding F9).
+func startGCPProcess(t *testing.T, port int, dsn, blobDir string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(gcpBin(),
+		"start",
+		"--port", strconv.Itoa(port),
+		"--dsn", dsn,
+		"--blob-dir", blobDir,
+		"--log-level", "warn",
+	)
+	cmd.Stdout = &testWriter{t: t, prefix: fmt.Sprintf("jaiscloud-gcp[%d]: ", port)}
+	cmd.Stderr = &testWriter{t: t, prefix: fmt.Sprintf("jaiscloud-gcp[%d] ERR: ", port)}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start jaiscloud-gcp on port %d: %v", port, err)
+	}
+	return cmd
+}
+
+// waitForHealth polls /_jaiscloud/health until the server responds 200 or times out.
+func waitForHealth(t *testing.T, host string) {
+	t.Helper()
+	client := &http.Client{Timeout: 2 * time.Second}
+	deadline := clock.RealNow().Add(30 * time.Second)
+	for clock.RealNow().Before(deadline) {
+		resp, err := client.Get(host + "/_jaiscloud/health")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == 200 {
+				return
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	t.Fatalf("jaiscloud-gcp at %s did not become healthy within 30s", host)
+}
+
+// stopProcess kills the managed server and waits for the port to be released.
+func stopProcess(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill jaiscloud-gcp: %v", err)
+	}
+	_ = cmd.Wait()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if !portInUse(persistPort()) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatal("jaiscloud-gcp did not release the port after kill")
+}
+
+func portInUse(port int) bool {
+	c, err := http.Get(fmt.Sprintf("http://localhost:%d/_jaiscloud/health", port))
+	if err != nil {
+		return false
+	}
+	c.Body.Close()
+	return true
+}

--- a/tests/persistent_mode/gcp/iceberg/partition_test.go
+++ b/tests/persistent_mode/gcp/iceberg/partition_test.go
@@ -1,0 +1,106 @@
+//go:build iceberg_e2e
+
+package iceberg_test
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestIceberg_HiveCatalog_PartitionedTable creates a DATE-partitioned Iceberg table,
+// inserts 300 rows across 3 dates, and verifies that a date-filtered query returns
+// only the matching partition.
+func TestIceberg_HiveCatalog_PartitionedTable(t *testing.T) {
+	requireIcebergEnv(t)
+
+	host := jaiscloudHost()
+
+	// Job 1 — Create partitioned table and insert 300 rows (100 per date)
+	runSparkSQL(t, SparkJob{
+		Name: "create-sales",
+		SQL: fmt.Sprintf(`
+%s
+CREATE TABLE IF NOT EXISTS hms.%s.sales (
+  id        INT,
+  region    STRING,
+  amount    DOUBLE,
+  sale_date DATE
+)
+USING iceberg
+PARTITIONED BY (days(sale_date))
+LOCATION '%s';
+
+INSERT INTO hms.%s.sales
+SELECT
+  id,
+  CASE WHEN id %% 3 = 0 THEN 'us-east' WHEN id %% 3 = 1 THEN 'us-west' ELSE 'eu-central' END AS region,
+  CAST(id * 1.5 AS DOUBLE) AS amount,
+  DATE '2026-01-01' AS sale_date
+FROM range(1, 101);
+
+INSERT INTO hms.%s.sales
+SELECT
+  id + 100,
+  'us-east',
+  CAST(id * 2.0 AS DOUBLE),
+  DATE '2026-01-02'
+FROM range(1, 101);
+
+INSERT INTO hms.%s.sales
+SELECT
+  id + 200,
+  'eu-central',
+  CAST(id * 2.5 AS DOUBLE),
+  DATE '2026-01-03'
+FROM range(1, 101);
+`, ensureDatabaseSQL(), icebergDB(), tableLocation("sales"), icebergDB(), icebergDB(), icebergDB()),
+	})
+
+	// Job 2 — Filtered read for 2026-01-02
+	runSparkSQL(t, SparkJob{
+		Name: "count-by-date",
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT COUNT(*) AS cnt
+FROM hms.%s.sales
+WHERE sale_date = DATE '2026-01-02';
+`, outputLoc("sales-count"), icebergDB()),
+	})
+
+	// Job 3 — Full count
+	runSparkSQL(t, SparkJob{
+		Name: "count-total",
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT COUNT(*) AS cnt FROM hms.%s.sales;
+`, outputLoc("sales-total"), icebergDB()),
+	})
+
+	// ── Assertions ────────────────────────────────────────────────────────────
+
+	// Note: Iceberg tables do NOT register partitions via the Hive metastore
+	// partition API. Partition metadata is embedded in Iceberg's own metadata
+	// files (in GCS) — this is the correct behavior in both real GCP and
+	// JaisCloud.
+
+	// a. GCS has 3 partition directories
+	if countGCSObjects(t, host, "iceberg-warehouse", tablePrefix("sales", "data/")) < 3 {
+		t.Error("expected at least 3 data files (one per partition) in sales/data/")
+	}
+
+	// b. Filtered count = 100 (partition pruning on 2026-01-02)
+	filteredResult := findGCSJSON(t, host, "iceberg-warehouse", outputPrefix("sales-count"))
+	cnt, _ := filteredResult["cnt"].(float64)
+	if int(cnt) != 100 {
+		t.Errorf("expected filtered cnt=100, got %v", cnt)
+	}
+
+	// c. Total count = 300
+	totalResult := findGCSJSON(t, host, "iceberg-warehouse", outputPrefix("sales-total"))
+	total, _ := totalResult["cnt"].(float64)
+	if int(total) != 300 {
+		t.Errorf("expected total cnt=300, got %v", total)
+	}
+}

--- a/tests/persistent_mode/gcp/iceberg/persistence_test.go
+++ b/tests/persistent_mode/gcp/iceberg/persistence_test.go
@@ -1,0 +1,171 @@
+//go:build iceberg_e2e
+
+package iceberg_test
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"testing"
+)
+
+// TestIceberg_Persistence_AcrossRestart verifies that Iceberg table data and
+// metadata survive a JaisCloud GCP process restart.
+//
+// The test manages its own jaiscloud-gcp server instance on a separate port so
+// it can control the lifecycle independently of the shared test server. It is
+// built directly from --dsn + --blob-dir (the GCP binary has no --mode flag;
+// see plan_docs/gcp-iceberg-dataproc-e2e.md finding F9).
+//
+// Required env vars:
+//
+//	SPARK_E2E_ICEBERG_GCP_IMAGE — Docker image with Spark + Iceberg (same as other tests)
+//	JAISCLOUD_DSN               — PostgreSQL DSN for persistence
+//
+// Optional env vars:
+//
+//	JAISCLOUD_GCP_BIN            — path to jaiscloud-gcp binary (default: ../../../../jaiscloud-gcp)
+//	JAISCLOUD_GCP_PERSIST_PORT   — port for the managed server (default: 8098)
+//	SPARK_E2E_HMS_ENDPOINT       — Thrift HMS endpoint (default: host.docker.internal:9083)
+func TestIceberg_Persistence_AcrossRestart(t *testing.T) {
+	requireIcebergEnv(t)
+
+	dsn := os.Getenv("JAISCLOUD_DSN")
+	if dsn == "" {
+		t.Skip("JAISCLOUD_DSN not set — skipping persistence test")
+	}
+
+	port := persistPort()
+	host := fmt.Sprintf("http://localhost:%d", port)
+
+	// Blob storage must survive across restarts — use t.TempDir() which persists
+	// for the duration of the test function (cleanup runs after the function returns).
+	blobDir := t.TempDir()
+
+	const (
+		bucket    = "persist-warehouse"
+		hmsDB     = "persist_db"
+		tableName = "checkpoints"
+		rowCount  = 200
+	)
+
+	// ── Phase 1: start server, create infrastructure, insert data ────────────
+
+	proc1 := startGCPProcess(t, port, dsn, blobDir)
+	waitForHealth(t, host)
+
+	// Create shared infrastructure for this test's server instance.
+	createGCSBucket(host, bucket)
+
+	overrideConf := []string{
+		fmt.Sprintf("spark.sql.catalog.hms.warehouse=gs://%s/", bucket),
+	}
+
+	// Create table and insert rowCount rows. The Hive database is created
+	// idempotently from Spark SQL (no Go-side metastore client exists — §7 D4).
+	runSparkSQLOnHost(t, host, SparkJob{
+		Name:      "persist-write",
+		ExtraConf: overrideConf,
+		SQL: fmt.Sprintf(`
+CREATE DATABASE IF NOT EXISTS hms.%s;
+CREATE TABLE IF NOT EXISTS hms.%s.%s (
+  id    INT,
+  value STRING
+)
+USING iceberg
+LOCATION 'gs://%s/%s';
+
+%s
+`, hmsDB, hmsDB, tableName, bucket, tableName, buildPersistInsertSQL(hmsDB, tableName, rowCount)),
+	})
+
+	// Read summary stats before restart: MIN(id), MAX(id), SUM(id), COUNT(*).
+	// SUM of 1..N = N*(N+1)/2 — used to detect data loss or duplication.
+	runSparkSQLOnHost(t, host, SparkJob{
+		Name:      "persist-stats-before",
+		ExtraConf: overrideConf,
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY 'gs://%s/stats-before/'
+USING JSON
+SELECT
+  MIN(id)               AS min_id,
+  MAX(id)               AS max_id,
+  SUM(CAST(id AS LONG)) AS sum_id,
+  COUNT(*)              AS cnt
+FROM hms.%s.%s;
+`, bucket, hmsDB, tableName),
+	})
+
+	statsBefore := findGCSJSON(t, host, bucket, "stats-before/")
+	assertPersistStats(t, "before restart", statsBefore, rowCount)
+
+	// ── Kill server and restart ───────────────────────────────────────────────
+
+	t.Log("killing server for restart test")
+	stopProcess(t, proc1)
+
+	t.Log("restarting server")
+	proc2 := startGCPProcess(t, port, dsn, blobDir)
+	defer stopProcess(t, proc2)
+	waitForHealth(t, host)
+
+	// ── Phase 2: verify data survived the restart ─────────────────────────────
+
+	runSparkSQLOnHost(t, host, SparkJob{
+		Name:      "persist-stats-after",
+		ExtraConf: overrideConf,
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY 'gs://%s/stats-after/'
+USING JSON
+SELECT
+  MIN(id)               AS min_id,
+  MAX(id)               AS max_id,
+  SUM(CAST(id AS LONG)) AS sum_id,
+  COUNT(*)              AS cnt
+FROM hms.%s.%s;
+`, bucket, hmsDB, tableName),
+	})
+
+	statsAfter := findGCSJSON(t, host, bucket, "stats-after/")
+	assertPersistStats(t, "after restart", statsAfter, rowCount)
+
+	// Compare before/after to confirm exact match (no data loss or duplication).
+	if statsBefore["sum_id"] != statsAfter["sum_id"] {
+		t.Errorf("sum_id mismatch: before=%v after=%v", statsBefore["sum_id"], statsAfter["sum_id"])
+	}
+}
+
+// buildPersistInsertSQL generates an INSERT of n rows with id 1..n.
+func buildPersistInsertSQL(hmsDB, tableName string, n int) string {
+	return fmt.Sprintf(
+		"INSERT INTO hms.%s.%s SELECT id, CONCAT('row-', CAST(id AS STRING)) FROM range(1, %d);",
+		hmsDB, tableName, n+1,
+	)
+}
+
+// assertPersistStats verifies that a summary-stats JSON row matches expectations
+// for a table with sequential ids 1..n.
+func assertPersistStats(t *testing.T, label string, stats map[string]any, n int) {
+	t.Helper()
+
+	cnt, _ := stats["cnt"].(float64)
+	if int(cnt) != n {
+		t.Errorf("[%s] expected cnt=%d, got %v", label, n, cnt)
+	}
+
+	minID, _ := stats["min_id"].(float64)
+	if int(minID) != 1 {
+		t.Errorf("[%s] expected min_id=1, got %v", label, minID)
+	}
+
+	maxID, _ := stats["max_id"].(float64)
+	if int(maxID) != n {
+		t.Errorf("[%s] expected max_id=%d, got %v", label, n, maxID)
+	}
+
+	expectedSum := float64(n) * float64(n+1) / 2
+	sumID, _ := stats["sum_id"].(float64)
+	if math.Abs(sumID-expectedSum) > 0.5 {
+		t.Errorf("[%s] expected sum_id=%.0f, got %v", label, expectedSum, sumID)
+	}
+}

--- a/tests/persistent_mode/gcp/iceberg/schema_evolution_test.go
+++ b/tests/persistent_mode/gcp/iceberg/schema_evolution_test.go
@@ -1,0 +1,82 @@
+//go:build iceberg_e2e
+
+package iceberg_test
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestIceberg_HiveCatalog_SchemaEvolution adds a column to an existing table and
+// verifies old rows return NULL for the new column while new rows have values.
+func TestIceberg_HiveCatalog_SchemaEvolution(t *testing.T) {
+	requireIcebergEnv(t)
+
+	host := jaiscloudHost()
+
+	// Job 1 — Create table with initial schema and insert 50 rows
+	runSparkSQL(t, SparkJob{
+		Name: "products-initial",
+		SQL: fmt.Sprintf(`
+%s
+CREATE TABLE IF NOT EXISTS hms.%s.products (
+  id   INT,
+  name STRING
+)
+USING iceberg
+LOCATION '%s';
+
+INSERT INTO hms.%s.products
+SELECT id, CONCAT('product-', CAST(id AS STRING))
+FROM range(1, 51);
+`, ensureDatabaseSQL(), icebergDB(), tableLocation("products"), icebergDB()),
+	})
+
+	// Job 2 — Add column and insert 50 more rows with price values
+	runSparkSQL(t, SparkJob{
+		Name: "products-evolve",
+		SQL: fmt.Sprintf(`
+ALTER TABLE hms.%s.products ADD COLUMN price DOUBLE;
+
+INSERT INTO hms.%s.products (id, name, price)
+SELECT id + 50, CONCAT('evolved-', CAST(id AS STRING)), CAST(id AS DOUBLE) * 9.99
+FROM range(1, 51);
+`, icebergDB(), icebergDB()),
+	})
+
+	// Job 3 — Total count
+	runSparkSQL(t, SparkJob{
+		Name: "products-count",
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT COUNT(*) AS cnt FROM hms.%s.products;
+`, outputLoc("products-count"), icebergDB()),
+	})
+
+	// Job 4 — Rows without price (old rows)
+	runSparkSQL(t, SparkJob{
+		Name: "products-null-price-count",
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT COUNT(*) AS cnt FROM hms.%s.products WHERE price IS NULL;
+`, outputLoc("products-nullprice"), icebergDB()),
+	})
+
+	// ── Assertions ────────────────────────────────────────────────────────────
+
+	// a. Total count = 100
+	countResult := findGCSJSON(t, host, "iceberg-warehouse", outputPrefix("products-count"))
+	cnt, _ := countResult["cnt"].(float64)
+	if int(cnt) != 100 {
+		t.Errorf("expected total cnt=100, got %v", cnt)
+	}
+
+	// b. Exactly 50 rows have NULL price (the original rows)
+	nullResult := findGCSJSON(t, host, "iceberg-warehouse", outputPrefix("products-nullprice"))
+	nullCnt, _ := nullResult["cnt"].(float64)
+	if int(nullCnt) != 50 {
+		t.Errorf("expected 50 null-price rows, got %v", nullCnt)
+	}
+}

--- a/tests/persistent_mode/gcp/iceberg/setup_test.go
+++ b/tests/persistent_mode/gcp/iceberg/setup_test.go
@@ -1,0 +1,43 @@
+//go:build iceberg_e2e
+
+package iceberg_test
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+)
+
+// testRunID is a random 6-hex-char string unique to this test binary invocation.
+// All Hive DB names and GCS paths are scoped under this ID so that concurrent
+// or back-to-back test runs never share state.
+var testRunID string
+
+// TestMain creates the shared Iceberg infrastructure once before all tests.
+// Shared resources (scoped to this run):
+//   - GCS bucket "iceberg-warehouse"
+//
+// Divergence from the AWS harness: the AWS TestMain also pre-creates the Glue
+// database via the Go Glue SDK. There is no Go-side Hive metastore client, so
+// the run-scoped Hive database is instead created idempotently from Spark SQL
+// (ensureDatabaseSQL) inside each test — see helpers_test.go and
+// plan_docs/gcp-iceberg-dataproc-e2e.md §7 D4.
+//
+// The lock manager is left at Spark's default (InMemoryLockManager): each
+// Docker container runs its own JVM, and the HiveCatalog lock path runs against
+// Phase 4's real jc_hms_locks state machine on the default lock-enabled=true.
+func TestMain(m *testing.M) {
+	testRunID = fmt.Sprintf("%06x", rand.Uint32())
+
+	host := jaiscloudHost()
+
+	// 1. Create GCS warehouse bucket (idempotent — error ignored if already exists)
+	createGCSBucket(host, "iceberg-warehouse")
+
+	code := m.Run()
+
+	// Teardown: GCS objects and any Hive tables are left intact for debugging
+	// (no Go-side metastore client exists to drop them).
+	os.Exit(code)
+}

--- a/tests/persistent_mode/gcp/iceberg/spark-iceberg/Dockerfile
+++ b/tests/persistent_mode/gcp/iceberg/spark-iceberg/Dockerfile
@@ -1,0 +1,13 @@
+FROM apache/spark:3.5.0
+
+USER root
+
+# Copy pre-downloaded JARs into Spark's jars directory.
+# Run download-jars.sh first to populate the jars/ directory.
+#
+# Data path decision (plan_docs/gcp-iceberg-dataproc-e2e.md §7 D1):
+# HadoopFileIO + gcs-connector. iceberg-gcp-bundle is intentionally NOT shipped.
+COPY jars/iceberg-spark-runtime-3.5_2.12-1.5.2.jar /opt/spark/jars/
+COPY jars/gcs-connector-hadoop3-2.2.11-shaded.jar   /opt/spark/jars/
+
+USER spark

--- a/tests/persistent_mode/gcp/iceberg/spark-iceberg/download-jars.sh
+++ b/tests/persistent_mode/gcp/iceberg/spark-iceberg/download-jars.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Download Iceberg and GCS JARs from Maven Central into ./jars/
+# Run once before building the Docker image:
+#
+#   bash download-jars.sh
+#   docker build -t spark-iceberg-gcp-test .
+#
+set -euo pipefail
+
+DEST="$(dirname "$0")/jars"
+mkdir -p "$DEST"
+
+BASE="https://repo1.maven.org/maven2"
+
+download() {
+    local url="$1"
+    local dest="$2"
+    if [ -f "$dest" ]; then
+        echo "  already exists: $(basename "$dest")"
+        return
+    fi
+    echo "  downloading: $(basename "$dest")"
+    curl -fL --progress-bar -o "$dest" "$url"
+}
+
+echo "Downloading Iceberg JARs to $DEST ..."
+
+download \
+    "$BASE/org/apache/iceberg/iceberg-spark-runtime-3.5_2.12/1.5.2/iceberg-spark-runtime-3.5_2.12-1.5.2.jar" \
+    "$DEST/iceberg-spark-runtime-3.5_2.12-1.5.2.jar"
+
+# gcs-connector hadoop3 (shaded). Data path is HadoopFileIO + gcs-connector
+# (plan_docs/gcp-iceberg-dataproc-e2e.md §7 D1); iceberg-gcp-bundle is dropped.
+#
+# TODO(D6 — unconfirmed pin): gcs-connector-hadoop3-2.2.11-shaded.jar is the
+# starting pin only. It must be confirmed empirically via the spark-sql boot
+# spike (spark-sql boots with it on the classpath + a gs:// round-trip works)
+# before the full harness runs. The spike cannot run here (needs Docker Spark
+# + the Phase 4 Hive Metastore Thrift listener). See
+# plan_docs/gcp-iceberg-dataproc-e2e.md §7 item 6 and finding F4.
+download \
+    "$BASE/com/google/cloud/bigdataoss/gcs-connector/hadoop3-2.2.11/gcs-connector-hadoop3-2.2.11-shaded.jar" \
+    "$DEST/gcs-connector-hadoop3-2.2.11-shaded.jar"
+
+echo ""
+echo "Done. Build the image with:"
+echo "  docker build -t spark-iceberg-gcp-test $(dirname "$0")"

--- a/tests/persistent_mode/gcp/iceberg/time_travel_test.go
+++ b/tests/persistent_mode/gcp/iceberg/time_travel_test.go
@@ -1,0 +1,109 @@
+//go:build iceberg_e2e
+
+package iceberg_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+// TestIceberg_HiveCatalog_TimeTravel inserts data in two batches, captures the
+// snapshot ID after the first batch, then queries AS OF that snapshot and verifies
+// only the first batch is visible.
+func TestIceberg_HiveCatalog_TimeTravel(t *testing.T) {
+	requireIcebergEnv(t)
+
+	host := jaiscloudHost()
+
+	// Job 1 — First batch (100 rows) + write snapshot ID to GCS
+	runSparkSQL(t, SparkJob{
+		Name: "orders-batch1",
+		SQL: fmt.Sprintf(`
+%s
+CREATE TABLE IF NOT EXISTS hms.%s.orders (
+  id     INT,
+  status STRING
+)
+USING iceberg
+LOCATION '%s';
+
+INSERT INTO hms.%s.orders
+SELECT id, 'pending' FROM range(1, 101);
+
+-- Write the current snapshot_id to GCS for the Go test to read back.
+INSERT OVERWRITE DIRECTORY '%s'
+USING TEXT
+SELECT CAST(snapshot_id AS STRING)
+FROM hms.%s.orders.snapshots
+ORDER BY committed_at DESC
+LIMIT 1;
+`, ensureDatabaseSQL(), icebergDB(), tableLocation("orders"), icebergDB(), outputLoc("orders-meta"), icebergDB()),
+	})
+
+	// Job 2 — Second batch (100 more rows)
+	runSparkSQL(t, SparkJob{
+		Name: "orders-batch2",
+		SQL: fmt.Sprintf(`
+INSERT INTO hms.%s.orders
+SELECT id + 100, 'shipped' FROM range(1, 101);
+`, icebergDB()),
+	})
+
+	// Read snapshot ID from GCS before running time-travel queries.
+	// Spark's FileOutputCommitter writes UUID-named files (e.g. part-00000-<uuid>.c000.txt)
+	// so we use findGCSText to locate the first data object under the prefix.
+	snapshotIDStr := findGCSText(t, host, "iceberg-warehouse", outputPrefix("orders-meta"))
+	snapshotID, err := strconv.ParseInt(snapshotIDStr, 10, 64)
+	if err != nil {
+		t.Fatalf("parse snapshot ID %q: %v", snapshotIDStr, err)
+	}
+	if snapshotID <= 0 {
+		t.Fatalf("invalid snapshot ID: %d", snapshotID)
+	}
+	t.Logf("snapshot ID after batch 1: %d", snapshotID)
+
+	// Job 3a — Time-travel query: COUNT(*) AS OF snapshot 1
+	runSparkSQL(t, SparkJob{
+		Name: "orders-timetravel",
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT COUNT(*) AS cnt
+FROM hms.%s.orders
+VERSION AS OF %s;
+`, outputLoc("orders-snap1"), icebergDB(), snapshotIDStr),
+	})
+
+	// Job 3b — Current snapshot query: COUNT(*) (both batches)
+	runSparkSQL(t, SparkJob{
+		Name: "orders-current",
+		SQL: fmt.Sprintf(`
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT COUNT(*) AS cnt FROM hms.%s.orders;
+`, outputLoc("orders-current"), icebergDB()),
+	})
+
+	// ── Assertions ────────────────────────────────────────────────────────────
+
+	// a. GCS metadata has at least 2 snapshot files
+	metaCount := countGCSObjects(t, host, "iceberg-warehouse", tablePrefix("orders", "metadata/"))
+	if metaCount < 2 {
+		t.Errorf("expected at least 2 metadata files, got %d", metaCount)
+	}
+
+	// b. Time-travel result = 100 (only batch 1)
+	snap1Result := findGCSJSON(t, host, "iceberg-warehouse", outputPrefix("orders-snap1"))
+	snap1Cnt, _ := snap1Result["cnt"].(float64)
+	if int(snap1Cnt) != 100 {
+		t.Errorf("expected time-travel cnt=100, got %v", snap1Cnt)
+	}
+
+	// c. Current result = 200 (both batches)
+	currentResult := findGCSJSON(t, host, "iceberg-warehouse", outputPrefix("orders-current"))
+	currentCnt, _ := currentResult["cnt"].(float64)
+	if int(currentCnt) != 200 {
+		t.Errorf("expected current cnt=200, got %v", currentCnt)
+	}
+}

--- a/tests/persistent_mode/gcp/iceberg/write_read_test.go
+++ b/tests/persistent_mode/gcp/iceberg/write_read_test.go
@@ -1,0 +1,79 @@
+//go:build iceberg_e2e
+
+package iceberg_test
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestIceberg_HiveCatalog_WriteAndRead creates an Iceberg table, inserts 100 rows,
+// reads them back via a COUNT(*) job, and verifies the result via GCS object
+// assertions.
+func TestIceberg_HiveCatalog_WriteAndRead(t *testing.T) {
+	requireIcebergEnv(t)
+
+	host := jaiscloudHost()
+
+	// Job 1 — Write: create table and insert 100 rows
+	runSparkSQL(t, SparkJob{
+		Name: "write-events",
+		SQL: fmt.Sprintf(`
+%s
+CREATE TABLE IF NOT EXISTS hms.%s.events (
+  id         INT,
+  name       STRING,
+  amount     DOUBLE,
+  created_at TIMESTAMP
+)
+USING iceberg
+LOCATION '%s';
+
+%s
+`, ensureDatabaseSQL(), icebergDB(), tableLocation("events"), buildInsertSQL(icebergDB(), "events", 100)),
+	})
+
+	// Job 2 — Read: COUNT(*) and write result to GCS
+	runSparkSQL(t, SparkJob{
+		Name: "read-events-count",
+		SQL: fmt.Sprintf(`
+SELECT COUNT(*) AS cnt FROM hms.%s.events;
+-- Write result to GCS as JSON
+INSERT OVERWRITE DIRECTORY '%s'
+USING JSON
+SELECT COUNT(*) AS cnt FROM hms.%s.events;
+`, icebergDB(), outputLoc("events-count"), icebergDB()),
+	})
+
+	// ── Assertions ────────────────────────────────────────────────────────────
+
+	// a. GCS metadata directory contains at least 1 JSON file
+	if !hasGCSObjects(t, host, "iceberg-warehouse", tablePrefix("events", "metadata/")) {
+		t.Error("expected metadata files in gs://iceberg-warehouse/.../events/metadata/")
+	}
+
+	// b. GCS data directory contains at least 1 Parquet file
+	if !hasGCSObjects(t, host, "iceberg-warehouse", tablePrefix("events", "data/")) {
+		t.Error("expected data files in gs://iceberg-warehouse/.../events/data/")
+	}
+
+	// c. COUNT result = 100
+	result := findGCSJSON(t, host, "iceberg-warehouse", outputPrefix("events-count"))
+	cnt, _ := result["cnt"].(float64)
+	if int(cnt) != 100 {
+		t.Errorf("expected cnt=100, got %v", cnt)
+	}
+}
+
+// buildInsertSQL generates a bulk INSERT of n rows into the given db.table.
+func buildInsertSQL(db, table string, n int) string {
+	sql := fmt.Sprintf("INSERT INTO hms.%s.%s VALUES\n", db, table)
+	for i := 1; i <= n; i++ {
+		comma := ","
+		if i == n {
+			comma = ";"
+		}
+		sql += fmt.Sprintf("  (%d, 'user%d', %.2f, current_timestamp())%s\n", i, i, float64(i)*0.99, comma)
+	}
+	return sql
+}


### PR DESCRIPTION
## Summary

**Iceberg-on-Dataproc E2E** (Phase 5) — port the 7 AWS `iceberg_e2e` tests to GCP, driving external Docker Spark (`apache/spark:3.5.0`) against the emulator's **Hive Metastore Thrift listener (`:9083`)** + **GCS**.

> **Depends on PR #57** (DPMS Hive Metastore Thrift serving plane). The tests compile under the `iceberg_e2e` build tag but will not *execute* until #57's `:9083` listener merges (Raj's decision D3: sequence strictly after Phase 4).

## Raj's resolved decisions implemented (§7)

- **D1** — `HadoopFileIO` + **gcs-connector** (`io-impl=org.apache.iceberg.hadoop.HadoopFileIO`); **`iceberg-gcp-bundle` dropped**. One `gs://` path via `fs.gs.storage.root.url=http://host.docker.internal:8080`.
- **D2** — default `iceberg.engine.hive.lock-enabled=true` path (Phase 4's real `jc_hms_locks`); no `lock-enabled=false`.
- **D4** — dropped Go-side Hive metastore assertions; assert on **GCS object counts** (`metadata/*.metadata.json`, `data/`).
- **D5** — anonymous `fs.gs.auth.null.enable=true` + `fs.gs.project.id`, no Workload Identity / no `GOOGLE_APPLICATION_CREDENTIALS`.
- **D6** — `gcs-connector-hadoop3-2.2.11-shaded.jar` as the starting pin with a `TODO(D6)` for the `spark-sql` boot spike (cannot run here).

## Layout

- `tests/persistent_mode/gcp/iceberg/spark-iceberg/` — `Dockerfile` + `download-jars.sh` (spark 3.5.0 + iceberg-spark-runtime 1.5.2 + gcs-connector hadoop3).
- `tests/persistent_mode/gcp/iceberg/` — `helpers_test.go` + `setup_test.go` harness + 7 test ports.
- `Makefile` — `test-e2e-iceberg-gcp` target + `_check-iceberg-prereq`.

## Faithful-port divergences (flagged, per the doc)

- No Go Hive Thrift client exists, so: Go-side metastore assertions **dropped** (→ GCS counts); `resetIcebergTables` dropped (run-scoped DB names give isolation); DB creation moved into Spark SQL (`CREATE DATABASE IF NOT EXISTS`), since `HiveCatalog` doesn't auto-create namespaces.
- Persistence test builds the subprocess harness from `--dsn`/`--blob-dir` directly — **not** the AWS `--mode full` invocation, which is dead code on the AWS binary (doc F9).

## Verification

`go build -tags iceberg_e2e ./...` ✅, `go vet -tags iceberg_e2e ./...` ✅, `gofmt -l` empty ✅. Emulator Go code (`internal/gcp/`, `cmd/`) untouched. Full E2E execution is blocked on #57 + Docker (as expected).

## Open (for review / spike)

- gcs-connector exact `hadoop3` artifact/version must be confirmed by the boot spike (D6) — documented `TODO`.