### PR TITLE
fix(gcp/storage): atomic gRPC object preconditions (follow-up to #48)

### DIFF
--- a/internal/gcp/grpc/status.go
+++ b/internal/gcp/grpc/status.go
@@ -82,6 +82,8 @@ func httpToCode(h int) (codes.Code, bool) {
 		return codes.NotFound, true
 	case 409:
 		return codes.Aborted, true
+	case 412:
+		return codes.FailedPrecondition, true
 	case 429:
 		return codes.ResourceExhausted, true
 	case 500:
@@ -103,7 +105,7 @@ func codeAlias(c string) (codes.Code, bool) {
 		return codes.NotFound, true
 	case "AlreadyExists":
 		return codes.AlreadyExists, true
-	case "FailedPrecondition":
+	case "FailedPrecondition", "PreconditionFailed":
 		return codes.FailedPrecondition, true
 	case "OutOfRange":
 		return codes.OutOfRange, true

--- a/internal/gcp/grpc/storage/service.go
+++ b/internal/gcp/grpc/storage/service.go
@@ -53,6 +53,7 @@ type uploadSession struct {
 	kmsKeyName   string
 	cseKey       []byte
 	cseKeySHA256 string
+	precondition *gcs.Precondition // from WriteObjectSpec's if_* fields; checked atomically at finalize
 	buf          []byte
 	length       int64
 	lastAccess   time.Time
@@ -473,32 +474,23 @@ func (s *Service) DeleteObject(ctx context.Context, req *storagepb.DeleteObjectR
 	bucket := parseBucketName(req.GetBucket())
 	object := req.GetObject()
 
-	// Preconditions are evaluated against the live object. The optional
-	// `generation` field selects the revision to delete; the store's delete
-	// operates on the live revision, so a non-live target is a precondition
-	// failure rather than a partial delete.
-	live, err := s.objects.GetObjectMeta(ctx, bucket, object)
-	if err != nil {
-		if errors.Is(err, gcs.ErrNoSuchObject) {
-			return nil, mapError(model.NewProviderError("NotFound", "object not found", 404))
+	// Preconditions are threaded into the store's *Checked delete so the check
+	// and the delete happen under one lock/transaction — the same atomic path
+	// the REST ObjectsDelete uses (see storage.objectPrecondition). A
+	// separately-fetched read would leave a check-then-write race.
+	pre := grpcObjectPrecondition(req.IfGenerationMatch, req.IfGenerationNotMatch, req.IfMetagenerationMatch, req.IfMetagenerationNotMatch)
+	// The optional `generation` field selects the revision to delete; the store
+	// deletes the live revision, so fold it into the atomic precondition (a
+	// non-live target is a precondition failure, not a partial delete).
+	if req.GetGeneration() > 0 {
+		if pre == nil {
+			pre = &gcs.Precondition{}
 		}
-		return nil, mapError(err)
+		gen := req.GetGeneration()
+		pre.GenerationMatch = &gen
 	}
-	if req.GetGeneration() > 0 && genToInt64(live.Generation) != req.GetGeneration() {
-		return nil, mapError(preconditionErr("generation precondition failed"))
-	}
-	if err := checkObjectPreconditions(live, req.IfGenerationMatch, req.IfGenerationNotMatch, req.IfMetagenerationMatch, req.IfMetagenerationNotMatch); err != nil {
-		return nil, mapError(err)
-	}
-
-	// precondition: nil — checkObjectPreconditions above already validated
-	// the request's preconditions against a separately-fetched read. That
-	// check-then-write isn't atomic the way the REST path's is (see
-	// storage.DeleteObjectData's *Checked call) — a real but narrower,
-	// pre-existing gap, left as a follow-up rather than duplicating the
-	// check here.
-	if err := s.provider.DeleteObjectData(ctx, bucket, object, nil); err != nil {
-		return nil, mapError(err)
+	if err := s.provider.DeleteObjectData(ctx, bucket, object, pre); err != nil {
+		return nil, mapError(preconditionResult(err))
 	}
 	return &emptypb.Empty{}, nil
 }
@@ -507,6 +499,36 @@ func (s *Service) DeleteObject(ctx context.Context, req *storagepb.DeleteObjectR
 // matching the canonical precondition-failure shape used across GCP services.
 func preconditionErr(msg string) error {
 	return &model.ProviderError{Code: "FailedPrecondition", Message: msg, HTTPStatus: 400, Status: "FAILED_PRECONDITION"}
+}
+
+// grpcObjectPrecondition builds a gcs.Precondition from a gRPC request's four
+// optional if_*_match fields, returning nil when none is set (the common case).
+// The proto fields are optional (*int64), so nil already means "unset" and a
+// present 0 keeps GCS's special "no live version" meaning — the same shape the
+// store's *Checked methods expect.
+func grpcObjectPrecondition(ifGenMatch, ifGenNotMatch, ifMetaMatch, ifMetaNotMatch *int64) *gcs.Precondition {
+	if ifGenMatch == nil && ifGenNotMatch == nil && ifMetaMatch == nil && ifMetaNotMatch == nil {
+		return nil
+	}
+	return &gcs.Precondition{
+		GenerationMatch:        ifGenMatch,
+		GenerationNotMatch:     ifGenNotMatch,
+		MetagenerationMatch:    ifMetaMatch,
+		MetagenerationNotMatch: ifMetaNotMatch,
+	}
+}
+
+// preconditionResult maps the store's raw gcs.ErrPreconditionFailed (returned
+// by the *Checked object-write methods) to the canonical FAILED_PRECONDITION
+// provider error. Callers still run the result through mapError. The provider's
+// delete path instead returns a 412 PreconditionFailed provider error, which
+// passes through here and is resolved by mapError's 412→FAILED_PRECONDITION
+// status mapping.
+func preconditionResult(err error) error {
+	if errors.Is(err, gcs.ErrPreconditionFailed) {
+		return preconditionErr("At least one of the pre-conditions you specified did not hold")
+	}
+	return err
 }
 
 // checkObjectPreconditions validates the four GCS object preconditions against
@@ -627,12 +649,13 @@ func (s *Service) ComposeObject(ctx context.Context, req *storagepb.ComposeObjec
 	meta := protoResourceToMeta(dest, bucket, object, s.provider.NextGen(), now)
 	meta.ComponentCount = int64(len(sources))
 
-	// precondition: nil — this gRPC path doesn't yet parse
-	// WriteObjectSpec.if_generation_match/if_metageneration_match; the REST
-	// ObjectsInsert/ObjectsRewrite path does (see storage.objectPrecondition).
-	finalMeta, err := s.provider.PutObjectData(ctx, project, meta, buf.Bytes(), versioned, priorBlobKey, false, meta.KmsKeyName, nil, "", nil)
+	// The compose destination's if_generation_match/if_metageneration_match
+	// (ComposeObjectRequest has no not-match variants) guard the write
+	// atomically via the store's *Checked path.
+	pre := grpcObjectPrecondition(req.IfGenerationMatch, nil, req.IfMetagenerationMatch, nil)
+	finalMeta, err := s.provider.PutObjectData(ctx, project, meta, buf.Bytes(), versioned, priorBlobKey, false, meta.KmsKeyName, nil, "", pre)
 	if err != nil {
-		return nil, mapError(err)
+		return nil, mapError(preconditionResult(err))
 	}
 	return objectToProto(finalMeta), nil
 }
@@ -651,13 +674,21 @@ func (s *Service) StartResumableWrite(ctx context.Context, req *storagepb.StartR
 	id := s.provider.NextGen()
 	now := clock.RealNow()
 
+	// Preconditions from the write spec are carried on the session and checked
+	// atomically when the resumable write is finalized.
+	var pre *gcs.Precondition
+	if spec != nil {
+		pre = grpcObjectPrecondition(spec.IfGenerationMatch, spec.IfGenerationNotMatch, spec.IfMetagenerationMatch, spec.IfMetagenerationNotMatch)
+	}
+
 	sess := &uploadSession{
-		bucket:      bucket,
-		object:      object,
-		contentType: resource.GetContentType(),
-		metadata:    resource.GetMetadata(),
-		kmsKeyName:  resource.GetKmsKey(),
-		lastAccess:  now,
+		bucket:       bucket,
+		object:       object,
+		contentType:  resource.GetContentType(),
+		metadata:     resource.GetMetadata(),
+		kmsKeyName:   resource.GetKmsKey(),
+		precondition: pre,
+		lastAccess:   now,
 	}
 	if sess.contentType == "" {
 		sess.contentType = "application/octet-stream"
@@ -737,9 +768,10 @@ func (s *Service) finalize(ctx context.Context, project string, sess *uploadSess
 	if meta.ContentType == "" {
 		meta.ContentType = "application/octet-stream"
 	}
-	finalMeta, err := s.provider.PutObjectData(ctx, project, meta, sess.buf, versioned, priorBlobKey, true, sess.kmsKeyName, sess.cseKey, sess.cseKeySHA256, nil)
+	finalMeta, err := s.provider.PutObjectData(ctx, project, meta, sess.buf, versioned, priorBlobKey, true, sess.kmsKeyName, sess.cseKey, sess.cseKeySHA256, sess.precondition)
 	if err != nil {
-		return nil, err
+		// The caller maps the result to a gRPC status.
+		return nil, preconditionResult(err)
 	}
 	return objectToProto(finalMeta), nil
 }
@@ -765,11 +797,12 @@ func (s *Service) WriteObject(stream storagepb.Storage_WriteObjectServer) error 
 			case *storagepb.WriteObjectRequest_WriteObjectSpec:
 				res := fm.WriteObjectSpec.GetResource()
 				sess = &uploadSession{
-					bucket:      parseBucketName(res.GetBucket()),
-					object:      res.GetName(),
-					contentType: res.GetContentType(),
-					metadata:    res.GetMetadata(),
-					kmsKeyName:  res.GetKmsKey(),
+					bucket:       parseBucketName(res.GetBucket()),
+					object:       res.GetName(),
+					contentType:  res.GetContentType(),
+					metadata:     res.GetMetadata(),
+					kmsKeyName:   res.GetKmsKey(),
+					precondition: grpcObjectPrecondition(fm.WriteObjectSpec.IfGenerationMatch, fm.WriteObjectSpec.IfGenerationNotMatch, fm.WriteObjectSpec.IfMetagenerationMatch, fm.WriteObjectSpec.IfMetagenerationNotMatch),
 				}
 				project = s.projectForBucket(ctx, sess.bucket)
 			case *storagepb.WriteObjectRequest_UploadId:
@@ -837,11 +870,12 @@ func (s *Service) BidiWriteObject(stream storagepb.Storage_BidiWriteObjectServer
 			case *storagepb.BidiWriteObjectRequest_WriteObjectSpec:
 				res := fm.WriteObjectSpec.GetResource()
 				sess = &uploadSession{
-					bucket:      parseBucketName(res.GetBucket()),
-					object:      res.GetName(),
-					contentType: res.GetContentType(),
-					metadata:    res.GetMetadata(),
-					kmsKeyName:  res.GetKmsKey(),
+					bucket:       parseBucketName(res.GetBucket()),
+					object:       res.GetName(),
+					contentType:  res.GetContentType(),
+					metadata:     res.GetMetadata(),
+					kmsKeyName:   res.GetKmsKey(),
+					precondition: grpcObjectPrecondition(fm.WriteObjectSpec.IfGenerationMatch, fm.WriteObjectSpec.IfGenerationNotMatch, fm.WriteObjectSpec.IfMetagenerationMatch, fm.WriteObjectSpec.IfMetagenerationNotMatch),
 				}
 				if sess.contentType == "" {
 					sess.contentType = "application/octet-stream"

--- a/internal/gcp/grpc/storage/service_test.go
+++ b/internal/gcp/grpc/storage/service_test.go
@@ -453,3 +453,136 @@ func TestDeleteAndUpdatePreconditions(t *testing.T) {
 		t.Fatalf("ReadObject content = %q, want %q", got, "data")
 	}
 }
+
+// The compose/write paths below thread their request preconditions into the
+// store's atomic *Checked methods — the follow-up #48 deliberately deferred
+// (its DeleteObject/ComposeObject/finalize calls passed precondition=nil). A
+// stale precondition must be rejected atomically, without mutating the object.
+
+func TestComposeObjectDestinationPrecondition(t *testing.T) {
+	client, cleanup := storageTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+
+	a := writeSingleShot(t, client, testBucket, "cs-a", "text/plain", []byte("A"))
+	b := writeSingleShot(t, client, testBucket, "cs-b", "text/plain", []byte("B"))
+	writeSingleShot(t, client, testBucket, "cs-dest", "text/plain", []byte("OLD"))
+
+	sources := []*storagepb.ComposeObjectRequest_SourceObject{
+		{Name: "cs-a", Generation: a.GetGeneration()},
+		{Name: "cs-b", Generation: b.GetGeneration()},
+	}
+
+	// if_generation_match=0 ("create only if absent") against an existing
+	// destination is rejected atomically; the existing object is untouched.
+	zero := int64(0)
+	if _, err := client.ComposeObject(ctx, &storagepb.ComposeObjectRequest{
+		Destination:       &storagepb.Object{Name: "cs-dest", Bucket: testBucket},
+		SourceObjects:     sources,
+		IfGenerationMatch: &zero,
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("compose if_generation_match=0 on existing dest: code = %v, want FailedPrecondition (err=%v)", status.Code(err), err)
+	}
+	if got := readObject(t, client, testBucket, "cs-dest"); string(got) != "OLD" {
+		t.Fatalf("destination unchanged after rejected compose, got %q, want OLD", got)
+	}
+
+	// The same create-only precondition succeeds against a new destination.
+	if _, err := client.ComposeObject(ctx, &storagepb.ComposeObjectRequest{
+		Destination:       &storagepb.Object{Name: "cs-new", Bucket: testBucket},
+		SourceObjects:     sources,
+		IfGenerationMatch: &zero,
+	}); err != nil {
+		t.Fatalf("compose if_generation_match=0 on new dest: %v", err)
+	}
+	if got := readObject(t, client, testBucket, "cs-new"); string(got) != "AB" {
+		t.Fatalf("composed content = %q, want AB", got)
+	}
+}
+
+// writeSingleShotPre writes via the client-streaming WriteObject RPC with an
+// optional if_generation_match precondition, returning the RPC error.
+func writeSingleShotPre(t *testing.T, client storagepb.StorageClient, bucket, object string, data []byte, ifGenMatch *int64) error {
+	t.Helper()
+	stream, err := client.WriteObject(context.Background())
+	if err != nil {
+		return err
+	}
+	if err := stream.Send(&storagepb.WriteObjectRequest{
+		FirstMessage: &storagepb.WriteObjectRequest_WriteObjectSpec{
+			WriteObjectSpec: &storagepb.WriteObjectSpec{
+				Resource:          &storagepb.Object{Name: object, Bucket: bucket, ContentType: "text/plain"},
+				IfGenerationMatch: ifGenMatch,
+			},
+		},
+		WriteOffset: 0,
+		Data:        &storagepb.WriteObjectRequest_ChecksummedData{ChecksummedData: &storagepb.ChecksummedData{Content: data}},
+		FinishWrite: true,
+	}); err != nil {
+		return err
+	}
+	_, err = stream.CloseAndRecv()
+	return err
+}
+
+func TestWriteObjectPrecondition(t *testing.T) {
+	client, cleanup := storageTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+
+	obj := writeSingleShot(t, client, testBucket, "wp", "text/plain", []byte("first"))
+	gen := obj.GetGeneration()
+	zero := int64(0)
+
+	// Create-only (if_generation_match=0) against an existing object is
+	// rejected; the stored bytes are untouched.
+	if err := writeSingleShotPre(t, client, testBucket, "wp", []byte("second"), &zero); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("write if_generation_match=0 on existing: code = %v, want FailedPrecondition (err=%v)", status.Code(err), err)
+	}
+	if got := readObject(t, client, testBucket, "wp"); string(got) != "first" {
+		t.Fatalf("object unchanged after rejected write, got %q, want first", got)
+	}
+
+	// A matching generation overwrites.
+	if err := writeSingleShotPre(t, client, testBucket, "wp", []byte("second"), &gen); err != nil {
+		t.Fatalf("write with matching if_generation_match: %v", err)
+	}
+	if got := readObject(t, client, testBucket, "wp"); string(got) != "second" {
+		t.Fatalf("object content = %q, want second", got)
+	}
+
+	// Create-only against a new object succeeds.
+	if err := writeSingleShotPre(t, client, testBucket, "wp-new", []byte("fresh"), &zero); err != nil {
+		t.Fatalf("write if_generation_match=0 on new object: %v", err)
+	}
+
+	// A resumable write carries the write spec's precondition through to
+	// finalize (StartResumableWrite captures it on the session).
+	srw, err := client.StartResumableWrite(ctx, &storagepb.StartResumableWriteRequest{
+		WriteObjectSpec: &storagepb.WriteObjectSpec{
+			Resource:          &storagepb.Object{Name: "wp", Bucket: testBucket, ContentType: "text/plain"},
+			IfGenerationMatch: &zero,
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartResumableWrite: %v", err)
+	}
+	stream, err := client.BidiWriteObject(ctx)
+	if err != nil {
+		t.Fatalf("BidiWriteObject: %v", err)
+	}
+	if err := stream.Send(&storagepb.BidiWriteObjectRequest{
+		FirstMessage: &storagepb.BidiWriteObjectRequest_UploadId{UploadId: srw.GetUploadId()},
+		Data:         &storagepb.BidiWriteObjectRequest_ChecksummedData{ChecksummedData: &storagepb.ChecksummedData{Content: []byte("resumed")}},
+	}); err != nil {
+		t.Fatalf("BidiWriteObject send data: %v", err)
+	}
+	if err := stream.Send(&storagepb.BidiWriteObjectRequest{FinishWrite: true}); err != nil {
+		t.Fatalf("BidiWriteObject send finish: %v", err)
+	}
+	if _, err := stream.Recv(); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("resumable finalize with stale precondition: code = %v, want FailedPrecondition (err=%v)", status.Code(err), err)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to **#48** (`raj/occ-gcs`). #48 fixed the **REST** object-mutation preconditions via the store's `*Checked` methods and explicitly **deferred the gRPC path** — its own `DeleteObject`/`ComposeObject`/`finalize` call sites passed `precondition=nil` with the in-code comment *"check-then-write isn't atomic the way the REST path's is … a real but narrower, pre-existing gap, left as a follow-up"*.

This closes that follow-up: the gRPC paths now thread the request preconditions into the same atomic `*Checked` store methods, so the check and the write/delete happen under one lock/transaction.

## Changes

- **`DeleteObject`** — build a `*gcs.Precondition` from the request's `if_generation_match`/`if_generation_not_match`/`if_metageneration_match`/`if_metageneration_not_match`, fold the `generation` selector in, and pass it to `DeleteObjectData` (was `nil`).
- **`ComposeObject`** — thread the destination's `if_generation_match`/`if_metageneration_match` (Compose has no not-match variants) into `PutObjectData` (was `nil`).
- **`finalize`** (resumable + non-resumable completion) — capture the `WriteObjectSpec` preconditions on the `uploadSession` (via `StartResumableWrite` and the `WriteObject`/`BidiWriteObject` first-message spec cases) and check them atomically at finalize (was `nil`).
- **`internal/gcp/grpc/status.go`** — map `412 → FAILED_PRECONDITION` and add the `"PreconditionFailed"` code alias. Needed because the provider's checked-delete returns a `412 PreconditionFailed` provider error, which previously fell through `GRPCStatus` to `codes.Internal` on the gRPC path.

Helpers added: `grpcObjectPrecondition` (proto `*int64` if_* → `gcs.Precondition`, nil when unset) and `preconditionResult` (raw `gcs.ErrPreconditionFailed` → `FAILED_PRECONDITION`).

## Not a duplicate of #48

#48 remains REST-side. This is the gRPC half it deferred; no overlap. Still open from #48's deferrals (separate, not touched here):
- REST `ObjectsCompose` destination precondition (`provider/storage/storage.go`).
- `BucketsUpdate` metageneration.

## Tests

- `TestComposeObjectDestinationPrecondition` — `if_generation_match=0` on an existing destination → `FAILED_PRECONDITION` and the destination is unchanged; succeeds on a new destination.
- `TestWriteObjectPrecondition` — single-shot create-only rejected on an existing object (bytes untouched) + matching-generation overwrite + create-only on new + **resumable** write carrying the precondition through to finalize.
- Existing `TestDeleteAndUpdatePreconditions` now exercises the atomic delete path.

## Verification

`go build ./...`, `go vet ./internal/gcp/grpc/...`, `go test -race ./internal/gcp/grpc/...` (incl. storage), `gofmt -l` clean.