### PR TITLE
fix(gcp): P1 quick wins (BigQuery startIndex/501s, Firestore removed_target_ids, bucket metageneration OCC, CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,9 @@ jobs:
       - name: Download modules
         run: |
           go mod download
-          for m in sdk sdk-rest sdk-firestore sdk-monitoring sdk-workflows sdk-dataproc sdk-datastore sdk-logging sdk-gcs-grpc sdk-managed-kafka sdk-bigquery sdk-metastore sdk-iceberg sdk-eventarc; do
-            (cd tests/integration/gcp/$m && go mod download)
+          for mod in tests/integration/gcp/*/go.mod; do
+            [ -f "$mod" ] || continue
+            (cd "${mod%/go.mod}" && go mod download)
           done
 
       - name: Build jaiscloud-gcp
@@ -174,6 +175,17 @@ jobs:
           for i in {1..60}; do
             if curl -sfS http://localhost:8080/_jaiscloud/health >/dev/null 2>&1; then
               echo "gcp server healthy"; exit 0
+            fi
+            sleep 1
+          done
+          cat gcp-server.log
+          exit 1
+
+      - name: Wait for gRPC listener
+        run: |
+          for i in $(seq 1 30); do
+            if (exec 3<>/dev/tcp/127.0.0.1/8081) 2>/dev/null; then
+              echo "grpc listener accepting connections"; exit 0
             fi
             sleep 1
           done

--- a/internal/gcp/adapter/bigquery.go
+++ b/internal/gcp/adapter/bigquery.go
@@ -3,6 +3,7 @@ package gcp
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"jaiscloud/internal/gcp/wire"
 	"jaiscloud/internal/model"
@@ -17,7 +18,10 @@ import (
 // share the same "projects/{project}" tail, so the segment scan below resolves
 // them identically. tabledata lives as trailing methods on a table path
 // (.../tables/{id}/insertAll and .../tables/{id}/data); jobs.delete is a DELETE
-// on .../jobs/{id}/delete (not a bare DELETE).
+// on .../jobs/{id}/delete (not a bare DELETE). The dataset-scoped routines and
+// models resources and the table-scoped rowAccessPolicies resource are deferred
+// by the emulator; they resolve to their own action names here so the provider
+// can fail loud with Unimplemented rather than the codec 404-ing them.
 type BigQueryCodec struct {
 	Service string
 }
@@ -98,16 +102,22 @@ func bigQueryAction(seg []string, method string) (action, datasetID, tableID, jo
 				return "DeleteDataset", seg[1], "", ""
 			}
 		case 3:
-			if seg[2] == "tables" {
+			switch seg[2] {
+			case "tables":
 				if method == http.MethodPost {
 					return "CreateTable", seg[1], "", ""
 				}
 				if method == http.MethodGet {
 					return "ListTables", seg[1], "", ""
 				}
+			case "routines":
+				return "Routines", seg[1], "", ""
+			case "models":
+				return "Models", seg[1], "", ""
 			}
 		case 4:
-			if seg[2] == "tables" {
+			switch seg[2] {
+			case "tables":
 				switch method {
 				case http.MethodGet:
 					return "GetTable", seg[1], seg[3], ""
@@ -118,10 +128,14 @@ func bigQueryAction(seg []string, method string) (action, datasetID, tableID, jo
 				case http.MethodDelete:
 					return "DeleteTable", seg[1], seg[3], ""
 				}
+			case "routines":
+				return "Routines", seg[1], "", ""
+			case "models":
+				return "Models", seg[1], "", ""
 			}
 		case 5:
 			if seg[2] == "tables" {
-				switch seg[4] {
+				switch resourceSegment(seg[4]) {
 				case "insertAll":
 					if method == http.MethodPost {
 						return "InsertAll", seg[1], seg[3], ""
@@ -130,7 +144,13 @@ func bigQueryAction(seg []string, method string) (action, datasetID, tableID, jo
 					if method == http.MethodGet {
 						return "ListRows", seg[1], seg[3], ""
 					}
+				case "rowAccessPolicies":
+					return "RowAccessPolicies", seg[1], seg[3], ""
 				}
+			}
+		case 6:
+			if seg[2] == "tables" && resourceSegment(seg[4]) == "rowAccessPolicies" {
+				return "RowAccessPolicies", seg[1], seg[3], ""
 			}
 		}
 	case "jobs":
@@ -175,6 +195,16 @@ func bigQueryAction(seg []string, method string) (action, datasetID, tableID, jo
 		}
 	}
 	return "", "", "", ""
+}
+
+// resourceSegment strips a trailing custom-method suffix (for example
+// "rowAccessPolicies:batchDelete") from a path segment, leaving the resource
+// type used to derive the action name.
+func resourceSegment(seg string) string {
+	if i := strings.IndexByte(seg, ':'); i >= 0 {
+		return seg[:i]
+	}
+	return seg
 }
 
 // Encode serialises a provider response as JSON.

--- a/internal/gcp/adapter/bigquery_test.go
+++ b/internal/gcp/adapter/bigquery_test.go
@@ -1,0 +1,59 @@
+package gcp
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBigQueryCodecDecode_DeferredResources(t *testing.T) {
+	cases := []struct {
+		method, path, action string
+	}{
+		// routines: collection + item, read + write.
+		{"GET", "/bigquery/v2/projects/p/datasets/d/routines", "Routines"},
+		{"POST", "/bigquery/v2/projects/p/datasets/d/routines", "Routines"},
+		{"GET", "/bigquery/v2/projects/p/datasets/d/routines/r", "Routines"},
+		{"DELETE", "/bigquery/v2/projects/p/datasets/d/routines/r", "Routines"},
+		// models: collection + item, read + write.
+		{"GET", "/bigquery/v2/projects/p/datasets/d/models", "Models"},
+		{"POST", "/bigquery/v2/projects/p/datasets/d/models", "Models"},
+		{"GET", "/bigquery/v2/projects/p/datasets/d/models/m", "Models"},
+		{"DELETE", "/bigquery/v2/projects/p/datasets/d/models/m", "Models"},
+		// rowAccessPolicies: table-scoped collection/item + custom method.
+		{"GET", "/bigquery/v2/projects/p/datasets/d/tables/tbl/rowAccessPolicies", "RowAccessPolicies"},
+		{"POST", "/bigquery/v2/projects/p/datasets/d/tables/tbl/rowAccessPolicies", "RowAccessPolicies"},
+		{"POST", "/bigquery/v2/projects/p/datasets/d/tables/tbl/rowAccessPolicies:batchDelete", "RowAccessPolicies"},
+		{"GET", "/bigquery/v2/projects/p/datasets/d/tables/tbl/rowAccessPolicies/rp", "RowAccessPolicies"},
+		{"DELETE", "/bigquery/v2/projects/p/datasets/d/tables/tbl/rowAccessPolicies/rp", "RowAccessPolicies"},
+		// WithEndpoint-stripped form (no bigquery/v2 servicePath).
+		{"GET", "/projects/p/datasets/d/routines", "Routines"},
+		{"GET", "/projects/p/datasets/d/models", "Models"},
+		{"GET", "/projects/p/datasets/d/tables/tbl/rowAccessPolicies", "RowAccessPolicies"},
+	}
+	for _, tc := range cases {
+		codec := &BigQueryCodec{Service: "bigquery"}
+		r := httptest.NewRequest(tc.method, tc.path, nil)
+		nr, err := codec.Decode(r, nil)
+		if err != nil {
+			t.Errorf("%s %s: %v", tc.method, tc.path, err)
+			continue
+		}
+		if nr.Action != tc.action {
+			t.Errorf("%s %s: action = %q, want %q", tc.method, tc.path, nr.Action, tc.action)
+		}
+	}
+}
+
+func TestDetectBigQueryDeferredResources(t *testing.T) {
+	cases := map[string]string{
+		"/bigquery/v2/projects/p/datasets/d/routines":                   "bigquery",
+		"/bigquery/v2/projects/p/datasets/d/tables/t/rowAccessPolicies": "bigquery",
+		"/projects/p/datasets/d/models":                                 "bigquery",
+	}
+	for path, want := range cases {
+		r := httptest.NewRequest("GET", path, nil)
+		if got, _ := DetectService(r); got != want {
+			t.Errorf("DetectService(%s) = %q, want %q", path, got, want)
+		}
+	}
+}

--- a/internal/gcp/grpc/firestore/listen.go
+++ b/internal/gcp/grpc/firestore/listen.go
@@ -317,8 +317,16 @@ func (ls *listenSession) sendDocumentChange(id int32, d firestorestore.Document)
 
 func (ls *listenSession) sendChange(id int32, ev firestoreprovider.ChangeEvent) error {
 	if ev.Doc == nil {
+		// A delete drops the document from every target that previously matched
+		// it. This engine resolves a ChangeEvent per target (the caller only
+		// invokes sendChange for targets where targetMatches is true), so the
+		// responding target is named in removed_target_ids, mirroring the
+		// TargetIds set on the DocumentChange path for non-delete events.
 		return ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_DocumentDelete{
-			DocumentDelete: &firestorepb.DocumentDelete{Document: ev.Name},
+			DocumentDelete: &firestorepb.DocumentDelete{
+				Document:         ev.Name,
+				RemovedTargetIds: []int32{id},
+			},
 		}})
 	}
 	return ls.sendDocumentChange(id, *ev.Doc)

--- a/internal/gcp/grpc/firestore/listen_test.go
+++ b/internal/gcp/grpc/firestore/listen_test.go
@@ -218,8 +218,63 @@ func TestListenCollectionRealTimeUpdates(t *testing.T) {
 	if dd == nil || dd.Document != listenParent+"/items/item1" {
 		t.Fatalf("expected DocumentDelete, got %v", responses[0])
 	}
+	if !containsTargetID(dd.RemovedTargetIds, 1) {
+		t.Fatalf("expected removed_target_ids to contain 1, got %v", dd.RemovedTargetIds)
+	}
 	if responses[1].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_NO_CHANGE {
 		t.Fatalf("expected NO_CHANGE after delete, got %v", responses[1])
+	}
+}
+
+func containsTargetID(ids []int32, want int32) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestListenDocumentDeleteRemovedTargetIds asserts that a delete which drops a
+// document out of a query target's result set names that target in
+// DocumentDelete.removed_target_ids, so a client can prune the document from
+// that target's result set (real Firestore semantics).
+func TestListenDocumentDeleteRemovedTargetIds(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	lctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	const tid int32 = 7
+	if err := stream.Send(addTargetReq(queryTarget(tid, "items"))); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	recvN(t, stream, 3, 3*time.Second) // ADD + CURRENT + NO_CHANGE
+
+	svc.CreateDocument(ctx, "test", "(default)", "items", "item1", map[string]*firestorestore.Value{
+		"title": firestorestore.StringVal("first item"),
+	})
+	responses := recvN(t, stream, 2, 3*time.Second) // DocumentChange + NO_CHANGE
+	if responses[0].GetDocumentChange() == nil {
+		t.Fatalf("expected DocumentChange, got %v", responses[0])
+	}
+
+	svc.DeleteDocument(ctx, "test", "(default)", "items/item1", nil)
+	responses = recvN(t, stream, 2, 3*time.Second) // DocumentDelete + NO_CHANGE
+	dd := responses[0].GetDocumentDelete()
+	if dd == nil {
+		t.Fatalf("expected DocumentDelete, got %v", responses[0])
+	}
+	if dd.Document != listenParent+"/items/item1" {
+		t.Fatalf("expected %q, got %q", listenParent+"/items/item1", dd.Document)
+	}
+	if !containsTargetID(dd.RemovedTargetIds, tid) {
+		t.Fatalf("expected removed_target_ids to contain %d, got %v", tid, dd.RemovedTargetIds)
 	}
 }
 

--- a/internal/gcp/grpc/storage/service.go
+++ b/internal/gcp/grpc/storage/service.go
@@ -176,7 +176,7 @@ func bucketToProto(m map[string]any) *storagepb.Bucket {
 	b := &storagepb.Bucket{
 		Name:           bucketResourceName(name),
 		BucketId:       name,
-		Metageneration: 1,
+		Metageneration: genToInt64(gcs.BucketMetageneration(m)),
 	}
 	if v, _ := m["location"].(string); v != "" {
 		b.Location = v

--- a/internal/gcp/provider/bigquery/bigquery.go
+++ b/internal/gcp/provider/bigquery/bigquery.go
@@ -3,13 +3,14 @@
 // datasets/tables/jobs are logical records only, jobs.query never evaluates
 // SQL (it stores the query and reports jobComplete=true with empty results),
 // and tabledata.insertAll stores streamed rows that tabledata.list reads back.
-// routines/models/rowAccessPolicies are deferred and route to Unimplemented.
+// tabledata.list honors startIndex (offset pagination) and echoes it in the
+// response. routines/models/rowAccessPolicies are deferred and route to an
+// explicit Unimplemented (501) rather than the codec's 404.
 //
 // Known limitations (emulator simplifications, documented rather than fixed):
 //   - tabledata.insertAll does not honor insertId/skipInvalidRows/
 //     ignoreUnknownValues/templateSuffix and performs no schema validation: it
 //     always streams the rows and returns an empty insertErrors list.
-//   - tabledata.list ignores startIndex (rows are returned from the first row).
 //   - List methods (datasets/tables/jobs) return full resource objects rather
 //     than the discovery-doc summary subsets (over-inclusion, tolerated by the
 //     SDK).
@@ -73,6 +74,9 @@ func (p *Provider) Routes() map[string]provider.HandlerFunc {
 		"BigQuery.Query":             p.Query,
 		"BigQuery.GetQueryResults":   p.GetQueryResults,
 		"BigQuery.GetServiceAccount": p.GetServiceAccount,
+		"BigQuery.Routines":          p.Routines,
+		"BigQuery.Models":            p.Models,
+		"BigQuery.RowAccessPolicies": p.RowAccessPolicies,
 	}
 }
 
@@ -545,6 +549,10 @@ func (p *Provider) ListRows(ctx context.Context, nr *model.NormalizedRequest) (*
 	if datasetID == "" || tableID == "" {
 		return nil, invalidArgument("datasetId and tableId are required")
 	}
+	startIndex, err := startIndexParam(nr)
+	if err != nil {
+		return nil, err
+	}
 	t, err := p.store.GetTable(ctx, projectOf(nr), datasetID, tableID)
 	if err != nil {
 		return nil, mapErr(err)
@@ -554,20 +562,45 @@ func (p *Provider) ListRows(ctx context.Context, nr *model.NormalizedRequest) (*
 	if err != nil {
 		return nil, err
 	}
+	total := int64(len(rows))
+	// startIndex offsets into the full row set; an out-of-range index yields an
+	// empty page rather than an error (matching the real API).
+	if startIndex > 0 {
+		if startIndex >= len(rows) {
+			rows = nil
+		} else {
+			rows = rows[startIndex:]
+		}
+	}
 	page, next := paging.Page(rows, func(r bqstore.Row) string { return fmt.Sprintf("%020d", r.Seq) }, pagingParams(nr.Params))
 	items := make([]any, 0, len(page))
 	for _, r := range page {
 		items = append(items, rowToTableRow(r.Data, fields))
 	}
 	resp := map[string]any{
-		"kind":      kindPrefix + "tableDataList",
-		"rows":      items,
-		"totalRows": strconv.FormatInt(int64(len(rows)), 10),
+		"kind":       kindPrefix + "tableDataList",
+		"rows":       items,
+		"totalRows":  strconv.FormatInt(total, 10),
+		"startIndex": strconv.Itoa(startIndex),
 	}
 	if next != "" {
 		resp["pageToken"] = next
 	}
 	return provider.OK(resp), nil
+}
+
+// startIndexParam parses the tabledata.list startIndex query parameter,
+// defaulting to 0. A non-numeric or negative value is InvalidArgument.
+func startIndexParam(nr *model.NormalizedRequest) (int, error) {
+	raw := strParam(nr, "startIndex")
+	if raw == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0, invalidArgument("startIndex must be a non-negative integer")
+	}
+	return n, nil
 }
 
 // --- Jobs ---
@@ -712,4 +745,28 @@ func (p *Provider) GetServiceAccount(ctx context.Context, nr *model.NormalizedRe
 		"kind":  kindPrefix + "getServiceAccountResponse",
 		"email": fmt.Sprintf("bq-%s@gcp-sa-bigquery.iam.gserviceaccount.com", projectOf(nr)),
 	}), nil
+}
+
+// --- Deferred resources ---
+
+// unimplementedResource fails loud with Unimplemented for the resource types
+// the emulator deliberately does not model, so clients get an explicit 501
+// rather than a misleading 404.
+func unimplementedResource(resource string) error {
+	return model.NewProviderError("Unimplemented", resource+" is not implemented by this emulator", 501)
+}
+
+// Routines handles the deferred dataset-scoped routines surface.
+func (p *Provider) Routines(_ context.Context, _ *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	return nil, unimplementedResource("routines")
+}
+
+// Models handles the deferred dataset-scoped models surface.
+func (p *Provider) Models(_ context.Context, _ *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	return nil, unimplementedResource("models")
+}
+
+// RowAccessPolicies handles the deferred table-scoped rowAccessPolicies surface.
+func (p *Provider) RowAccessPolicies(_ context.Context, _ *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	return nil, unimplementedResource("rowAccessPolicies")
 }

--- a/internal/gcp/provider/bigquery/bigquery_test.go
+++ b/internal/gcp/provider/bigquery/bigquery_test.go
@@ -269,6 +269,106 @@ func TestTableAndRowRoundTrip(t *testing.T) {
 	}
 }
 
+func TestListRowsStartIndex(t *testing.T) {
+	ctx := context.Background()
+	p := New(bqstore.NewMemoryStore())
+
+	if _, err := p.CreateDataset(ctx, newNR(map[string]any{"body": map[string]any{
+		"datasetReference": map[string]any{"datasetId": "d"},
+	}})); err != nil {
+		t.Fatalf("create dataset: %v", err)
+	}
+	if _, err := p.CreateTable(ctx, newNR(map[string]any{
+		"datasetId": "d",
+		"body": map[string]any{
+			"tableReference": map[string]any{"tableId": "t"},
+			"schema": map[string]any{
+				"fields": []any{map[string]any{"name": "id", "type": "INTEGER"}},
+			},
+		},
+	})); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	rawRows := make([]any, 0, 5)
+	for i := 0; i < 5; i++ {
+		rawRows = append(rawRows, map[string]any{"json": map[string]any{"id": i}})
+	}
+	if _, err := p.InsertAll(ctx, newNR(map[string]any{
+		"datasetId": "d",
+		"tableId":   "t",
+		"body":      map[string]any{"rows": rawRows},
+	})); err != nil {
+		t.Fatalf("insertAll: %v", err)
+	}
+
+	firstID := func(row any) any {
+		m, _ := row.(map[string]any)
+		cells, _ := m["f"].([]any)
+		if len(cells) == 0 {
+			return nil
+		}
+		cell, _ := cells[0].(map[string]any)
+		return cell["v"]
+	}
+
+	// startIndex=2 returns rows from index 2 and echoes startIndex.
+	list, err := p.ListRows(ctx, newNR(map[string]any{"datasetId": "d", "tableId": "t", "startIndex": "2"}))
+	if err != nil {
+		t.Fatalf("list rows startIndex=2: %v", err)
+	}
+	if list.Data["startIndex"] != "2" {
+		t.Errorf("startIndex echo = %v, want 2", list.Data["startIndex"])
+	}
+	if list.Data["totalRows"] != "5" {
+		t.Errorf("totalRows = %v, want 5", list.Data["totalRows"])
+	}
+	rows, _ := list.Data["rows"].([]any)
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows from startIndex 2, got %d", len(rows))
+	}
+	if got := firstID(rows[0]); got != float64(2) {
+		t.Errorf("first row id = %v, want 2", got)
+	}
+
+	// Out-of-range startIndex yields an empty page, not an error.
+	empty, err := p.ListRows(ctx, newNR(map[string]any{"datasetId": "d", "tableId": "t", "startIndex": "99"}))
+	if err != nil {
+		t.Fatalf("list rows with out-of-range startIndex: %v", err)
+	}
+	if rows, _ := empty.Data["rows"].([]any); len(rows) != 0 {
+		t.Errorf("expected no rows for out-of-range startIndex, got %d", len(rows))
+	}
+	if empty.Data["startIndex"] != "99" {
+		t.Errorf("startIndex echo = %v, want 99", empty.Data["startIndex"])
+	}
+
+	// Invalid startIndex → 400 InvalidArgument.
+	_, err = p.ListRows(ctx, newNR(map[string]any{"datasetId": "d", "tableId": "t", "startIndex": "abc"}))
+	if err == nil {
+		t.Fatalf("expected InvalidArgument for non-numeric startIndex")
+	}
+	if perr, ok := err.(*model.ProviderError); !ok || perr.Code != "InvalidArgument" || perr.HTTPStatus != 400 {
+		t.Fatalf("expected InvalidArgument/400, got %v", err)
+	}
+}
+
+func TestDeferredResourceOps_Unimplemented(t *testing.T) {
+	ctx := context.Background()
+	p := New(bqstore.NewMemoryStore())
+	routes := p.Routes()
+	for _, action := range []string{"BigQuery.Routines", "BigQuery.Models", "BigQuery.RowAccessPolicies"} {
+		h, ok := routes[action]
+		if !ok {
+			t.Fatalf("missing route %q", action)
+		}
+		_, err := h(ctx, newNR(nil))
+		perr, ok := err.(*model.ProviderError)
+		if !ok || perr.Code != "Unimplemented" || perr.HTTPStatus != 501 {
+			t.Errorf("%s: expected Unimplemented/501, got %v", action, err)
+		}
+	}
+}
+
 func TestJobAndQueryEmptyResults(t *testing.T) {
 	ctx := context.Background()
 	p := New(bqstore.NewMemoryStore())

--- a/internal/gcp/provider/storage/precondition_test.go
+++ b/internal/gcp/provider/storage/precondition_test.go
@@ -197,3 +197,95 @@ func TestObjectsDelete_IfGenerationMatch(t *testing.T) {
 		t.Fatal("expected the object to be gone after a matching conditional delete")
 	}
 }
+
+// TestBucketsUpdate_MetagenerationPrecondition verifies buckets.update honors
+// GCS's ifMetagenerationMatch/ifMetagenerationNotMatch preconditions atomically
+// with the write: a stale match is rejected with 412 and the bucket is left
+// unchanged, a matching one applies and advances the metageneration.
+func TestBucketsUpdate_MetagenerationPrecondition(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	created, err := p.BucketsInsert(ctx, nr)
+	if err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+	if got, _ := created.Data["metageneration"].(string); got != "1" {
+		t.Fatalf("new bucket metageneration = %q, want \"1\"", got)
+	}
+
+	get := func() (string, string) {
+		nr := bucketParams()
+		nr.Params["bucket"] = "bkt"
+		resp, err := p.BucketsGet(ctx, nr)
+		if err != nil {
+			t.Fatalf("get bucket: %v", err)
+		}
+		metagen, _ := resp.Data["metageneration"].(string)
+		sc, _ := resp.Data["storageClass"].(string)
+		return metagen, sc
+	}
+	update := func(params map[string]any, storageClass string) (*model.ProviderResponse, error) {
+		nr := bucketParams()
+		nr.Params["bucket"] = "bkt"
+		for k, v := range params {
+			nr.Params[k] = v
+		}
+		nr.Params["body"] = map[string]any{"storageClass": storageClass}
+		return p.BucketsUpdate(ctx, nr)
+	}
+
+	// Stale ifMetagenerationMatch: rejected, bucket unchanged.
+	if _, err := update(map[string]any{"ifMetagenerationMatch": "999"}, "NEARLINE"); err == nil {
+		t.Fatal("expected a stale ifMetagenerationMatch update to fail")
+	} else {
+		assertPrecondition412(t, err)
+	}
+	if metagen, sc := get(); metagen != "1" || sc != "STANDARD" {
+		t.Fatalf("rejected update must not apply: metageneration=%q storageClass=%q", metagen, sc)
+	}
+
+	// Matching ifMetagenerationMatch: applies and bumps 1 → 2.
+	resp, err := update(map[string]any{"ifMetagenerationMatch": "1"}, "NEARLINE")
+	if err != nil {
+		t.Fatalf("matching metageneration update: %v", err)
+	}
+	if got, _ := resp.Data["metageneration"].(string); got != "2" {
+		t.Fatalf("after update metageneration = %q, want \"2\"", got)
+	}
+	if metagen, sc := get(); metagen != "2" || sc != "NEARLINE" {
+		t.Fatalf("matching update not applied: metageneration=%q storageClass=%q", metagen, sc)
+	}
+
+	// The now-stale value is rejected again.
+	if _, err := update(map[string]any{"ifMetagenerationMatch": "1"}, "COLDLINE"); err == nil {
+		t.Fatal("expected the same now-stale match to fail")
+	} else {
+		assertPrecondition412(t, err)
+	}
+
+	// ifMetagenerationNotMatch fails when it equals the current metageneration…
+	if _, err := update(map[string]any{"ifMetagenerationNotMatch": "2"}, "COLDLINE"); err == nil {
+		t.Fatal("expected ifMetagenerationNotMatch=2 to fail against current 2")
+	} else {
+		assertPrecondition412(t, err)
+	}
+
+	// …and applies against a different one, bumping 2 → 3.
+	if _, err := update(map[string]any{"ifMetagenerationNotMatch": "1"}, "COLDLINE"); err != nil {
+		t.Fatalf("ifMetagenerationNotMatch against a different value: %v", err)
+	}
+	if metagen, sc := get(); metagen != "3" || sc != "COLDLINE" {
+		t.Fatalf("not-match update not applied: metageneration=%q storageClass=%q", metagen, sc)
+	}
+
+	// No precondition still bumps (3 → 4).
+	if _, err := update(nil, "STANDARD"); err != nil {
+		t.Fatalf("unconditional update: %v", err)
+	}
+	if metagen, _ := get(); metagen != "4" {
+		t.Fatalf("unconditional update metageneration = %q, want \"4\"", metagen)
+	}
+}

--- a/internal/gcp/provider/storage/storage.go
+++ b/internal/gcp/provider/storage/storage.go
@@ -233,6 +233,7 @@ type bucketMeta struct {
 	StorageClass    string         `json:"storageClass,omitempty"`
 	TimeCreated     string         `json:"timeCreated,omitempty"`
 	Updated         string         `json:"updated,omitempty"`
+	Metageneration  string         `json:"metageneration,omitempty"`
 	Versioning      map[string]any `json:"versioning,omitempty"`
 	RetentionPolicy map[string]any `json:"retentionPolicy,omitempty"`
 	Lifecycle       map[string]any `json:"lifecycle,omitempty"`
@@ -415,6 +416,26 @@ func objectPrecondition(nr *model.NormalizedRequest) *gcs.Precondition {
 	return &pre
 }
 
+// bucketPrecondition parses the bucket-level OCC preconditions GCS honors on
+// buckets.update: ifMetagenerationMatch/ifMetagenerationNotMatch. Returns nil
+// when neither is present (the common case).
+func bucketPrecondition(nr *model.NormalizedRequest) *gcs.Precondition {
+	var pre gcs.Precondition
+	set := false
+	if v, ok := parseInt64Param(nr, "ifMetagenerationMatch"); ok {
+		pre.MetagenerationMatch = &v
+		set = true
+	}
+	if v, ok := parseInt64Param(nr, "ifMetagenerationNotMatch"); ok {
+		pre.MetagenerationNotMatch = &v
+		set = true
+	}
+	if !set {
+		return nil
+	}
+	return &pre
+}
+
 func parseInt64Param(nr *model.NormalizedRequest, key string) (int64, bool) {
 	s, ok := nr.Params[key].(string)
 	if !ok || s == "" {
@@ -519,6 +540,7 @@ func (p *Provider) BucketsInsert(ctx context.Context, nr *model.NormalizedReques
 	b.Encryption = bodyMap(body, "encryption")
 	b.TimeCreated = clock.Now().Format(time.RFC3339Nano)
 	b.Updated = b.TimeCreated
+	b.Metageneration = "1"
 
 	if err := p.objects.CreateBucket(ctx, nr.AccountID, name, bucketToMap(b)); err != nil {
 		if errors.Is(err, gcs.ErrAlreadyExists) {
@@ -543,42 +565,51 @@ func (p *Provider) BucketsGet(ctx context.Context, nr *model.NormalizedRequest) 
 
 func (p *Provider) BucketsUpdate(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
 	name, _ := nr.Params["bucket"].(string)
-	meta, err := p.objects.GetBucket(ctx, name)
+	body, _ := nr.Params["body"].(map[string]any)
+	pre := bucketPrecondition(nr)
+	// The read-modify-write runs atomically in the store: the metageneration
+	// precondition is validated against the bucket's current meta, then the
+	// metageneration is bumped and the requested fields are applied, all under
+	// the same lock/transaction — so a concurrent update can't be lost and a
+	// stale precondition (checked against the same snapshot) can't slip through.
+	updated, err := p.objects.UpdateBucketMetaAtomic(ctx, name, func(meta map[string]any) (map[string]any, error) {
+		if !gcs.BucketMetagenerationMatches(meta, pre) {
+			return nil, gcs.ErrPreconditionFailed
+		}
+		b := mapToBucket(meta)
+		// Preserve timeCreated; update only fields present in the request body.
+		if loc, _ := body["location"].(string); loc != "" {
+			b.Location = loc
+		}
+		if sc, _ := body["storageClass"].(string); sc != "" {
+			b.StorageClass = sc
+		}
+		if _, ok := body["versioning"]; ok {
+			b.Versioning = bodyMap(body, "versioning")
+		}
+		if _, ok := body["retentionPolicy"]; ok {
+			b.RetentionPolicy = bodyMap(body, "retentionPolicy")
+		}
+		if _, ok := body["lifecycle"]; ok {
+			b.Lifecycle = bodyMap(body, "lifecycle")
+		}
+		if _, ok := body["encryption"]; ok {
+			b.Encryption = bodyMap(body, "encryption")
+		}
+		b.Metageneration = bumpMeta(gcs.BucketMetageneration(meta))
+		b.Updated = clock.Now().Format(time.RFC3339Nano)
+		return bucketToMap(b), nil
+	})
 	if err != nil {
 		if errors.Is(err, gcs.ErrNoSuchBucket) {
 			return nil, model.NewProviderError("NotFound", "bucket not found", 404)
 		}
-		return nil, err
-	}
-	b := mapToBucket(meta)
-	// Preserve timeCreated; update only fields present in the request body.
-	body, _ := nr.Params["body"].(map[string]any)
-	if loc, _ := body["location"].(string); loc != "" {
-		b.Location = loc
-	}
-	if sc, _ := body["storageClass"].(string); sc != "" {
-		b.StorageClass = sc
-	}
-	if _, ok := body["versioning"]; ok {
-		b.Versioning = bodyMap(body, "versioning")
-	}
-	if _, ok := body["retentionPolicy"]; ok {
-		b.RetentionPolicy = bodyMap(body, "retentionPolicy")
-	}
-	if _, ok := body["lifecycle"]; ok {
-		b.Lifecycle = bodyMap(body, "lifecycle")
-	}
-	if _, ok := body["encryption"]; ok {
-		b.Encryption = bodyMap(body, "encryption")
-	}
-	b.Updated = clock.Now().Format(time.RFC3339Nano)
-	if err := p.objects.UpdateBucketMeta(ctx, name, bucketToMap(b)); err != nil {
-		if errors.Is(err, gcs.ErrNoSuchBucket) {
-			return nil, model.NewProviderError("NotFound", "bucket not found", 404)
+		if errors.Is(err, gcs.ErrPreconditionFailed) {
+			return nil, model.NewProviderError("PreconditionFailed", "At least one of the pre-conditions you specified did not hold", 412)
 		}
 		return nil, err
 	}
-	return provider.OK(toBucketMap(b)), nil
+	return provider.OK(toBucketMap(mapToBucket(updated))), nil
 }
 
 func (p *Provider) BucketsDelete(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
@@ -1702,6 +1733,10 @@ func toBucketMap(b bucketMeta) map[string]any {
 	if versioning == nil {
 		versioning = map[string]any{"enabled": false}
 	}
+	metageneration := b.Metageneration
+	if metageneration == "" {
+		metageneration = "1"
+	}
 	out := map[string]any{
 		"kind":           "storage#bucket",
 		"id":             b.Name,
@@ -1712,7 +1747,7 @@ func toBucketMap(b bucketMeta) map[string]any {
 		"timeCreated":    b.TimeCreated,
 		"updated":        b.Updated,
 		"generation":     "0",
-		"metageneration": "1",
+		"metageneration": metageneration,
 		"projectNumber":  "0",
 		"selfLink":       "https://www.googleapis.com/storage/v1/b/" + b.Name,
 		"etag":           "CAE=",

--- a/internal/gcp/store/gcs/bucket_meta_test.go
+++ b/internal/gcp/store/gcs/bucket_meta_test.go
@@ -1,0 +1,114 @@
+package gcs
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+// bumpMetageneration applies the "N" → "N+1" increment a buckets.update would.
+func bumpMetageneration(m map[string]any) {
+	n, _ := strconv.Atoi(BucketMetageneration(m))
+	m["metageneration"] = strconv.Itoa(n + 1)
+}
+
+func TestMemoryObjectStoreBucketMetagenerationAtomic(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryObjectStore()
+	if err := s.CreateBucket(ctx, "proj", "bkt", nil); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	meta, err := s.GetBucket(ctx, "bkt")
+	if err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if meta["metageneration"] != "1" {
+		t.Fatalf("new bucket metageneration = %v, want \"1\"", meta["metageneration"])
+	}
+
+	// A successful atomic update bumps the metageneration and applies the field.
+	updated, err := s.UpdateBucketMetaAtomic(ctx, "bkt", func(m map[string]any) (map[string]any, error) {
+		bumpMetageneration(m)
+		m["storageClass"] = "NEARLINE"
+		return m, nil
+	})
+	if err != nil {
+		t.Fatalf("atomic update: %v", err)
+	}
+	if updated["metageneration"] != "2" || updated["storageClass"] != "NEARLINE" {
+		t.Fatalf("after update: %v", updated)
+	}
+
+	// A rejected precondition (sentinel) leaves the bucket untouched.
+	tooNew := int64(999)
+	if _, err := s.UpdateBucketMetaAtomic(ctx, "bkt", func(m map[string]any) (map[string]any, error) {
+		if !BucketMetagenerationMatches(m, &Precondition{MetagenerationMatch: &tooNew}) {
+			return nil, ErrPreconditionFailed
+		}
+		return m, nil
+	}); !errors.Is(err, ErrPreconditionFailed) {
+		t.Fatalf("expected ErrPreconditionFailed, got %v", err)
+	}
+	meta, _ = s.GetBucket(ctx, "bkt")
+	if meta["metageneration"] != "2" || meta["storageClass"] != "NEARLINE" {
+		t.Fatalf("rejected update must not apply: %v", meta)
+	}
+
+	// Matching precondition applies.
+	one := int64(2)
+	if _, err := s.UpdateBucketMetaAtomic(ctx, "bkt", func(m map[string]any) (map[string]any, error) {
+		if !BucketMetagenerationMatches(m, &Precondition{MetagenerationMatch: &one}) {
+			return nil, ErrPreconditionFailed
+		}
+		bumpMetageneration(m)
+		return m, nil
+	}); err != nil {
+		t.Fatalf("matching update: %v", err)
+	}
+	if meta, _ = s.GetBucket(ctx, "bkt"); meta["metageneration"] != "3" {
+		t.Fatalf("metageneration = %v after matching update, want \"3\"", meta["metageneration"])
+	}
+
+	// Missing bucket.
+	if _, err := s.UpdateBucketMetaAtomic(ctx, "missing", func(m map[string]any) (map[string]any, error) {
+		return m, nil
+	}); !errors.Is(err, ErrNoSuchBucket) {
+		t.Fatalf("expected ErrNoSuchBucket, got %v", err)
+	}
+}
+
+// TestMemoryObjectStoreBucketMetagenerationNoLostUpdates is the regression test
+// for the read-modify-write race AtomicUpdate closes: N concurrent updates each
+// increment the metageneration; without a lock spanning the read and the write,
+// increments would be lost and the final value would be less than N+1.
+func TestMemoryObjectStoreBucketMetagenerationNoLostUpdates(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryObjectStore()
+	if err := s.CreateBucket(ctx, "proj", "bkt", nil); err != nil {
+		t.Fatalf("create bucket: %v", err)
+	}
+	const n = 64
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := s.UpdateBucketMetaAtomic(ctx, "bkt", func(m map[string]any) (map[string]any, error) {
+				bumpMetageneration(m)
+				return m, nil
+			}); err != nil {
+				t.Errorf("atomic update: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	meta, err := s.GetBucket(ctx, "bkt")
+	if err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	if got := BucketMetageneration(meta); got != strconv.Itoa(n+1) {
+		t.Fatalf("metageneration = %s after %d concurrent updates, want %d (lost updates)", got, n, n+1)
+	}
+}

--- a/internal/gcp/store/gcs/memory.go
+++ b/internal/gcp/store/gcs/memory.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"jaiscloud/internal/clock"
+	"jaiscloud/internal/gcp/storeutil"
 )
 
 // MemoryObjectStore is an in-memory ObjectStore.
@@ -38,6 +39,7 @@ func (s *MemoryObjectStore) CreateBucket(_ context.Context, projectID, name stri
 	}
 	meta["name"] = name
 	meta["projectId"] = projectID
+	normalizeBucketMeta(meta)
 	s.buckets[name] = meta
 	return nil
 }
@@ -54,6 +56,7 @@ func (s *MemoryObjectStore) GetBucket(_ context.Context, name string) (map[strin
 	for k, v := range meta {
 		out[k] = v
 	}
+	normalizeBucketMeta(out)
 	return out, nil
 }
 
@@ -65,6 +68,34 @@ func (s *MemoryObjectStore) UpdateBucketMeta(_ context.Context, name string, met
 	}
 	s.buckets[name] = meta
 	return nil
+}
+
+func (s *MemoryObjectStore) UpdateBucketMetaAtomic(_ context.Context, name string, mutate func(meta map[string]any) (map[string]any, error)) (map[string]any, error) {
+	return storeutil.AtomicUpdate(&s.mu,
+		func() (map[string]any, bool) { meta, ok := s.buckets[name]; return meta, ok },
+		func(current map[string]any, exists bool) (map[string]any, error) {
+			if !exists {
+				return nil, ErrNoSuchBucket
+			}
+			// Mutate a copy so a precondition failure (or any error) leaves the
+			// stored map untouched rather than partially modified.
+			next := make(map[string]any, len(current))
+			for k, v := range current {
+				next[k] = v
+			}
+			next, err := mutate(next)
+			if err != nil {
+				return nil, err
+			}
+			if next == nil {
+				next = map[string]any{}
+			}
+			next["name"] = name
+			normalizeBucketMeta(next)
+			return next, nil
+		},
+		func(next map[string]any) { s.buckets[name] = next },
+	)
 }
 
 func (s *MemoryObjectStore) DeleteBucket(_ context.Context, name string) error {
@@ -95,6 +126,7 @@ func (s *MemoryObjectStore) ListBuckets(_ context.Context, projectID string) ([]
 			out[k] = v
 		}
 		out["name"] = name
+		normalizeBucketMeta(out)
 		result = append(result, out)
 	}
 	sort.Slice(result, func(i, j int) bool { return result[i]["name"].(string) < result[j]["name"].(string) })

--- a/internal/gcp/store/gcs/postgres.go
+++ b/internal/gcp/store/gcs/postgres.go
@@ -34,6 +34,7 @@ func (s *PostgresObjectStore) CreateBucket(ctx context.Context, projectID, name 
 	}
 	meta["name"] = name
 	meta["projectId"] = projectID
+	normalizeBucketMeta(meta)
 	loc, _ := meta["location"].(string)
 	sc, _ := meta["storageClass"].(string)
 	raw, _ := json.Marshal(meta)
@@ -64,6 +65,7 @@ func (s *PostgresObjectStore) GetBucket(ctx context.Context, name string) (map[s
 	if err := json.Unmarshal(raw, &meta); err != nil {
 		return nil, err
 	}
+	normalizeBucketMeta(meta)
 	return meta, nil
 }
 
@@ -77,6 +79,48 @@ func (s *PostgresObjectStore) UpdateBucketMeta(ctx context.Context, name string,
 		return ErrNoSuchBucket
 	}
 	return nil
+}
+
+// UpdateBucketMetaAtomic runs mutate against the bucket's current meta inside a
+// Serializable transaction that row-locks the bucket (SELECT ... FOR UPDATE),
+// then persists the result. The lock spans the read-mutate-write sequence, so a
+// precondition validated inside mutate cannot race a concurrent update — the
+// same discipline as the object *Checked methods above.
+func (s *PostgresObjectStore) UpdateBucketMetaAtomic(ctx context.Context, name string, mutate func(meta map[string]any) (map[string]any, error)) (map[string]any, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+	var raw []byte
+	err = tx.QueryRow(ctx, `SELECT meta FROM jc_gcs_buckets WHERE name=$1 FOR UPDATE`, name).Scan(&raw)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNoSuchBucket
+	}
+	if err != nil {
+		return nil, err
+	}
+	var current map[string]any
+	if err := json.Unmarshal(raw, &current); err != nil {
+		return nil, err
+	}
+	next, err := mutate(current)
+	if err != nil {
+		return nil, err
+	}
+	if next == nil {
+		next = map[string]any{}
+	}
+	next["name"] = name
+	normalizeBucketMeta(next)
+	out, _ := json.Marshal(next)
+	if _, err := tx.Exec(ctx, `UPDATE jc_gcs_buckets SET meta=$2 WHERE name=$1`, name, json.RawMessage(out)); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return next, nil
 }
 
 func (s *PostgresObjectStore) DeleteBucket(ctx context.Context, name string) error {
@@ -128,6 +172,7 @@ func (s *PostgresObjectStore) ListBuckets(ctx context.Context, projectID string)
 		}
 		var meta map[string]any
 		if json.Unmarshal(raw, &meta) == nil {
+			normalizeBucketMeta(meta)
 			result = append(result, meta)
 		}
 	}

--- a/internal/gcp/store/gcs/snapshot.go
+++ b/internal/gcp/store/gcs/snapshot.go
@@ -80,6 +80,7 @@ func (s *MemoryObjectStore) Restore(_ context.Context, r io.Reader) error {
 		if b.StorageClass != "" {
 			meta["storageClass"] = b.StorageClass
 		}
+		normalizeBucketMeta(meta)
 		buckets[b.Name] = meta
 	}
 	objects := make(map[string]map[string][]ObjectMeta)
@@ -193,6 +194,7 @@ func (s *PostgresObjectStore) Restore(ctx context.Context, r io.Reader) error {
 		if meta == nil {
 			meta = map[string]any{}
 		}
+		normalizeBucketMeta(meta)
 		if _, err := tx.Exec(ctx, `INSERT INTO jc_gcs_buckets (name, project_id, location, storage_class, meta) VALUES ($1,$2,$3,$4,$5)`,
 			b.Name, b.ProjectID, b.Location, b.StorageClass, json.RawMessage(mustJSON(meta))); err != nil {
 			return err

--- a/internal/gcp/store/gcs/store.go
+++ b/internal/gcp/store/gcs/store.go
@@ -30,6 +30,42 @@ var (
 	ErrPreconditionFailed = errors.New("PreconditionFailed")
 )
 
+// BucketMetageneration returns the bucket's metageneration as a decimal string,
+// defaulting to "1" for buckets persisted before the counter existed (and when
+// the stored value is missing or not a string).
+func BucketMetageneration(meta map[string]any) string {
+	if s, ok := meta["metageneration"].(string); ok && s != "" {
+		return s
+	}
+	return "1"
+}
+
+// normalizeBucketMeta ensures a bucket's metageneration field is present and a
+// decimal string, defaulting a legacy bucket to "1".
+func normalizeBucketMeta(meta map[string]any) {
+	if _, ok := meta["metageneration"].(string); !ok {
+		meta["metageneration"] = "1"
+	}
+}
+
+// BucketMetagenerationMatches reports whether p is satisfied by the bucket's
+// current metageneration. Buckets have no generation dimension, so only
+// MetagenerationMatch/MetagenerationNotMatch are consulted; a nil p matches,
+// mirroring objectPreconditionMatches' nil behavior.
+func BucketMetagenerationMatches(meta map[string]any, p *Precondition) bool {
+	if p == nil {
+		return true
+	}
+	metagen, _ := strconv.ParseInt(BucketMetageneration(meta), 10, 64)
+	if p.MetagenerationMatch != nil && metagen != *p.MetagenerationMatch {
+		return false
+	}
+	if p.MetagenerationNotMatch != nil && metagen == *p.MetagenerationNotMatch {
+		return false
+	}
+	return true
+}
+
 // Precondition is GCS's real per-request conditional-write precondition:
 // ifGenerationMatch / ifGenerationNotMatch / ifMetagenerationMatch /
 // ifMetagenerationNotMatch. A nil field means that condition wasn't
@@ -147,6 +183,14 @@ type ObjectStore interface {
 	CreateBucket(ctx context.Context, projectID, name string, meta map[string]any) error
 	GetBucket(ctx context.Context, name string) (map[string]any, error)
 	UpdateBucketMeta(ctx context.Context, name string, meta map[string]any) error
+	// UpdateBucketMetaAtomic atomically reads the bucket's current meta, applies
+	// mutate, and writes the result — holding the same lock (memory) or
+	// Serializable transaction with a row lock (postgres) across the read and
+	// the write, so a precondition checked inside mutate cannot race a
+	// concurrent update. Returns ErrNoSuchBucket when the bucket is absent;
+	// mutate may return ErrPreconditionFailed to abort without applying.
+	// The returned map is the persisted post-mutation meta.
+	UpdateBucketMetaAtomic(ctx context.Context, name string, mutate func(meta map[string]any) (map[string]any, error)) (map[string]any, error)
 	DeleteBucket(ctx context.Context, name string) error // ErrBucketNotEmpty if objects exist
 	ListBuckets(ctx context.Context, projectID string) ([]map[string]any, error)
 


### PR DESCRIPTION
## Summary

Closes the **P1 quick-win** tier from `plan_docs/gcp-deferred-debt-plan.md` §7 (four small, independent fixes, one commit each). The D6 gcs-connector spike is excluded (needs Docker Spark + an empirical pin — can't be verified here); it stays open.

## Commits

1. **`fix(gcp/bigquery): honor tabledata.list startIndex + 501 for routines/models/rowAccessPolicies`**
   - `tabledata.list` now parses/skips `startIndex` (default 0; non-numeric/negative → 400) and echoes it (string) with full `totalRows`.
   - `routines`/`models`/`rowAccessPolicies` previously fell through the codec to **404**; now they route to explicit **501 `Unimplemented`** (repo fail-loud convention).

2. **`fix(gcp/firestore): populate DocumentDelete.removed_target_ids on Listen`**
   - `Listen` deletes now set `removed_target_ids` (previously only `Document`). Faithful-to-Firestore interpretation: the responding target's ID, mirroring the existing per-target `DocumentChange{TargetIds}` shape.
   - *Flagged:* emits one `DocumentDelete` per matching target (singleton set) rather than one aggregated message — semantically equivalent for client result-set bookkeeping; the canonical multi-target aggregation and `DocumentChange.removed_target_ids` are out of scope (need per-target prior-match state).

3. **`fix(gcp/storage): bucket metageneration + ifMetagenerationMatch OCC in BucketsUpdate`**
   - Adds a bucket metageneration counter (default `"1"`, bumped on update; previously buckets had **none**).
   - `BucketsUpdate` honors `ifMetagenerationMatch`/`ifMetagenerationNotMatch` via a new **atomic** store method `UpdateBucketMetaAtomic` (`storeutil.AtomicUpdate` in memory / `Serializable` + `SELECT … FOR UPDATE` in postgres), so the check+bump+write is race-free — matching the OCC discipline from #44–#56. Mismatch → **412**.

4. **`ci(gcp): derive SDK module list + probe the gRPC listener`**
   - Replaces the hardcoded `for m in sdk …` list with a glob over `tests/integration/gcp/*/go.mod` (auto-discovers new modules; note `*/go.mod` not just `sdk-*/` so the `sdk` module isn't dropped).
   - Adds a dependency-free TCP liveness probe for the gRPC listener (`--grpc-port 8081`); the existing wait only probed the HTTP gateway.

## Verification

`go build ./...`, `go vet ./internal/gcp/...`, `go test -race` on the affected packages (bigquery/adapter/firestore/storage/gcs), full `./internal/gcp/...` suite clean, `gofmt -l` empty, `paginationcheck` clean, CI YAML validated. Postgres-tagged store test compiles (`go vet -tags gcp_persistence`).

## Not included

- §3.6 remainder (resumable-buffer spill / range-read decrypt) and §3.5 (`RewriteObject`/`MoveObject`/IAM) — P1 medium, follow-ups.
- §3.13 D6 gcs-connector pin spike — requires Docker Spark + empirical confirmation.