### PR TITLE
fix(gcp): P1 medium — GCS Rewrite/Move+IAM+spill, Pub/Sub StreamingPull flow-control, BigQuery insertAll

### DIFF
--- a/cmd/jaiscloud-gcp/main.go
+++ b/cmd/jaiscloud-gcp/main.go
@@ -322,6 +322,7 @@ func startCmd() *cobra.Command {
 			adminHandler.RegisterResetter(stores.resources)
 			adminHandler.RegisterResetter(stores.blobs)
 			adminHandler.RegisterResetter(storageP)
+			adminHandler.RegisterResetter(storageGRPC)
 			adminHandler.RegisterResetter(firestoreP)
 			adminHandler.RegisterResetter(firestoreGRPC)
 			adminHandler.RegisterPostRestoreHook(storageP)

--- a/cmd/jaiscloud-gcp/main.go
+++ b/cmd/jaiscloud-gcp/main.go
@@ -276,7 +276,7 @@ func startCmd() *cobra.Command {
 			kmsGRPC := grpckms.NewService(stores.keys, stores.resources, crypto.NewEnvelopeEncryptor(stores.keys), cfg.ProjectID)
 			loggingGRPC := grpclogging.NewService(stores.logEntries, cfg.ProjectID)
 			monitoringGRPC := grpcmonitoring.NewService(stores.monitoring, cfg.ProjectID)
-			storageGRPC := grpcstorage.NewService(stores.objects, storageP, cfg.ProjectID)
+			storageGRPC := grpcstorage.NewService(stores.objects, stores.resources, storageP, cfg.ProjectID)
 			datastoreGRPC := grpcdatastore.NewService(stores.entities, cfg.ProjectID)
 			gserv := grpcserver.NewServer(fmt.Sprintf(":%d", grpcPort))
 			firestorepb.RegisterFirestoreServer(gserv.GRPC(), firestoreGRPC)

--- a/internal/gcp/grpc/pubsub/service.go
+++ b/internal/gcp/grpc/pubsub/service.go
@@ -29,6 +29,7 @@ import (
 	"jaiscloud/internal/model"
 	"jaiscloud/internal/store"
 
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -578,9 +579,20 @@ func (s *Service) StreamingPull(stream pubsubpb.Subscriber_StreamingPullServer) 
 	}
 	retention := s.topicRetention(ctx, project, topicID)
 
+	// Flow control: honor the client's max_outstanding_messages /
+	// max_outstanding_bytes (0 or omitted = unlimited). The counters are scoped
+	// to this stream and track only messages this stream has sent and that are
+	// still unacked. Per the proto, these fields are only valid on the initial
+	// request; later values are ignored.
+	flow := newStreamFlowControl(first.GetMaxOutstandingMessages(), first.GetMaxOutstandingBytes())
+
 	// Handle the initial request's control fields.
-	s.applyStreamAcks(ctx, topicID, first)
-	s.applyStreamModifyDeadlines(ctx, topicID, first)
+	for _, id := range s.applyStreamAcks(ctx, topicID, first) {
+		flow.release(id)
+	}
+	for _, id := range s.applyStreamModifyDeadlines(ctx, topicID, first) {
+		flow.release(id)
+	}
 
 	// recvLoop consumes subsequent requests (acks / modify-deadlines) as they
 	// arrive, so message delivery is never blocked on the client's control flow.
@@ -592,14 +604,43 @@ func (s *Service) StreamingPull(stream pubsubpb.Subscriber_StreamingPullServer) 
 				recvErr <- err
 				return
 			}
-			s.applyStreamAcks(ctx, topicID, r)
-			s.applyStreamModifyDeadlines(ctx, topicID, r)
+			for _, id := range s.applyStreamAcks(ctx, topicID, r) {
+				flow.release(id)
+			}
+			for _, id := range s.applyStreamModifyDeadlines(ctx, topicID, r) {
+				flow.release(id)
+			}
 		}
 	}()
 
-	// sendLoop streams claimed messages until the stream is closed.
+	// sendLoop streams claimed messages until the stream is closed, never
+	// claiming more than the client's declared flow-control budget allows.
 	for {
-		msgs, err := s.messages.Pull(ctx, topicID, streamPullBatch, ackDeadline, retention, clock.Now())
+		budget := flow.claimBudget(streamPullBatch)
+		if budget <= 0 || flow.bytesExhausted() {
+			// At the client's limit: release any messages acked out of band
+			// (another stream / unary Acknowledge) and wait for a slot.
+			if stored, err := s.messages.List(ctx, topicID); err == nil {
+				flow.reconcile(stored)
+			}
+			if flow.claimBudget(1) <= 0 || flow.bytesExhausted() {
+				select {
+				case <-ctx.Done():
+					return nil
+				case err := <-recvErr:
+					if errors.Is(err, io.EOF) {
+						return nil
+					}
+					return err
+				case <-flow.wake:
+				case <-time.After(longPollInterval):
+				}
+				continue
+			}
+			budget = flow.claimBudget(streamPullBatch)
+		}
+
+		msgs, err := s.messages.Pull(ctx, topicID, budget, ackDeadline, retention, clock.Now())
 		if err != nil {
 			return mapError(err)
 		}
@@ -608,19 +649,40 @@ func (s *Service) StreamingPull(stream pubsubpb.Subscriber_StreamingPullServer) 
 			if err != nil {
 				return err
 			}
-			if len(received) > 0 {
-				if err := stream.Send(&pubsubpb.StreamingPullResponse{ReceivedMessages: received}); err != nil {
+			sendable := make([]*pubsubpb.ReceivedMessage, 0, len(received))
+			for _, rm := range received {
+				size := proto.Size(rm.GetMessage())
+				// Let a lone oversized message through when nothing is
+				// outstanding, so it cannot stall the stream forever.
+				allowOverflow := len(sendable) == 0 && flow.outstandingCount() == 0
+				if flow.reserve(rm.GetMessage().GetMessageId(), size, allowOverflow) {
+					sendable = append(sendable, rm)
+					continue
+				}
+				// Claimed but over the byte budget: make it visible again
+				// immediately instead of stranding it until the ack deadline.
+				if decoded, ok := decodeAckID(rm.GetAckId()); ok {
+					if parts := strings.SplitN(decoded, "/", 2); len(parts) == 2 {
+						_ = s.messages.ModifyAckDeadline(ctx, topicID, []string{decoded}, 0, clock.Now())
+					}
+				}
+			}
+			if len(sendable) > 0 {
+				if err := stream.Send(&pubsubpb.StreamingPullResponse{ReceivedMessages: sendable}); err != nil {
 					if errors.Is(err, io.EOF) {
 						return nil
 					}
 					return err
 				}
+				continue
 			}
-			continue
+			// Everything this poll claimed was over the byte budget; fall
+			// through to the wait so we don't busy-spin on re-claiming it.
 		}
 
-		// No messages: long-poll by waiting a short interval rather than
-		// busy-spinning, and stop promptly on stream close / context cancel.
+		// No sendable messages: long-poll by waiting a short interval rather
+		// than busy-spinning, and stop promptly on stream close / context
+		// cancel / a freed flow-control slot.
 		select {
 		case <-ctx.Done():
 			return nil
@@ -629,13 +691,17 @@ func (s *Service) StreamingPull(stream pubsubpb.Subscriber_StreamingPullServer) 
 				return nil
 			}
 			return err
+		case <-flow.wake:
 		case <-time.After(longPollInterval):
 		}
 	}
 }
 
-// applyStreamAcks acknowledges the ackIds in a StreamingPull request.
-func (s *Service) applyStreamAcks(ctx context.Context, topicID string, req *pubsubpb.StreamingPullRequest) {
+// applyStreamAcks acknowledges the ackIds in a StreamingPull request. It returns
+// the decoded message IDs so the caller can release them from the stream's
+// outstanding flow-control set.
+func (s *Service) applyStreamAcks(ctx context.Context, topicID string, req *pubsubpb.StreamingPullRequest) []string {
+	var acked []string
 	for _, a := range req.GetAckIds() {
 		decoded, ok := decodeAckID(a)
 		if !ok {
@@ -644,26 +710,38 @@ func (s *Service) applyStreamAcks(ctx context.Context, topicID string, req *pubs
 		parts := strings.SplitN(decoded, "/", 2)
 		if len(parts) == 2 {
 			_ = s.messages.Delete(ctx, parts[0], parts[1])
+			acked = append(acked, parts[1])
 		}
 	}
+	return acked
 }
 
 // applyStreamModifyDeadlines applies the parallel modifyDeadlineAckIds /
 // modifyDeadlineSeconds arrays, resetting each message's visibility deadline.
-func (s *Service) applyStreamModifyDeadlines(ctx context.Context, topicID string, req *pubsubpb.StreamingPullRequest) {
+// A deadline of 0 is a nack (immediately redeliverable), so those IDs are
+// returned for flow-control release; a positive extension keeps the message
+// outstanding.
+func (s *Service) applyStreamModifyDeadlines(ctx context.Context, topicID string, req *pubsubpb.StreamingPullRequest) []string {
 	ackIDs := req.GetModifyDeadlineAckIds()
 	seconds := req.GetModifyDeadlineSeconds()
 	n := len(seconds)
 	if len(ackIDs) < n {
 		n = len(ackIDs)
 	}
+	var nacked []string
 	for i := 0; i < n; i++ {
 		decoded, ok := decodeAckID(ackIDs[i])
 		if !ok {
 			continue
 		}
 		_ = s.messages.ModifyAckDeadline(ctx, topicID, []string{decoded}, int(seconds[i]), clock.Now())
+		if seconds[i] <= 0 {
+			if parts := strings.SplitN(decoded, "/", 2); len(parts) == 2 {
+				nacked = append(nacked, parts[1])
+			}
+		}
 	}
+	return nacked
 }
 
 func (s *Service) Acknowledge(ctx context.Context, req *pubsubpb.AcknowledgeRequest) (*emptypb.Empty, error) {

--- a/internal/gcp/grpc/pubsub/service_test.go
+++ b/internal/gcp/grpc/pubsub/service_test.go
@@ -315,6 +315,108 @@ func TestStreamingPullDeliversAndAcks(t *testing.T) {
 	stream.CloseSend()
 }
 
+func TestStreamingPullHonorsMaxOutstandingMessages(t *testing.T) {
+	pub, subc, _, _, cleanup := pubsubTestService(t)
+	defer cleanup()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const topic = "projects/test/topics/flow-topic"
+	const subscription = "projects/test/subscriptions/flow-sub"
+
+	if _, err := pub.CreateTopic(ctx, &pubsubpb.Topic{Name: topic}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	if _, err := subc.CreateSubscription(ctx, &pubsubpb.Subscription{Name: subscription, Topic: topic}); err != nil {
+		t.Fatalf("CreateSubscription: %v", err)
+	}
+	if _, err := pub.Publish(ctx, &pubsubpb.PublishRequest{
+		Topic: topic,
+		Messages: []*pubsubpb.PubsubMessage{
+			{Data: []byte("flow-1")},
+			{Data: []byte("flow-2")},
+			{Data: []byte("flow-3")},
+		},
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	stream, err := subc.StreamingPull(ctx)
+	if err != nil {
+		t.Fatalf("StreamingPull: %v", err)
+	}
+	if err := stream.Send(&pubsubpb.StreamingPullRequest{
+		Subscription:             subscription,
+		StreamAckDeadlineSeconds: 10,
+		MaxOutstandingMessages:   1,
+	}); err != nil {
+		t.Fatalf("StreamingPull Send: %v", err)
+	}
+
+	type recvResult struct {
+		msgs []*pubsubpb.ReceivedMessage
+		err  error
+	}
+	recvCh := make(chan recvResult, 4)
+	go func() {
+		for {
+			resp, err := stream.Recv()
+			if err != nil {
+				recvCh <- recvResult{err: err}
+				return
+			}
+			recvCh <- recvResult{msgs: resp.GetReceivedMessages()}
+		}
+	}()
+
+	// The first response must carry exactly one message: the batch is clamped
+	// to max_outstanding_messages=1.
+	var first *pubsubpb.ReceivedMessage
+	select {
+	case r := <-recvCh:
+		if r.err != nil {
+			t.Fatalf("StreamingPull Recv: %v", r.err)
+		}
+		if len(r.msgs) != 1 {
+			t.Fatalf("first response delivered %d messages, want 1", len(r.msgs))
+		}
+		first = r.msgs[0]
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the first message")
+	}
+
+	// While that message is unacked, no further messages may be delivered.
+	select {
+	case r := <-recvCh:
+		if r.err != nil {
+			t.Fatalf("StreamingPull Recv before ack: %v", r.err)
+		}
+		if len(r.msgs) != 0 {
+			t.Fatalf("received %d more messages before ack, want 0", len(r.msgs))
+		}
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// Acking the outstanding message frees the single slot, so the next message
+	// must be delivered.
+	if err := stream.Send(&pubsubpb.StreamingPullRequest{AckIds: []string{first.GetAckId()}}); err != nil {
+		t.Fatalf("StreamingPull ack Send: %v", err)
+	}
+	select {
+	case r := <-recvCh:
+		if r.err != nil {
+			t.Fatalf("StreamingPull Recv after ack: %v", r.err)
+		}
+		if len(r.msgs) != 1 {
+			t.Fatalf("after ack delivered %d messages, want 1", len(r.msgs))
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the message after ack")
+	}
+
+	stream.CloseSend()
+}
+
 func TestTestIamPermissionsFailsOpenOnMissingTopic(t *testing.T) {
 	_, _, iam, _, cleanup := pubsubTestService(t)
 	defer cleanup()

--- a/internal/gcp/grpc/pubsub/streamflow.go
+++ b/internal/gcp/grpc/pubsub/streamflow.go
@@ -1,0 +1,149 @@
+package pubsub
+
+import (
+	"sync"
+
+	pubsubstore "jaiscloud/internal/gcp/store/pubsub"
+)
+
+// streamFlowControl tracks the messages a single StreamingPull has sent to its
+// client that have not yet been acked or nacked, and throttles the stream's
+// send loop to the client-declared max_outstanding_messages /
+// max_outstanding_bytes. A limit <= 0 means unlimited (matching Pub/Sub), in
+// which case claimBudget reserves nothing and reserve always admits, so the
+// stream keeps its pre-flow-control behavior.
+//
+// The outstanding set is keyed by message ID, which makes release idempotent
+// (a double ack cannot underflow the counters) and prevents a redelivered
+// message from being counted twice. It is scoped to the stream: the shared
+// message store has no per-stream claim ownership, so an ack delivered over a
+// different stream is folded in by reconcile (see below) rather than by
+// release.
+type streamFlowControl struct {
+	mu          sync.Mutex
+	maxMsgs     int64
+	maxBytes    int64
+	outstanding map[string]int // messageID -> delivered size in bytes
+	bytes       int64
+	wake        chan struct{}
+}
+
+func newStreamFlowControl(maxMsgs, maxBytes int64) *streamFlowControl {
+	return &streamFlowControl{
+		maxMsgs:     maxMsgs,
+		maxBytes:    maxBytes,
+		outstanding: map[string]int{},
+		wake:        make(chan struct{}, 1),
+	}
+}
+
+// claimBudget returns how many messages the stream may claim in one poll given
+// the message-count limit and the requested batch size. It returns 0 when the
+// client's max_outstanding_messages is already reached, the batch when there is
+// room for at least that many (or no limit is set), and the remaining slots
+// otherwise.
+func (fc *streamFlowControl) claimBudget(batch int) int {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if fc.maxMsgs <= 0 {
+		return batch
+	}
+	remaining := int(fc.maxMsgs) - len(fc.outstanding)
+	if remaining <= 0 {
+		return 0
+	}
+	if remaining > batch {
+		return batch
+	}
+	return remaining
+}
+
+// bytesExhausted reports whether the byte limit is already spent, so no further
+// message can be admitted without exceeding it.
+func (fc *streamFlowControl) bytesExhausted() bool {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	return fc.maxBytes > 0 && fc.bytes >= fc.maxBytes
+}
+
+// reserve records a message as outstanding if it fits within both limits.
+// allowOverflow admits a message that alone exceeds max_outstanding_bytes, used
+// only when nothing is outstanding so an oversized message cannot stall the
+// stream forever. It returns false when the message must not be sent.
+func (fc *streamFlowControl) reserve(msgID string, size int, allowOverflow bool) bool {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if _, ok := fc.outstanding[msgID]; ok {
+		return true // already outstanding (redelivery): don't double-count
+	}
+	if fc.maxMsgs > 0 && int64(len(fc.outstanding)) >= fc.maxMsgs {
+		return false
+	}
+	if fc.maxBytes > 0 && fc.bytes+int64(size) > fc.maxBytes && !allowOverflow {
+		return false
+	}
+	fc.outstanding[msgID] = size
+	fc.bytes += int64(size)
+	return true
+}
+
+// release drops a message from the outstanding set after an ack or nack. It is
+// idempotent and wakes the send loop so a freed slot resumes delivery.
+func (fc *streamFlowControl) release(msgID string) {
+	fc.mu.Lock()
+	size, ok := fc.outstanding[msgID]
+	if ok {
+		delete(fc.outstanding, msgID)
+		fc.bytes -= int64(size)
+	}
+	fc.mu.Unlock()
+	if ok {
+		fc.signal()
+	}
+}
+
+// outstandingCount returns the number of messages currently outstanding.
+func (fc *streamFlowControl) outstandingCount() int {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	return len(fc.outstanding)
+}
+
+// outstandingIDs snapshots the outstanding message IDs.
+func (fc *streamFlowControl) outstandingIDs() []string {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	ids := make([]string, 0, len(fc.outstanding))
+	for id := range fc.outstanding {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// reconcile releases outstanding messages that are no longer present in the
+// store — i.e. acked by the client over a different stream or through the
+// unary Acknowledge RPC. Bounding this leak to one poll interval is what keeps
+// the stream from wedging forever when acks arrive out of band.
+func (fc *streamFlowControl) reconcile(stored []pubsubstore.Message) {
+	if fc.outstandingCount() == 0 {
+		return
+	}
+	live := make(map[string]struct{}, len(stored))
+	for _, m := range stored {
+		live[m.MessageID] = struct{}{}
+	}
+	for _, id := range fc.outstandingIDs() {
+		if _, ok := live[id]; !ok {
+			fc.release(id)
+		}
+	}
+}
+
+// signal wakes a send loop blocked on the flow-control limit without blocking
+// when a wake is already pending.
+func (fc *streamFlowControl) signal() {
+	select {
+	case fc.wake <- struct{}{}:
+	default:
+	}
+}

--- a/internal/gcp/grpc/pubsub/streamflow_test.go
+++ b/internal/gcp/grpc/pubsub/streamflow_test.go
@@ -1,0 +1,107 @@
+package pubsub
+
+import (
+	"testing"
+
+	pubsubstore "jaiscloud/internal/gcp/store/pubsub"
+)
+
+func TestStreamFlowControlClaimBudget(t *testing.T) {
+	// Unlimited when the client sets 0 or omits the limit.
+	if got := newStreamFlowControl(0, 0).claimBudget(100); got != 100 {
+		t.Fatalf("unlimited claimBudget = %d, want 100", got)
+	}
+
+	fc := newStreamFlowControl(1, 0)
+	if got := fc.claimBudget(100); got != 1 {
+		t.Fatalf("maxMsgs=1 empty claimBudget = %d, want 1", got)
+	}
+	if !fc.reserve("m1", 10, false) {
+		t.Fatal("reserve m1 = false, want true")
+	}
+	if got := fc.claimBudget(100); got != 0 {
+		t.Fatalf("maxMsgs=1 saturated claimBudget = %d, want 0", got)
+	}
+	// An ack frees the slot and delivery resumes.
+	fc.release("m1")
+	if got := fc.claimBudget(100); got != 1 {
+		t.Fatalf("maxMsgs=1 after release claimBudget = %d, want 1", got)
+	}
+
+	// A larger limit clamps the batch to the remaining slots.
+	fc = newStreamFlowControl(5, 0)
+	if !fc.reserve("a", 1, false) || !fc.reserve("b", 1, false) {
+		t.Fatal("reserve a,b = false, want true")
+	}
+	if got := fc.claimBudget(100); got != 3 {
+		t.Fatalf("maxMsgs=5 with 2 outstanding claimBudget = %d, want 3", got)
+	}
+	if got := fc.claimBudget(2); got != 2 {
+		t.Fatalf("batch smaller than remaining claimBudget = %d, want 2", got)
+	}
+}
+
+func TestStreamFlowControlReserveBytes(t *testing.T) {
+	fc := newStreamFlowControl(0, 10)
+	if !fc.reserve("m1", 6, false) {
+		t.Fatal("reserve m1 (6 bytes) = false, want true")
+	}
+	if fc.reserve("m2", 6, false) {
+		t.Fatal("reserve m2 (would total 12 > 10) = true, want false")
+	}
+	if fc.bytesExhausted() {
+		t.Fatal("bytesExhausted with 6/10 bytes = true, want false")
+	}
+	// Idempotent redelivery of an already-outstanding message stays admitted
+	// without double-counting bytes.
+	if !fc.reserve("m1", 6, false) {
+		t.Fatal("re-reserve m1 = false, want true")
+	}
+	fc.release("m1")
+	if fc.bytesExhausted() {
+		t.Fatal("bytesExhausted after release = true, want false")
+	}
+
+	// An oversized message is admitted once when nothing is outstanding, so it
+	// cannot deadlock the stream.
+	fc = newStreamFlowControl(0, 5)
+	if !fc.reserve("big", 100, true) {
+		t.Fatal("reserve oversized with allowOverflow = false, want true")
+	}
+	if !fc.bytesExhausted() {
+		t.Fatal("bytesExhausted after oversized reserve = false, want true")
+	}
+	if fc.reserve("next", 1, false) {
+		t.Fatal("reserve after oversized = true, want false")
+	}
+}
+
+func TestStreamFlowControlReleaseIdempotent(t *testing.T) {
+	fc := newStreamFlowControl(2, 100)
+	fc.reserve("m1", 10, false)
+	fc.release("m1")
+	fc.release("m1") // double release must not underflow the byte counter
+	if fc.outstandingCount() != 0 || fc.bytesExhausted() {
+		t.Fatalf("after double release count=%d bytes=%d, want 0/0", fc.outstandingCount(), fc.bytes)
+	}
+	if !fc.reserve("m1", 10, false) {
+		t.Fatal("re-reserve after double release = false, want true")
+	}
+}
+
+func TestStreamFlowControlReconcileReleasesAckedElsewhere(t *testing.T) {
+	fc := newStreamFlowControl(2, 0)
+	fc.reserve("a", 1, false)
+	fc.reserve("b", 1, false)
+
+	// Only "a" still exists in the store: "b" was acked out of band.
+	fc.reconcile([]pubsubstore.Message{{MessageID: "a"}})
+
+	if got := fc.outstandingCount(); got != 1 {
+		t.Fatalf("after reconcile count = %d, want 1", got)
+	}
+	ids := fc.outstandingIDs()
+	if len(ids) != 1 || ids[0] != "a" {
+		t.Fatalf("after reconcile outstanding = %v, want [a]", ids)
+	}
+}

--- a/internal/gcp/grpc/storage/service.go
+++ b/internal/gcp/grpc/storage/service.go
@@ -10,7 +10,9 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -52,7 +54,10 @@ type Service struct {
 	uploads map[string]*uploadSession // in-progress resumable uploads (in-memory)
 }
 
-// uploadSession accumulates the bytes of an in-progress resumable write.
+// uploadSession accumulates the bytes of an in-progress resumable write. Bytes
+// stay in buf up to resumableSpillThreshold; past that they spill to private
+// tmpFile so a large upload never buffers fully in memory (mirroring the REST
+// provider's spill model).
 type uploadSession struct {
 	bucket       string
 	object       string
@@ -63,9 +68,27 @@ type uploadSession struct {
 	cseKeySHA256 string
 	precondition *gcs.Precondition // from WriteObjectSpec's if_* fields; checked atomically at finalize
 	buf          []byte
+	tmpPath      string   // spill file path once the threshold is exceeded
+	tmpFile      *os.File // open handle for appending spilled bytes
 	length       int64
 	lastAccess   time.Time
 }
+
+// closeSpill closes and removes the session's spill file, if any. It is
+// idempotent and safe to call on both the finalize and error/reset paths.
+func (sess *uploadSession) closeSpill() {
+	if sess.tmpFile != nil {
+		sess.tmpFile.Close()
+		os.Remove(sess.tmpPath)
+		sess.tmpFile = nil
+		sess.tmpPath = ""
+	}
+}
+
+// resumableSpillThreshold is the in-memory buffer size beyond which a
+// resumable upload session spills its accumulated bytes to a temp file. It
+// matches the REST provider's threshold so both transports behave alike.
+const resumableSpillThreshold = 4 << 20 // 4 MiB
 
 // NewService returns a Cloud Storage v2 gRPC service backed by the shared
 // object store, the generic ResourceStore (IAM policies), and the REST
@@ -79,6 +102,18 @@ func NewService(objects gcs.ObjectStore, resources store.ResourceStore, provider
 		defaultProj: defaultProj,
 		uploads:     make(map[string]*uploadSession),
 	}
+}
+
+// Reset closes and removes every in-progress resumable session's spill file
+// and clears the session map. Implements admin.Resetter so /_jaiscloud/reset
+// does not leak temp files across test runs.
+func (s *Service) Reset(_ context.Context) {
+	s.mu.Lock()
+	for _, sess := range s.uploads {
+		sess.closeSpill()
+	}
+	s.uploads = make(map[string]*uploadSession)
+	s.mu.Unlock()
 }
 
 func mapError(err error) error { return grpcutil.GRPCStatus(err) }
@@ -1044,15 +1079,70 @@ func (s *Service) QueryWriteStatus(ctx context.Context, req *storagepb.QueryWrit
 // stream left off). A gap or overlap is an OutOfRange error, matching real
 // GCS. It runs under s.mu so a concurrent QueryWriteStatus read of sess.length
 // never races with an active write stream.
+//
+// Bytes accumulate in memory until they would cross resumableSpillThreshold, at
+// which point the buffer is flushed to a temp file and subsequent bytes are
+// appended there (mirroring the REST provider's spill model), so a large upload
+// never holds its whole payload in memory.
 func (s *Service) appendData(sess *uploadSession, writeOffset int64, content []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if writeOffset != sess.length {
 		return &model.ProviderError{Code: "OutOfRange", Message: "write offset does not match the persisted size", HTTPStatus: 400, Status: "OUT_OF_RANGE"}
 	}
-	sess.buf = append(sess.buf, content...)
+	if sess.tmpFile != nil {
+		if _, err := sess.tmpFile.Write(content); err != nil {
+			return fmt.Errorf("resumable upload: write spill file: %w", err)
+		}
+	} else if int64(len(sess.buf))+int64(len(content)) > resumableSpillThreshold {
+		if err := spillUploadSession(sess); err != nil {
+			return err
+		}
+		if _, err := sess.tmpFile.Write(content); err != nil {
+			return fmt.Errorf("resumable upload: write spill file: %w", err)
+		}
+	} else {
+		sess.buf = append(sess.buf, content...)
+	}
 	sess.length += int64(len(content))
 	return nil
+}
+
+// spillUploadSession flushes the in-memory buffer to a temp file and switches
+// the session to file-backed accumulation. The caller must hold s.mu.
+func spillUploadSession(sess *uploadSession) error {
+	f, err := os.CreateTemp("", "jaiscloud-gcp-grpc-resumable-*")
+	if err != nil {
+		return fmt.Errorf("resumable upload: create spill file: %w", err)
+	}
+	if _, err := f.Write(sess.buf); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return fmt.Errorf("resumable upload: flush spill file: %w", err)
+	}
+	sess.tmpFile = f
+	sess.tmpPath = f.Name()
+	sess.buf = nil
+	return nil
+}
+
+// sessionBytes returns the session's accumulated bytes, reading them back from
+// the spill file when the session spilled. It runs under s.mu so a concurrent
+// resume stream's append cannot race the read (appendData takes the same lock).
+func (s *Service) sessionBytes(sess *uploadSession) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if sess.tmpFile == nil {
+		return sess.buf, nil
+	}
+	if _, err := sess.tmpFile.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("resumable upload: seek spill file: %w", err)
+	}
+	data, err := io.ReadAll(sess.tmpFile)
+	if err != nil {
+		return nil, fmt.Errorf("resumable upload: read spill file: %w", err)
+	}
+	return data, nil
 }
 
 // finalize persists the accumulated bytes as a new object generation and
@@ -1080,7 +1170,11 @@ func (s *Service) finalize(ctx context.Context, project string, sess *uploadSess
 	if meta.ContentType == "" {
 		meta.ContentType = "application/octet-stream"
 	}
-	finalMeta, err := s.provider.PutObjectData(ctx, project, meta, sess.buf, versioned, priorBlobKey, true, sess.kmsKeyName, sess.cseKey, sess.cseKeySHA256, sess.precondition)
+	raw, err := s.sessionBytes(sess)
+	if err != nil {
+		return nil, err
+	}
+	finalMeta, err := s.provider.PutObjectData(ctx, project, meta, raw, versioned, priorBlobKey, true, sess.kmsKeyName, sess.cseKey, sess.cseKeySHA256, sess.precondition)
 	if err != nil {
 		// The caller maps the result to a gRPC status.
 		return nil, preconditionResult(err)
@@ -1095,6 +1189,16 @@ func (s *Service) WriteObject(stream storagepb.Storage_WriteObjectServer) error 
 	var uploadID string
 	project := ""
 	resumable := false
+
+	// A non-resumable session is local to this stream, so its spill file (if
+	// any) is removed when the stream ends, success or error. A resumable
+	// session stays in the upload map for a later resume and is cleaned up on
+	// finish (below) or Reset.
+	defer func() {
+		if sess != nil && !resumable {
+			sess.closeSpill()
+		}
+	}()
 
 	for {
 		req, err := stream.Recv()
@@ -1146,6 +1250,7 @@ func (s *Service) WriteObject(stream storagepb.Storage_WriteObjectServer) error 
 				s.mu.Lock()
 				delete(s.uploads, uploadID)
 				s.mu.Unlock()
+				sess.closeSpill()
 				_ = s.objects.DeleteResumable(ctx, uploadID)
 			}
 			return stream.SendAndClose(&storagepb.WriteObjectResponse{
@@ -1168,6 +1273,16 @@ func (s *Service) BidiWriteObject(stream storagepb.Storage_BidiWriteObjectServer
 	var uploadID string
 	project := ""
 	resumable := false
+
+	// A non-resumable session is local to this stream, so its spill file (if
+	// any) is removed when the stream ends, success or error. A resumable
+	// session stays in the upload map for a later resume and is cleaned up on
+	// finish (below) or Reset.
+	defer func() {
+		if sess != nil && !resumable {
+			sess.closeSpill()
+		}
+	}()
 
 	for {
 		req, err := stream.Recv()
@@ -1226,6 +1341,7 @@ func (s *Service) BidiWriteObject(stream storagepb.Storage_BidiWriteObjectServer
 				s.mu.Lock()
 				delete(s.uploads, uploadID)
 				s.mu.Unlock()
+				sess.closeSpill()
 				_ = s.objects.DeleteResumable(ctx, uploadID)
 			}
 			return stream.Send(&storagepb.BidiWriteObjectResponse{
@@ -1251,27 +1367,42 @@ func (s *Service) BidiWriteObject(stream storagepb.Storage_BidiWriteObjectServer
 
 // ─── reads ────────────────────────────────────────────────────────────────────
 
+// ReadObject streams an object (or a byte range of it) to the client.
+//
+// Range handling note: objects are stored as a single AES-256-GCM blob
+// (iv || ciphertext || tag) for both CSEK and the server/CMEK envelope. GCM
+// authenticates the entire ciphertext with one tag, so the requested window
+// cannot be decrypted without processing the whole blob — true partial
+// decryption is not feasible for the on-disk format. The closest safe
+// improvement is therefore: (1) decrypt exactly once per request (the provider
+// returns the full plaintext and the range is sliced as a view, with no copy),
+// and (2) detect a zero-byte range from the metadata and skip the blob read and
+// decryption entirely. Both paths preserve correctness.
 func (s *Service) ReadObject(req *storagepb.ReadObjectRequest, stream storagepb.Storage_ReadObjectServer) error {
 	ctx := stream.Context()
 	bucket := parseBucketName(req.GetBucket())
 	project := s.projectForBucket(ctx, bucket)
-
 	gen := ""
 	if req.GetGeneration() > 0 {
 		gen = int64ToGen(req.GetGeneration())
 	}
-	var cseKey []byte
-	if cop := req.GetCommonObjectRequestParams(); cop != nil {
-		cseKey, _ = cseKeyFromParams(cop)
+
+	// Resolve the byte range from metadata before touching the blob so a
+	// zero-length read never decrypts the object.
+	var meta gcs.ObjectMeta
+	var err error
+	if req.GetGeneration() > 0 {
+		meta, err = s.objects.GetObjectGeneration(ctx, bucket, req.GetObject(), gen)
+	} else {
+		meta, err = s.objects.GetObjectMeta(ctx, bucket, req.GetObject())
 	}
-	meta, plain, err := s.provider.GetObjectData(ctx, project, bucket, req.GetObject(), gen, cseKey)
 	if err != nil {
+		if errors.Is(err, gcs.ErrNoSuchObject) {
+			return mapError(model.NewProviderError("NotFound", "object not found", 404))
+		}
 		return mapError(err)
 	}
-
-	// Honor read_offset (negative = from end) and read_limit.
-	start, end := readRange(int64(len(plain)), req.GetReadOffset(), req.GetReadLimit())
-	data := plain[start:end]
+	start, end := readRange(meta.Size, req.GetReadOffset(), req.GetReadLimit())
 
 	// First message carries metadata + object checksums + content range.
 	first := &storagepb.ReadObjectResponse{
@@ -1280,12 +1411,40 @@ func (s *Service) ReadObject(req *storagepb.ReadObjectRequest, stream storagepb.
 		ContentRange: &storagepb.ContentRange{
 			Start:          start,
 			End:            end,
-			CompleteLength: int64(len(plain)),
+			CompleteLength: meta.Size,
 		},
 	}
+	if start == end {
+		// Zero-byte range: metadata-only response; no blob read/decrypt.
+		return stream.Send(first)
+	}
+
+	var cseKey []byte
+	if cop := req.GetCommonObjectRequestParams(); cop != nil {
+		cseKey, _ = cseKeyFromParams(cop)
+	}
+	readMeta, plain, err := s.provider.GetObjectData(ctx, project, bucket, req.GetObject(), gen, cseKey)
+	if err != nil {
+		return mapError(err)
+	}
+	meta = readMeta
+	// Defensive clamp: metadata size and the decrypted length should agree, but
+	// never index past the plaintext actually in hand.
+	if int64(len(plain)) < end {
+		end = int64(len(plain))
+	}
+	if start > end {
+		start = end
+	}
+	// Rebuild the envelope from the decrypted plaintext (the authoritative
+	// length) rather than the pre-decrypt metadata snapshot.
+	first.Metadata = objectToProto(meta)
+	first.ObjectChecksums = objectChecksumsFromMeta(meta)
+	first.ContentRange = &storagepb.ContentRange{Start: start, End: end, CompleteLength: int64(len(plain))}
 	if err := stream.Send(first); err != nil {
 		return err
 	}
+	data := plain[start:end]
 
 	// Stream the data in bounded chunks.
 	const chunk = 2 << 20 // 2 MiB

--- a/internal/gcp/grpc/storage/service.go
+++ b/internal/gcp/grpc/storage/service.go
@@ -17,12 +17,16 @@ import (
 	"sync"
 	"time"
 
+	iampb "cloud.google.com/go/iam/apiv1/iampb"
+
 	"jaiscloud/internal/clock"
 	grpcutil "jaiscloud/internal/gcp/grpc"
 	storagepb "jaiscloud/internal/gcp/grpc/storage/storagepb"
+	"jaiscloud/internal/gcp/policy"
 	storageprovider "jaiscloud/internal/gcp/provider/storage"
 	"jaiscloud/internal/gcp/store/gcs"
 	"jaiscloud/internal/model"
+	"jaiscloud/internal/store"
 
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -36,7 +40,11 @@ import (
 type Service struct {
 	storagepb.UnimplementedStorageServer
 
-	objects     gcs.ObjectStore
+	objects gcs.ObjectStore
+	// resources is the generic ResourceStore holding IAM policies. It is the
+	// same store the REST provider uses, so bucket/object policies set through
+	// either transport are visible to both.
+	resources   store.ResourceStore
 	provider    *storageprovider.Provider
 	defaultProj string
 
@@ -60,12 +68,13 @@ type uploadSession struct {
 }
 
 // NewService returns a Cloud Storage v2 gRPC service backed by the shared
-// object store and the REST provider (generation counter + byte/encryption
-// helpers). defaultProj is the config-default project used when a request
-// carries none.
-func NewService(objects gcs.ObjectStore, provider *storageprovider.Provider, defaultProj string) *Service {
+// object store, the generic ResourceStore (IAM policies), and the REST
+// provider (generation counter + byte/encryption helpers). defaultProj is the
+// config-default project used when a request carries none.
+func NewService(objects gcs.ObjectStore, resources store.ResourceStore, provider *storageprovider.Provider, defaultProj string) *Service {
 	return &Service{
 		objects:     objects,
+		resources:   resources,
 		provider:    provider,
 		defaultProj: defaultProj,
 		uploads:     make(map[string]*uploadSession),
@@ -258,6 +267,160 @@ func cseKeyFromParams(params *storagepb.CommonObjectRequestParams) ([]byte, stri
 	}
 	sum := sha256.Sum256(key)
 	return key, base64.StdEncoding.EncodeToString(sum[:])
+}
+
+// ─── IAM (bucket + object policies over the shared ResourceStore) ─────────────
+
+// parseIamResource resolves a gRPC Storage IAM resource name to the bucket and
+// (for object-scoped policies) the object. The recognized shapes are
+// "projects/_/buckets/{bucket}", "projects/_/buckets/{bucket}/objects/{object}",
+// and a bare "{bucket}". Managed folders are not supported.
+func parseIamResource(resource string) (bucket, object string, isObject, ok bool) {
+	rest, found := strings.CutPrefix(resource, "projects/_/buckets/")
+	if !found {
+		if resource != "" && !strings.Contains(resource, "/") {
+			return resource, "", false, true
+		}
+		return "", "", false, false
+	}
+	b, o, found := strings.Cut(rest, "/objects/")
+	if found {
+		if b == "" || o == "" {
+			return "", "", false, false
+		}
+		return b, o, true, true
+	}
+	if rest == "" || strings.Contains(rest, "/") {
+		return "", "", false, false
+	}
+	return rest, "", false, true
+}
+
+// iamPolicyKey returns the policy resource type and id for a bucket- or
+// object-scoped request. The ids match the REST provider's ("{bucket}" and
+// "{bucket}/{object}") so the two transports share stored policies.
+func iamPolicyKey(bucket, object string) (resourceType, id string) {
+	if object == "" {
+		return storageprovider.ResourceTypeBucketIAM, bucket
+	}
+	return storageprovider.ResourceTypeObjectIAM, bucket + "/" + object
+}
+
+// requireIamResource verifies the bucket or object backing an IAM request
+// exists, returning a NotFound provider error otherwise.
+func (s *Service) requireIamResource(ctx context.Context, bucket, object string) error {
+	if object != "" {
+		if _, err := s.objects.GetObjectMeta(ctx, bucket, object); err != nil {
+			if errors.Is(err, gcs.ErrNoSuchObject) {
+				return model.NewProviderError("NotFound", "object not found", 404)
+			}
+			return err
+		}
+		return nil
+	}
+	if _, err := s.objects.GetBucket(ctx, bucket); err != nil {
+		if errors.Is(err, gcs.ErrNoSuchBucket) {
+			return model.NewProviderError("NotFound", "bucket not found", 404)
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *Service) GetIamPolicy(ctx context.Context, req *iampb.GetIamPolicyRequest) (*iampb.Policy, error) {
+	bucket, object, _, ok := parseIamResource(req.GetResource())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	if err := s.requireIamResource(ctx, bucket, object); err != nil {
+		return nil, mapError(err)
+	}
+	rt, id := iamPolicyKey(bucket, object)
+	return policyToProto(policy.Load(ctx, s.resources, s.projectForBucket(ctx, bucket), rt, id)), nil
+}
+
+func (s *Service) SetIamPolicy(ctx context.Context, req *iampb.SetIamPolicyRequest) (*iampb.Policy, error) {
+	bucket, object, _, ok := parseIamResource(req.GetResource())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	if err := s.requireIamResource(ctx, bucket, object); err != nil {
+		return nil, mapError(err)
+	}
+	rt, id := iamPolicyKey(bucket, object)
+	pol, err := policy.Set(ctx, s.resources, s.projectForBucket(ctx, bucket), rt, id, protoPolicyToBody(req.GetPolicy()))
+	if err != nil {
+		return nil, mapError(err)
+	}
+	return policyToProto(pol), nil
+}
+
+func (s *Service) TestIamPermissions(ctx context.Context, req *iampb.TestIamPermissionsRequest) (*iampb.TestIamPermissionsResponse, error) {
+	bucket, object, _, ok := parseIamResource(req.GetResource())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid resource name", 400))
+	}
+	if err := s.requireIamResource(ctx, bucket, object); err != nil {
+		return nil, mapError(err)
+	}
+	return &iampb.TestIamPermissionsResponse{Permissions: policy.TestPermissions(req.GetPermissions())}, nil
+}
+
+// protoPolicyToBody converts a proto IAM policy into the map shape the shared
+// policy package persists (mirrors the KMS/Pub/Sub/Secret Manager services).
+func protoPolicyToBody(p *iampb.Policy) map[string]any {
+	body := map[string]any{}
+	if p == nil {
+		return body
+	}
+	bindings := make([]any, 0, len(p.GetBindings()))
+	for _, b := range p.GetBindings() {
+		members := make([]any, 0, len(b.GetMembers()))
+		for _, m := range b.GetMembers() {
+			members = append(members, m)
+		}
+		bindings = append(bindings, map[string]any{"role": b.GetRole(), "members": members})
+	}
+	body["bindings"] = bindings
+	if et := p.GetEtag(); len(et) > 0 {
+		body["etag"] = string(et)
+	}
+	if p.GetVersion() != 0 {
+		body["version"] = int(p.GetVersion())
+	}
+	return body
+}
+
+// policyToProto renders a stored policy as the proto IAM policy.
+func policyToProto(p policy.Policy) *iampb.Policy {
+	out := &iampb.Policy{Version: int32(p.Version)}
+	if p.Etag != "" {
+		out.Etag = []byte(p.Etag)
+	}
+	for _, b := range p.Bindings {
+		m, ok := b.(map[string]any)
+		if !ok {
+			continue
+		}
+		binding := &iampb.Binding{}
+		binding.Role, _ = m["role"].(string)
+		for _, v := range toStrings(m["members"]) {
+			binding.Members = append(binding.Members, v)
+		}
+		out.Bindings = append(out.Bindings, binding)
+	}
+	return out
+}
+
+func toStrings(v any) []string {
+	items, _ := v.([]any)
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		if s, ok := it.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // ─── buckets ──────────────────────────────────────────────────────────────────
@@ -656,6 +819,155 @@ func (s *Service) ComposeObject(ctx context.Context, req *storagepb.ComposeObjec
 	finalMeta, err := s.provider.PutObjectData(ctx, project, meta, buf.Bytes(), versioned, priorBlobKey, false, meta.KmsKeyName, nil, "", pre)
 	if err != nil {
 		return nil, mapError(preconditionResult(err))
+	}
+	return objectToProto(finalMeta), nil
+}
+
+// copySourceKey extracts the raw CSEK from a RewriteObjectRequest's
+// copy_source_encryption_key_bytes field (32 bytes); nil when absent. The
+// provider verifies it against the source object's stored key hash.
+func copySourceKey(req *storagepb.RewriteObjectRequest) []byte {
+	key := req.GetCopySourceEncryptionKeyBytes()
+	if len(key) != 32 {
+		return nil
+	}
+	return key
+}
+
+// rewriteDestinationMeta builds the destination metadata for a server-side
+// copy: a copy of the source metadata with a fresh generation, overridden by
+// the request's optional destination resource (contentType/metadata/
+// storageClass). kmsKey is the destination key (empty = server-DEK); the
+// emulator re-encrypts, so encryption fields from the source are cleared.
+func rewriteDestinationMeta(src gcs.ObjectMeta, dest *storagepb.Object, dstBucket, dstObject, generation, kmsKey string) gcs.ObjectMeta {
+	now := clock.Now()
+	meta := src
+	meta.Bucket = dstBucket
+	meta.Name = dstObject
+	meta.Generation = generation
+	meta.Metageneration = "1"
+	meta.TimeCreated = now
+	meta.Updated = now
+	meta.TimeDeleted = nil
+	meta.Retention = nil
+	meta.WrappedDEK = nil
+	meta.CSEKeySHA256 = ""
+	meta.KmsKeyName = kmsKey
+	if dest != nil {
+		if ct := dest.GetContentType(); ct != "" {
+			meta.ContentType = ct
+		}
+		if dest.GetMetadata() != nil {
+			meta.Metadata = dest.GetMetadata()
+		}
+		if sc := dest.GetStorageClass(); sc != "" {
+			meta.StorageClass = sc
+		}
+	}
+	return meta
+}
+
+// priorBlobKeyFor returns the blob key of the destination object's existing
+// live generation when the bucket is not versioned (so the overwrite can drop
+// the superseded blob); empty when versioned or absent.
+func (s *Service) priorBlobKeyFor(ctx context.Context, bucket, object string) string {
+	if s.provider.BucketVersioned(ctx, bucket) {
+		return ""
+	}
+	if prev, err := s.objects.GetObjectMeta(ctx, bucket, object); err == nil && prev.Generation != "" {
+		return storageprovider.BlobKey(bucket, object, prev.Generation)
+	}
+	return ""
+}
+
+// RewriteObject implements the server-side copy RPC. The emulator re-encrypts
+// on write, so it performs a full in-process copy of the source bytes +
+// metadata and records it as a single fresh destination generation
+// (done=true, no rewrite-token chunking). Destination preconditions are
+// enforced atomically by the provider's guarded write; source generation
+// selection and source preconditions are validated against the source meta.
+func (s *Service) RewriteObject(ctx context.Context, req *storagepb.RewriteObjectRequest) (*storagepb.RewriteResponse, error) {
+	srcBucket := parseBucketName(req.GetSourceBucket())
+	srcObject := req.GetSourceObject()
+	dstBucket := parseBucketName(req.GetDestinationBucket())
+	dstObject := req.GetDestinationName()
+	if srcBucket == "" || srcObject == "" || dstBucket == "" || dstObject == "" {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "rewrite requires source and destination object names", 400))
+	}
+
+	srcProject := s.projectForBucket(ctx, srcBucket)
+	srcGen := ""
+	if req.GetSourceGeneration() > 0 {
+		srcGen = int64ToGen(req.GetSourceGeneration())
+	}
+	srcKey := copySourceKey(req)
+	srcMeta, raw, err := s.provider.GetObjectData(ctx, srcProject, srcBucket, srcObject, srcGen, srcKey)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	if err := checkObjectPreconditions(srcMeta, req.IfSourceGenerationMatch, req.IfSourceGenerationNotMatch, req.IfSourceMetagenerationMatch, req.IfSourceMetagenerationNotMatch); err != nil {
+		return nil, mapError(err)
+	}
+
+	dstProject := s.projectForBucket(ctx, dstBucket)
+	versioned := s.provider.BucketVersioned(ctx, dstBucket)
+	dstKey, dstKeySHA := cseKeyFromParams(req.GetCommonObjectRequestParams())
+	meta := rewriteDestinationMeta(srcMeta, req.GetDestination(), dstBucket, dstObject, s.provider.NextGen(), req.GetDestinationKmsKey())
+
+	pre := grpcObjectPrecondition(req.IfGenerationMatch, req.IfGenerationNotMatch, req.IfMetagenerationMatch, req.IfMetagenerationNotMatch)
+	finalMeta, err := s.provider.PutObjectData(ctx, dstProject, meta, raw, versioned, s.priorBlobKeyFor(ctx, dstBucket, dstObject), true, meta.KmsKeyName, dstKey, dstKeySHA, pre)
+	if err != nil {
+		return nil, mapError(preconditionResult(err))
+	}
+	obj := objectToProto(finalMeta)
+	return &storagepb.RewriteResponse{
+		TotalBytesRewritten: finalMeta.Size,
+		ObjectSize:          finalMeta.Size,
+		Done:                true,
+		Resource:            obj,
+	}, nil
+}
+
+// MoveObject implements the move RPC for the single-live-generation emulator as
+// a copy-then-delete: the source bytes+metadata are written to the destination
+// under the destination preconditions, then the source is deleted under the
+// source preconditions. Both mutations go through the store's atomic *Checked
+// path (via the provider), so a precondition mismatch on either side is
+// rejected WITHOUT mutating that side. The two steps are not one transaction,
+// so a concurrent source mutation between them can leave both objects present;
+// the write is ordered first so a failure never loses the source's bytes.
+func (s *Service) MoveObject(ctx context.Context, req *storagepb.MoveObjectRequest) (*storagepb.Object, error) {
+	bucket := parseBucketName(req.GetBucket())
+	srcObject := req.GetSourceObject()
+	dstObject := req.GetDestinationObject()
+	if bucket == "" || srcObject == "" || dstObject == "" {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "move requires bucket, source and destination object names", 400))
+	}
+	if srcObject == dstObject {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "source and destination object must differ", 400))
+	}
+
+	project := s.projectForBucket(ctx, bucket)
+	srcMeta, raw, err := s.provider.GetObjectData(ctx, project, bucket, srcObject, "", nil)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	srcPre := grpcObjectPrecondition(req.IfSourceGenerationMatch, req.IfSourceGenerationNotMatch, req.IfSourceMetagenerationMatch, req.IfSourceMetagenerationNotMatch)
+	if err := checkObjectPreconditions(srcMeta, req.IfSourceGenerationMatch, req.IfSourceGenerationNotMatch, req.IfSourceMetagenerationMatch, req.IfSourceMetagenerationNotMatch); err != nil {
+		return nil, mapError(err)
+	}
+
+	versioned := s.provider.BucketVersioned(ctx, bucket)
+	meta := rewriteDestinationMeta(srcMeta, nil, bucket, dstObject, s.provider.NextGen(), "")
+	destPre := grpcObjectPrecondition(req.IfGenerationMatch, req.IfGenerationNotMatch, req.IfMetagenerationMatch, req.IfMetagenerationNotMatch)
+	finalMeta, err := s.provider.PutObjectData(ctx, project, meta, raw, versioned, s.priorBlobKeyFor(ctx, bucket, dstObject), true, "", nil, "", destPre)
+	if err != nil {
+		return nil, mapError(preconditionResult(err))
+	}
+
+	if err := s.provider.DeleteObjectData(ctx, bucket, srcObject, srcPre); err != nil {
+		return nil, mapError(err)
 	}
 	return objectToProto(finalMeta), nil
 }

--- a/internal/gcp/grpc/storage/service_test.go
+++ b/internal/gcp/grpc/storage/service_test.go
@@ -1,9 +1,12 @@
 package storage
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net"
+	"os"
 	"testing"
 
 	iampb "cloud.google.com/go/iam/apiv1/iampb"
@@ -882,5 +885,234 @@ func TestStorageIAMNotFound(t *testing.T) {
 		Resource: "projects/_/buckets/missing-bucket",
 	}); status.Code(err) != codes.NotFound {
 		t.Fatalf("TestIamPermissions missing bucket: code = %v, want NotFound (err=%v)", status.Code(err), err)
+	}
+}
+
+// ─── resumable spill ──────────────────────────────────────────────────────────
+
+func TestResumableUploadSpillsToTempFileAndCleansUp(t *testing.T) {
+	client, svc, cleanup := newStorageTestServer(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+
+	srw, err := client.StartResumableWrite(ctx, &storagepb.StartResumableWriteRequest{
+		WriteObjectSpec: &storagepb.WriteObjectSpec{
+			Resource: &storagepb.Object{Name: "spill-obj", Bucket: testBucket, ContentType: "application/octet-stream"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartResumableWrite: %v", err)
+	}
+	uploadID := srw.GetUploadId()
+
+	// Two sub-4-MiB chunks: each is under the gRPC default max message size,
+	// but together they cross resumableSpillThreshold and force a spill.
+	chunk1 := bytes.Repeat([]byte("x"), 3<<20)
+	chunk2 := bytes.Repeat([]byte("y"), 2<<20)
+	big := append(append([]byte{}, chunk1...), chunk2...)
+	stream, err := client.BidiWriteObject(ctx)
+	if err != nil {
+		t.Fatalf("BidiWriteObject: %v", err)
+	}
+	if err := stream.Send(&storagepb.BidiWriteObjectRequest{
+		FirstMessage: &storagepb.BidiWriteObjectRequest_UploadId{UploadId: uploadID},
+		WriteOffset:  0,
+		Data:         &storagepb.BidiWriteObjectRequest_ChecksummedData{ChecksummedData: &storagepb.ChecksummedData{Content: chunk1}},
+	}); err != nil {
+		t.Fatalf("BidiWriteObject send first chunk: %v", err)
+	}
+	if err := stream.Send(&storagepb.BidiWriteObjectRequest{
+		WriteOffset: int64(len(chunk1)),
+		Data:        &storagepb.BidiWriteObjectRequest_ChecksummedData{ChecksummedData: &storagepb.ChecksummedData{Content: chunk2}},
+	}); err != nil {
+		t.Fatalf("BidiWriteObject send second chunk: %v", err)
+	}
+	// A state lookup forces the server to process the preceding data messages
+	// before we inspect in-memory session state (client Send is asynchronous).
+	if err := stream.Send(&storagepb.BidiWriteObjectRequest{StateLookup: true}); err != nil {
+		t.Fatalf("BidiWriteObject send state lookup: %v", err)
+	}
+	if _, err := stream.Recv(); err != nil {
+		t.Fatalf("BidiWriteObject state lookup Recv: %v", err)
+	}
+
+	// The session must have spilled: bytes live in a temp file, not memory.
+	svc.mu.Lock()
+	sess := svc.uploads[uploadID]
+	spilled := sess != nil && sess.tmpFile != nil && sess.buf == nil
+	var tmpPath string
+	if spilled {
+		tmpPath = sess.tmpPath
+	}
+	svc.mu.Unlock()
+	if !spilled {
+		t.Fatal("expected the resumable session to spill to a temp file past the threshold")
+	}
+	if _, err := os.Stat(tmpPath); err != nil {
+		t.Fatalf("expected spill file %s to exist: %v", tmpPath, err)
+	}
+
+	if err := stream.Send(&storagepb.BidiWriteObjectRequest{FinishWrite: true}); err != nil {
+		t.Fatalf("BidiWriteObject send finish: %v", err)
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatalf("BidiWriteObject Recv: %v", err)
+	}
+	if resp.GetResource() == nil {
+		t.Fatalf("BidiWriteObject response = %v, want Resource", resp.GetWriteStatus())
+	}
+
+	if got := readObject(t, client, testBucket, "spill-obj"); !bytes.Equal(got, big) {
+		t.Fatalf("spilled round-trip: got %d bytes, want %d", len(got), len(big))
+	}
+	if _, err := os.Stat(tmpPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("spill file %s not removed after finalize (err=%v)", tmpPath, err)
+	}
+}
+
+func TestResetRemovesSpillFiles(t *testing.T) {
+	client, svc, cleanup := newStorageTestServer(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+
+	srw, err := client.StartResumableWrite(ctx, &storagepb.StartResumableWriteRequest{
+		WriteObjectSpec: &storagepb.WriteObjectSpec{
+			Resource: &storagepb.Object{Name: "reset-obj", Bucket: testBucket, ContentType: "application/octet-stream"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartResumableWrite: %v", err)
+	}
+	uploadID := srw.GetUploadId()
+
+	stream, err := client.BidiWriteObject(ctx)
+	if err != nil {
+		t.Fatalf("BidiWriteObject: %v", err)
+	}
+	chunk1 := bytes.Repeat([]byte("y"), 3<<20)
+	chunk2 := bytes.Repeat([]byte("z"), 2<<20)
+	if err := stream.Send(&storagepb.BidiWriteObjectRequest{
+		FirstMessage: &storagepb.BidiWriteObjectRequest_UploadId{UploadId: uploadID},
+		WriteOffset:  0,
+		Data:         &storagepb.BidiWriteObjectRequest_ChecksummedData{ChecksummedData: &storagepb.ChecksummedData{Content: chunk1}},
+	}); err != nil {
+		t.Fatalf("BidiWriteObject send first chunk: %v", err)
+	}
+	if err := stream.Send(&storagepb.BidiWriteObjectRequest{
+		WriteOffset: int64(len(chunk1)),
+		Data:        &storagepb.BidiWriteObjectRequest_ChecksummedData{ChecksummedData: &storagepb.ChecksummedData{Content: chunk2}},
+	}); err != nil {
+		t.Fatalf("BidiWriteObject send second chunk: %v", err)
+	}
+	// Synchronize with the server before inspecting session state.
+	if err := stream.Send(&storagepb.BidiWriteObjectRequest{StateLookup: true}); err != nil {
+		t.Fatalf("BidiWriteObject send state lookup: %v", err)
+	}
+	if _, err := stream.Recv(); err != nil {
+		t.Fatalf("BidiWriteObject state lookup Recv: %v", err)
+	}
+
+	svc.mu.Lock()
+	sess := svc.uploads[uploadID]
+	var tmpPath string
+	if sess != nil {
+		tmpPath = sess.tmpPath
+	}
+	svc.mu.Unlock()
+	if tmpPath == "" {
+		t.Fatal("expected a spilled session before Reset")
+	}
+
+	svc.Reset(ctx)
+	if _, err := os.Stat(tmpPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("spill file %s not removed by Reset (err=%v)", tmpPath, err)
+	}
+	if _, err := client.QueryWriteStatus(ctx, &storagepb.QueryWriteStatusRequest{UploadId: uploadID}); status.Code(err) != codes.NotFound {
+		t.Fatalf("QueryWriteStatus after Reset: code = %v, want NotFound (err=%v)", status.Code(err), err)
+	}
+}
+
+// ─── range reads ──────────────────────────────────────────────────────────────
+
+func TestReadObjectRange(t *testing.T) {
+	client, cleanup := storageTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+
+	payload := []byte("0123456789abcdefghij")
+	writeSingleShot(t, client, testBucket, "range-obj", "text/plain", payload)
+
+	stream, err := client.ReadObject(ctx, &storagepb.ReadObjectRequest{
+		Bucket: testBucket, Object: "range-obj", ReadOffset: 5, ReadLimit: 4,
+	})
+	if err != nil {
+		t.Fatalf("ReadObject: %v", err)
+	}
+	var out []byte
+	first := true
+	var cr *storagepb.ContentRange
+	for {
+		msg, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("ReadObject Recv: %v", err)
+		}
+		if first {
+			first = false
+			cr = msg.GetContentRange()
+			if msg.GetMetadata() == nil {
+				t.Fatal("ReadObject first message missing metadata")
+			}
+		}
+		if cd := msg.GetChecksummedData(); cd != nil {
+			out = append(out, cd.GetContent()...)
+		}
+	}
+	if string(out) != "5678" {
+		t.Fatalf("range read = %q, want 5678", out)
+	}
+	if cr.GetStart() != 5 || cr.GetEnd() != 9 || cr.GetCompleteLength() != int64(len(payload)) {
+		t.Fatalf("content range = %+v, want start=5 end=9 complete=%d", cr, len(payload))
+	}
+
+	// A whole-object read still round-trips.
+	if got := readObject(t, client, testBucket, "range-obj"); !bytes.Equal(got, payload) {
+		t.Fatalf("full read = %q, want %q", got, payload)
+	}
+
+	// A zero-length range (offset at EOF) returns metadata only and no data
+	// chunks; this path deliberately skips the blob read and decryption.
+	zero, err := client.ReadObject(ctx, &storagepb.ReadObjectRequest{
+		Bucket: testBucket, Object: "range-obj", ReadOffset: int64(len(payload)),
+	})
+	if err != nil {
+		t.Fatalf("ReadObject zero range: %v", err)
+	}
+	zeroMsgs := 0
+	for {
+		msg, err := zero.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("ReadObject zero range Recv: %v", err)
+		}
+		zeroMsgs++
+		if msg.GetChecksummedData() != nil {
+			t.Fatalf("zero-length range returned data: %q", msg.GetChecksummedData().GetContent())
+		}
+		cr := msg.GetContentRange()
+		if cr.GetStart() != int64(len(payload)) || cr.GetEnd() != int64(len(payload)) {
+			t.Fatalf("zero-length content range = %+v, want start=end=%d", cr, len(payload))
+		}
+	}
+	if zeroMsgs != 1 {
+		t.Fatalf("zero-length range messages = %d, want 1 (metadata only)", zeroMsgs)
 	}
 }

--- a/internal/gcp/grpc/storage/service_test.go
+++ b/internal/gcp/grpc/storage/service_test.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"testing"
 
+	iampb "cloud.google.com/go/iam/apiv1/iampb"
+
 	"jaiscloud/internal/blobfs"
 	gcpcrypto "jaiscloud/internal/gcp/crypto"
 	storagepb "jaiscloud/internal/gcp/grpc/storage/storagepb"
@@ -21,14 +23,17 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
-func storageTestService(t *testing.T) (storagepb.StorageClient, func()) {
+// newStorageTestServer starts an in-process gRPC Storage server and returns the
+// client plus the service itself (so tests can inspect in-memory session state,
+// e.g. the resumable spill file).
+func newStorageTestServer(t *testing.T) (storagepb.StorageClient, *Service, func()) {
 	t.Helper()
 	objects := gcs.NewMemoryObjectStore()
 	blobs := blobfs.NewMemoryBlobStore()
 	keys := kmsstore.NewMemoryStore()
 	resources := store.NewMemoryResourceStore()
 	provider := storageprovider.New(objects, resources, blobs, gcpcrypto.NewEnvelopeEncryptor(keys))
-	svc := NewService(objects, provider, "test-project")
+	svc := NewService(objects, resources, provider, "test-project")
 
 	ln, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
@@ -47,7 +52,13 @@ func storageTestService(t *testing.T) (storagepb.StorageClient, func()) {
 		conn.Close()
 		srv.Stop()
 	}
-	return storagepb.NewStorageClient(conn), cleanup
+	return storagepb.NewStorageClient(conn), svc, cleanup
+}
+
+func storageTestService(t *testing.T) (storagepb.StorageClient, func()) {
+	t.Helper()
+	client, _, cleanup := newStorageTestServer(t)
+	return client, cleanup
 }
 
 const testBucket = "projects/_/buckets/bucket-a"
@@ -584,5 +595,292 @@ func TestWriteObjectPrecondition(t *testing.T) {
 	}
 	if _, err := stream.Recv(); status.Code(err) != codes.FailedPrecondition {
 		t.Fatalf("resumable finalize with stale precondition: code = %v, want FailedPrecondition (err=%v)", status.Code(err), err)
+	}
+}
+
+// ─── RewriteObject ────────────────────────────────────────────────────────────
+
+func TestRewriteObjectCopiesBytesAndMetadata(t *testing.T) {
+	client, cleanup := storageTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+
+	src := writeSingleShot(t, client, testBucket, "rw-src", "text/plain", []byte("rewrite-payload"))
+	if _, err := client.UpdateObject(ctx, &storagepb.UpdateObjectRequest{
+		Object:     &storagepb.Object{Name: "rw-src", Bucket: testBucket, Metadata: map[string]string{"k": "v"}},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"metadata.k"}},
+	}); err != nil {
+		t.Fatalf("UpdateObject source: %v", err)
+	}
+
+	resp, err := client.RewriteObject(ctx, &storagepb.RewriteObjectRequest{
+		SourceBucket:      testBucket,
+		SourceObject:      "rw-src",
+		DestinationBucket: testBucket,
+		DestinationName:   "rw-dst",
+	})
+	if err != nil {
+		t.Fatalf("RewriteObject: %v", err)
+	}
+	if !resp.GetDone() {
+		t.Fatalf("RewriteObject done = false, want true")
+	}
+	if resp.GetObjectSize() != int64(len("rewrite-payload")) {
+		t.Fatalf("RewriteObject objectSize = %d, want %d", resp.GetObjectSize(), len("rewrite-payload"))
+	}
+	dst := resp.GetResource()
+	if dst.GetName() != "rw-dst" {
+		t.Fatalf("RewriteObject resource name = %q, want rw-dst", dst.GetName())
+	}
+	if dst.GetGeneration() == src.GetGeneration() {
+		t.Fatalf("destination generation = source generation %d, want a fresh generation", dst.GetGeneration())
+	}
+	if dst.GetContentType() != "text/plain" {
+		t.Fatalf("destination contentType = %q, want text/plain", dst.GetContentType())
+	}
+	if dst.GetMetadata()["k"] != "v" {
+		t.Fatalf("destination metadata = %v, want k=v", dst.GetMetadata())
+	}
+	if got := readObject(t, client, testBucket, "rw-dst"); string(got) != "rewrite-payload" {
+		t.Fatalf("rewritten content = %q, want rewrite-payload", got)
+	}
+	// Source is untouched by a rewrite.
+	if got := readObject(t, client, testBucket, "rw-src"); string(got) != "rewrite-payload" {
+		t.Fatalf("source content = %q, want rewrite-payload", got)
+	}
+}
+
+func TestRewriteObjectDestinationPrecondition(t *testing.T) {
+	client, cleanup := storageTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+
+	writeSingleShot(t, client, testBucket, "rw-p-src", "text/plain", []byte("SRC"))
+	writeSingleShot(t, client, testBucket, "rw-p-dst", "text/plain", []byte("OLD"))
+
+	zero := int64(0)
+	if _, err := client.RewriteObject(ctx, &storagepb.RewriteObjectRequest{
+		SourceBucket:      testBucket,
+		SourceObject:      "rw-p-src",
+		DestinationBucket: testBucket,
+		DestinationName:   "rw-p-dst",
+		IfGenerationMatch: &zero,
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("rewrite if_generation_match=0 on existing dest: code = %v, want FailedPrecondition (err=%v)", status.Code(err), err)
+	}
+	if got := readObject(t, client, testBucket, "rw-p-dst"); string(got) != "OLD" {
+		t.Fatalf("destination unchanged after rejected rewrite, got %q, want OLD", got)
+	}
+	if got := readObject(t, client, testBucket, "rw-p-src"); string(got) != "SRC" {
+		t.Fatalf("source unchanged after rejected rewrite, got %q, want SRC", got)
+	}
+
+	// A matching source generation is honored; a stale if_source_generation_match
+	// fails without writing the destination.
+	srcObj, err := client.GetObject(ctx, &storagepb.GetObjectRequest{Bucket: testBucket, Object: "rw-p-src"})
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	if _, err := client.RewriteObject(ctx, &storagepb.RewriteObjectRequest{
+		SourceBucket:            testBucket,
+		SourceObject:            "rw-p-src",
+		DestinationBucket:       testBucket,
+		DestinationName:         "rw-p-new",
+		IfSourceGenerationMatch: &zero,
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("rewrite stale if_source_generation_match: code = %v, want FailedPrecondition (err=%v)", status.Code(err), err)
+	}
+	if _, err := client.GetObject(ctx, &storagepb.GetObjectRequest{Bucket: testBucket, Object: "rw-p-new"}); status.Code(err) != codes.NotFound {
+		t.Fatalf("destination created despite source precondition failure: %v", err)
+	}
+
+	if _, err := client.RewriteObject(ctx, &storagepb.RewriteObjectRequest{
+		SourceBucket:            testBucket,
+		SourceObject:            "rw-p-src",
+		DestinationBucket:       testBucket,
+		DestinationName:         "rw-p-new",
+		IfSourceGenerationMatch: &srcObj.Generation,
+	}); err != nil {
+		t.Fatalf("rewrite with matching source generation: %v", err)
+	}
+	if got := readObject(t, client, testBucket, "rw-p-new"); string(got) != "SRC" {
+		t.Fatalf("rewritten content = %q, want SRC", got)
+	}
+}
+
+// ─── MoveObject ───────────────────────────────────────────────────────────────
+
+func TestMoveObjectLeavesSourceGoneAndDestPresent(t *testing.T) {
+	client, cleanup := storageTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+
+	writeSingleShot(t, client, testBucket, "mv-src", "text/plain", []byte("move-payload"))
+
+	moved, err := client.MoveObject(ctx, &storagepb.MoveObjectRequest{
+		Bucket:            testBucket,
+		SourceObject:      "mv-src",
+		DestinationObject: "mv-dst",
+	})
+	if err != nil {
+		t.Fatalf("MoveObject: %v", err)
+	}
+	if moved.GetName() != "mv-dst" {
+		t.Fatalf("MoveObject resource name = %q, want mv-dst", moved.GetName())
+	}
+	if got := readObject(t, client, testBucket, "mv-dst"); string(got) != "move-payload" {
+		t.Fatalf("moved content = %q, want move-payload", got)
+	}
+	if _, err := client.GetObject(ctx, &storagepb.GetObjectRequest{Bucket: testBucket, Object: "mv-src"}); status.Code(err) != codes.NotFound {
+		t.Fatalf("source after move: code = %v, want NotFound (err=%v)", status.Code(err), err)
+	}
+}
+
+func TestMoveObjectPreconditionsAndMissingSource(t *testing.T) {
+	client, cleanup := storageTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+
+	writeSingleShot(t, client, testBucket, "mv-p-src", "text/plain", []byte("SRC"))
+	writeSingleShot(t, client, testBucket, "mv-p-dst", "text/plain", []byte("OLD"))
+
+	// Destination create-only precondition rejects the move; the source stays.
+	zero := int64(0)
+	if _, err := client.MoveObject(ctx, &storagepb.MoveObjectRequest{
+		Bucket:            testBucket,
+		SourceObject:      "mv-p-src",
+		DestinationObject: "mv-p-dst",
+		IfGenerationMatch: &zero,
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("move destination precondition: code = %v, want FailedPrecondition (err=%v)", status.Code(err), err)
+	}
+	if got := readObject(t, client, testBucket, "mv-p-dst"); string(got) != "OLD" {
+		t.Fatalf("destination unchanged after rejected move, got %q, want OLD", got)
+	}
+	if got := readObject(t, client, testBucket, "mv-p-src"); string(got) != "SRC" {
+		t.Fatalf("source removed despite rejected move, got %q, want SRC", got)
+	}
+
+	// A missing source is NotFound.
+	if _, err := client.MoveObject(ctx, &storagepb.MoveObjectRequest{
+		Bucket:            testBucket,
+		SourceObject:      "mv-p-missing",
+		DestinationObject: "mv-p-new",
+	}); status.Code(err) != codes.NotFound {
+		t.Fatalf("move missing source: code = %v, want NotFound (err=%v)", status.Code(err), err)
+	}
+}
+
+// ─── IAM ──────────────────────────────────────────────────────────────────────
+
+func TestStorageBucketIAMRoundTrip(t *testing.T) {
+	client, cleanup := storageTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+
+	got, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: testBucket})
+	if err != nil {
+		t.Fatalf("GetIamPolicy: %v", err)
+	}
+	if got.GetEtag() == nil {
+		t.Fatalf("GetIamPolicy etag is empty, want a default etag")
+	}
+
+	set, err := client.SetIamPolicy(ctx, &iampb.SetIamPolicyRequest{
+		Resource: testBucket,
+		Policy: &iampb.Policy{
+			Bindings: []*iampb.Binding{
+				{Role: "roles/storage.objectViewer", Members: []string{"user:alice@example.com"}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SetIamPolicy: %v", err)
+	}
+	if len(set.GetBindings()) != 1 || set.GetBindings()[0].GetRole() != "roles/storage.objectViewer" {
+		t.Fatalf("SetIamPolicy bindings = %v, want objectViewer", set.GetBindings())
+	}
+
+	got, err = client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: testBucket})
+	if err != nil {
+		t.Fatalf("GetIamPolicy after set: %v", err)
+	}
+	if len(got.GetBindings()) != 1 || got.GetBindings()[0].GetMembers()[0] != "user:alice@example.com" {
+		t.Fatalf("GetIamPolicy round-trip bindings = %v", got.GetBindings())
+	}
+
+	perms, err := client.TestIamPermissions(ctx, &iampb.TestIamPermissionsRequest{
+		Resource:    testBucket,
+		Permissions: []string{"storage.buckets.get", "storage.objects.list"},
+	})
+	if err != nil {
+		t.Fatalf("TestIamPermissions: %v", err)
+	}
+	if len(perms.GetPermissions()) != 2 {
+		t.Fatalf("TestIamPermissions = %v, want both permissions", perms.GetPermissions())
+	}
+}
+
+func TestStorageObjectIAMRoundTrip(t *testing.T) {
+	client, cleanup := storageTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+	writeSingleShot(t, client, testBucket, "iam-obj", "text/plain", []byte("data"))
+
+	const res = testBucket + "/objects/iam-obj"
+	if _, err := client.SetIamPolicy(ctx, &iampb.SetIamPolicyRequest{
+		Resource: res,
+		Policy: &iampb.Policy{
+			Bindings: []*iampb.Binding{
+				{Role: "roles/storage.objectAdmin", Members: []string{"serviceAccount:svc@example.com"}},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("SetIamPolicy(object): %v", err)
+	}
+	got, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: res})
+	if err != nil {
+		t.Fatalf("GetIamPolicy(object): %v", err)
+	}
+	if len(got.GetBindings()) != 1 || got.GetBindings()[0].GetRole() != "roles/storage.objectAdmin" {
+		t.Fatalf("object IAM bindings = %v, want objectAdmin", got.GetBindings())
+	}
+	// The bucket policy is stored under a separate id and stays empty.
+	bucketPol, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: testBucket})
+	if err != nil {
+		t.Fatalf("GetIamPolicy(bucket): %v", err)
+	}
+	if len(bucketPol.GetBindings()) != 0 {
+		t.Fatalf("bucket IAM unexpectedly shares object bindings: %v", bucketPol.GetBindings())
+	}
+}
+
+func TestStorageIAMNotFound(t *testing.T) {
+	client, cleanup := storageTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+
+	if _, err := client.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{
+		Resource: "projects/_/buckets/missing-bucket",
+	}); status.Code(err) != codes.NotFound {
+		t.Fatalf("GetIamPolicy missing bucket: code = %v, want NotFound (err=%v)", status.Code(err), err)
+	}
+	if _, err := client.SetIamPolicy(ctx, &iampb.SetIamPolicyRequest{
+		Resource: testBucket + "/objects/missing-obj",
+		Policy:   &iampb.Policy{},
+	}); status.Code(err) != codes.NotFound {
+		t.Fatalf("SetIamPolicy missing object: code = %v, want NotFound (err=%v)", status.Code(err), err)
+	}
+	if _, err := client.TestIamPermissions(ctx, &iampb.TestIamPermissionsRequest{
+		Resource: "projects/_/buckets/missing-bucket",
+	}); status.Code(err) != codes.NotFound {
+		t.Fatalf("TestIamPermissions missing bucket: code = %v, want NotFound (err=%v)", status.Code(err), err)
 	}
 }

--- a/internal/gcp/provider/bigquery/bigquery.go
+++ b/internal/gcp/provider/bigquery/bigquery.go
@@ -8,9 +8,13 @@
 // explicit Unimplemented (501) rather than the codec's 404.
 //
 // Known limitations (emulator simplifications, documented rather than fixed):
-//   - tabledata.insertAll does not honor insertId/skipInvalidRows/
-//     ignoreUnknownValues/templateSuffix and performs no schema validation: it
-//     always streams the rows and returns an empty insertErrors list.
+//   - tabledata.insertAll honors insertId (best-effort duplicate suppression
+//     over a bounded, TTL'd per-table window), skipInvalidRows,
+//     ignoreUnknownValues and the table schema (missing REQUIRED fields and
+//     unknown fields), reporting per-row insertErrors. insertId dedup is
+//     process-local and not persisted across store snapshots/restarts.
+//     templateSuffix is not supported and field *types* are not enforced (only
+//     presence/unknown-field checks).
 //   - List methods (datasets/tables/jobs) return full resource objects rather
 //     than the discovery-doc summary subsets (over-inclusion, tolerated by the
 //     SDK).
@@ -28,6 +32,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"jaiscloud/internal/clock"
@@ -474,6 +479,95 @@ func (p *Provider) DeleteTable(ctx context.Context, nr *model.NormalizedRequest)
 
 // --- Tabledata ---
 
+// insertError is one entry in a row's insertErrors[].errors list.
+type insertError struct {
+	Reason   string
+	Location string
+	Message  string
+}
+
+func (e insertError) toMap() map[string]any {
+	return map[string]any{
+		"reason":    e.Reason,
+		"location":  e.Location,
+		"message":   e.Message,
+		"debugInfo": "",
+	}
+}
+
+// schemaField is one top-level field of a table schema.
+type schemaField struct {
+	Name   string        `json:"name"`
+	Mode   string        `json:"mode"`
+	Type   string        `json:"type"`
+	Fields []schemaField `json:"fields"`
+}
+
+// parseSchemaFields extracts the top-level fields from a table's schema JSON.
+// A missing/empty/unparseable schema yields nil, which callers treat as "no
+// schema validation" so tables without one keep accepting any row.
+func parseSchemaFields(schema json.RawMessage) []schemaField {
+	if len(schema) == 0 {
+		return nil
+	}
+	var s struct {
+		Fields []schemaField `json:"fields"`
+	}
+	if json.Unmarshal(schema, &s) != nil {
+		return nil
+	}
+	return s.Fields
+}
+
+// validateRow checks row against the table's top-level fields. A field is
+// required only when its mode is explicitly REQUIRED (BigQuery's default mode
+// is NULLABLE). Unknown fields are rejected unless ignoreUnknownValues is set.
+// Field value types are not checked — only presence and unknown-field names.
+func validateRow(row map[string]any, fields []schemaField, ignoreUnknownValues bool) []insertError {
+	if len(fields) == 0 {
+		return nil
+	}
+	known := make(map[string]bool, len(fields))
+	for _, f := range fields {
+		known[f.Name] = true
+	}
+	var errs []insertError
+	for _, f := range fields {
+		if !strings.EqualFold(f.Mode, "REQUIRED") {
+			continue
+		}
+		if v, ok := row[f.Name]; !ok || v == nil {
+			errs = append(errs, insertError{
+				Reason:   "invalid",
+				Location: f.Name,
+				Message:  fmt.Sprintf("missing required field %q", f.Name),
+			})
+		}
+	}
+	if !ignoreUnknownValues {
+		keys := make([]string, 0, len(row))
+		for k := range row {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if !known[k] {
+				errs = append(errs, insertError{
+					Reason:   "invalid",
+					Location: k,
+					Message:  fmt.Sprintf("no such field: %s", k),
+				})
+			}
+		}
+	}
+	return errs
+}
+
+func boolValue(m map[string]any, key string) bool {
+	b, _ := m[key].(bool)
+	return b
+}
+
 func (p *Provider) InsertAll(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
 	datasetID := strParam(nr, "datasetId")
 	tableID := strParam(nr, "tableId")
@@ -482,22 +576,76 @@ func (p *Provider) InsertAll(ctx context.Context, nr *model.NormalizedRequest) (
 	}
 	body := bodyMap(nr)
 	rawRows, _ := body["rows"].([]any)
-	rows := make([]bqstore.Row, 0, len(rawRows))
-	for _, rr := range rawRows {
+	skipInvalidRows := boolValue(body, "skipInvalidRows")
+	ignoreUnknownValues := boolValue(body, "ignoreUnknownValues")
+
+	t, err := p.store.GetTable(ctx, projectOf(nr), datasetID, tableID)
+	if err != nil {
+		return nil, mapErr(err)
+	}
+	fields := parseSchemaFields(t.Schema)
+
+	type parsedRow struct {
+		index    int
+		insertID string
+		json     map[string]any
+	}
+	parsed := make([]parsedRow, 0, len(rawRows))
+	for i, rr := range rawRows {
 		rowObj, _ := rr.(map[string]any)
 		jsonObj := mapValue(rowObj, "json")
 		if jsonObj == nil {
 			jsonObj = map[string]any{}
 		}
-		data, _ := json.Marshal(jsonObj)
-		rows = append(rows, bqstore.Row{Data: data})
+		parsed = append(parsed, parsedRow{index: i, insertID: strValue(rowObj, "insertId"), json: jsonObj})
 	}
-	if err := p.store.InsertRows(ctx, projectOf(nr), datasetID, tableID, rows); err != nil {
+
+	type rowErrors struct {
+		index int
+		errs  []insertError
+	}
+	var rowErrs []rowErrors
+	validRows := make([]bqstore.Row, 0, len(parsed))
+	validIndexes := make([]int, 0, len(parsed))
+	for _, pr := range parsed {
+		if errs := validateRow(pr.json, fields, ignoreUnknownValues); len(errs) > 0 {
+			if !skipInvalidRows {
+				return nil, invalidArgument(fmt.Sprintf("invalid row %d: %s", pr.index, errs[0].Message))
+			}
+			rowErrs = append(rowErrs, rowErrors{index: pr.index, errs: errs})
+			continue
+		}
+		data, _ := json.Marshal(pr.json)
+		validRows = append(validRows, bqstore.Row{InsertID: pr.insertID, Data: data})
+		validIndexes = append(validIndexes, pr.index)
+	}
+
+	dups, err := p.store.InsertRows(ctx, projectOf(nr), datasetID, tableID, validRows)
+	if err != nil {
 		return nil, mapErr(err)
+	}
+	for _, di := range dups {
+		rowErrs = append(rowErrs, rowErrors{
+			index: validIndexes[di],
+			errs: []insertError{{
+				Reason:  "duplicate",
+				Message: "row already inserted with the same insertId",
+			}},
+		})
+	}
+
+	sort.Slice(rowErrs, func(i, j int) bool { return rowErrs[i].index < rowErrs[j].index })
+	insertErrors := make([]any, 0, len(rowErrs))
+	for _, re := range rowErrs {
+		errs := make([]any, 0, len(re.errs))
+		for _, e := range re.errs {
+			errs = append(errs, e.toMap())
+		}
+		insertErrors = append(insertErrors, map[string]any{"index": re.index, "errors": errs})
 	}
 	return provider.OK(map[string]any{
 		"kind":         kindPrefix + "tableDataInsertAllResponse",
-		"insertErrors": []any{},
+		"insertErrors": insertErrors,
 	}), nil
 }
 

--- a/internal/gcp/provider/bigquery/bigquery_test.go
+++ b/internal/gcp/provider/bigquery/bigquery_test.go
@@ -554,3 +554,223 @@ func TestGetServiceAccount(t *testing.T) {
 		t.Fatalf("expected email")
 	}
 }
+
+// --- tabledata.insertAll semantics ---
+
+func createDataset(t *testing.T, p *Provider, datasetID string) {
+	t.Helper()
+	if _, err := p.CreateDataset(context.Background(), newNR(map[string]any{"body": map[string]any{
+		"datasetReference": map[string]any{"datasetId": datasetID},
+	}})); err != nil {
+		t.Fatalf("create dataset: %v", err)
+	}
+}
+
+func createTable(t *testing.T, p *Provider, datasetID, tableID string, schema any) {
+	t.Helper()
+	body := map[string]any{"tableReference": map[string]any{"tableId": tableID}}
+	if schema != nil {
+		body["schema"] = schema
+	}
+	if _, err := p.CreateTable(context.Background(), newNR(map[string]any{
+		"datasetId": datasetID,
+		"body":      body,
+	})); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+}
+
+func schemaOf(fields ...map[string]any) map[string]any {
+	arr := make([]any, 0, len(fields))
+	for _, f := range fields {
+		arr = append(arr, f)
+	}
+	return map[string]any{"fields": arr}
+}
+
+func insertErrorsOf(t *testing.T, resp *model.ProviderResponse) []any {
+	t.Helper()
+	errs, _ := resp.Data["insertErrors"].([]any)
+	return errs
+}
+
+// soleRowError asserts exactly one row-error entry and returns its request
+// index and first error object.
+func soleRowError(t *testing.T, resp *model.ProviderResponse) (int, map[string]any) {
+	t.Helper()
+	errs := insertErrorsOf(t, resp)
+	if len(errs) != 1 {
+		t.Fatalf("expected exactly 1 row error, got %v", errs)
+	}
+	re, _ := errs[0].(map[string]any)
+	idx, _ := re["index"].(int)
+	list, _ := re["errors"].([]any)
+	if len(list) == 0 {
+		t.Fatalf("row error entry has no errors: %v", re)
+	}
+	e0, _ := list[0].(map[string]any)
+	return idx, e0
+}
+
+func rowDataCount(t *testing.T, p *Provider, datasetID, tableID string) int {
+	t.Helper()
+	resp, err := p.ListRows(context.Background(), newNR(map[string]any{"datasetId": datasetID, "tableId": tableID}))
+	if err != nil {
+		t.Fatalf("list rows: %v", err)
+	}
+	rows, _ := resp.Data["rows"].([]any)
+	return len(rows)
+}
+
+// TestInsertAllInsertIdDedup verifies a repeated insertId is skipped (not
+// double-inserted) and reported as reason "duplicate" at its request index.
+func TestInsertAllInsertIdDedup(t *testing.T) {
+	ctx := context.Background()
+	p := New(bqstore.NewMemoryStore())
+	createDataset(t, p, "d")
+	createTable(t, p, "d", "t", schemaOf(map[string]any{"name": "id", "type": "INTEGER"}))
+
+	insert := func() *model.ProviderResponse {
+		resp, err := p.InsertAll(ctx, newNR(map[string]any{
+			"datasetId": "d", "tableId": "t",
+			"body": map[string]any{"rows": []any{
+				map[string]any{"insertId": "dup-1", "json": map[string]any{"id": 1}},
+			}},
+		}))
+		if err != nil {
+			t.Fatalf("insertAll: %v", err)
+		}
+		return resp
+	}
+
+	if errs := insertErrorsOf(t, insert()); len(errs) != 0 {
+		t.Fatalf("first insert should have no errors, got %v", errs)
+	}
+	idx, e := soleRowError(t, insert())
+	if idx != 0 || e["reason"] != "duplicate" {
+		t.Fatalf("expected duplicate at index 0, got index=%d err=%v", idx, e)
+	}
+	if got := rowDataCount(t, p, "d", "t"); got != 1 {
+		t.Fatalf("duplicate insertId must not double-insert: got %d rows", got)
+	}
+	tbl, err := p.GetTable(ctx, newNR(map[string]any{"datasetId": "d", "tableId": "t"}))
+	if err != nil || tbl.Data["numRows"] != "1" {
+		t.Fatalf("expected numRows 1, got %v (%v)", tbl.Data["numRows"], err)
+	}
+}
+
+// TestInsertAllUnknownField verifies ignoreUnknownValues=false rejects the
+// request with a top-level error, while true accepts the row.
+func TestInsertAllUnknownField(t *testing.T) {
+	ctx := context.Background()
+	p := New(bqstore.NewMemoryStore())
+	createDataset(t, p, "d")
+	createTable(t, p, "d", "t", schemaOf(map[string]any{"name": "id", "type": "INTEGER"}))
+
+	insert := func(ignore bool, insertID string) (*model.ProviderResponse, error) {
+		return p.InsertAll(ctx, newNR(map[string]any{
+			"datasetId": "d", "tableId": "t",
+			"body": map[string]any{
+				"ignoreUnknownValues": ignore,
+				"rows": []any{
+					map[string]any{"insertId": insertID, "json": map[string]any{"id": 1, "extra": "x"}},
+				},
+			},
+		}))
+	}
+
+	if _, err := insert(false, "u1"); err == nil {
+		t.Fatal("expected top-level error for unknown field with ignoreUnknownValues=false")
+	}
+	if got := rowDataCount(t, p, "d", "t"); got != 0 {
+		t.Fatalf("rejected request must insert nothing, got %d rows", got)
+	}
+
+	resp, err := insert(true, "u1")
+	if err != nil {
+		t.Fatalf("insertAll with ignoreUnknownValues=true: %v", err)
+	}
+	if errs := insertErrorsOf(t, resp); len(errs) != 0 {
+		t.Fatalf("expected no insertErrors, got %v", errs)
+	}
+	if got := rowDataCount(t, p, "d", "t"); got != 1 {
+		t.Fatalf("expected 1 stored row, got %d", got)
+	}
+}
+
+// TestInsertAllRequiredFieldAndSkipInvalidRows covers both skipInvalidRows
+// modes: false fails the whole request and writes nothing; true reports the
+// invalid row per-index while inserting the valid ones.
+func TestInsertAllRequiredFieldAndSkipInvalidRows(t *testing.T) {
+	ctx := context.Background()
+	p := New(bqstore.NewMemoryStore())
+	createDataset(t, p, "d")
+	createTable(t, p, "d", "t", schemaOf(
+		map[string]any{"name": "id", "type": "STRING", "mode": "REQUIRED"},
+		map[string]any{"name": "name", "type": "STRING"},
+	))
+
+	if _, err := p.InsertAll(ctx, newNR(map[string]any{
+		"datasetId": "d", "tableId": "t",
+		"body": map[string]any{"rows": []any{
+			map[string]any{"insertId": "r1", "json": map[string]any{"id": "a"}},
+			map[string]any{"insertId": "r2", "json": map[string]any{"name": "missing-id"}},
+		}},
+	})); err == nil {
+		t.Fatal("expected top-level error when a required field is missing and skipInvalidRows=false")
+	}
+	if got := rowDataCount(t, p, "d", "t"); got != 0 {
+		t.Fatalf("failed request must write nothing, got %d rows", got)
+	}
+
+	resp, err := p.InsertAll(ctx, newNR(map[string]any{
+		"datasetId": "d", "tableId": "t",
+		"body": map[string]any{
+			"skipInvalidRows": true,
+			"rows": []any{
+				map[string]any{"insertId": "r1", "json": map[string]any{"id": "a"}},
+				map[string]any{"insertId": "r2", "json": map[string]any{"name": "missing-id"}},
+				map[string]any{"insertId": "r3", "json": map[string]any{"id": "c"}},
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("insertAll: %v", err)
+	}
+	idx, e := soleRowError(t, resp)
+	if idx != 1 || e["reason"] != "invalid" || e["location"] != "id" {
+		t.Fatalf("unexpected row error: index=%d err=%v", idx, e)
+	}
+	if got := rowDataCount(t, p, "d", "t"); got != 2 {
+		t.Fatalf("valid rows must be inserted alongside the invalid one: got %d rows", got)
+	}
+	tbl, err := p.GetTable(ctx, newNR(map[string]any{"datasetId": "d", "tableId": "t"}))
+	if err != nil || tbl.Data["numRows"] != "2" {
+		t.Fatalf("expected numRows 2, got %v (%v)", tbl.Data["numRows"], err)
+	}
+}
+
+// TestInsertAllNoSchemaAcceptsAnyRow locks in that a table without a schema
+// performs no validation (the pre-existing behavior).
+func TestInsertAllNoSchemaAcceptsAnyRow(t *testing.T) {
+	ctx := context.Background()
+	p := New(bqstore.NewMemoryStore())
+	createDataset(t, p, "d")
+	createTable(t, p, "d", "t", nil)
+
+	resp, err := p.InsertAll(ctx, newNR(map[string]any{
+		"datasetId": "d", "tableId": "t",
+		"body": map[string]any{"rows": []any{
+			map[string]any{"insertId": "n1", "json": map[string]any{"whatever": 1, "extra": true}},
+		}},
+	}))
+	if err != nil {
+		t.Fatalf("insertAll: %v", err)
+	}
+	if errs := insertErrorsOf(t, resp); len(errs) != 0 {
+		t.Fatalf("schema-less table should accept any row, got %v", errs)
+	}
+	if got := rowDataCount(t, p, "d", "t"); got != 1 {
+		t.Fatalf("expected 1 stored row, got %d", got)
+	}
+}

--- a/internal/gcp/provider/storage/storage.go
+++ b/internal/gcp/provider/storage/storage.go
@@ -37,10 +37,15 @@ import (
 )
 
 // Resource types used in the generic ResourceStore (IAM + ACL; buckets and
-// objects live in the dedicated gcs.ObjectStore).
+// objects live in the dedicated gcs.ObjectStore). The two IAM types are
+// exported so the gRPC Storage service keys bucket/object policies identically
+// and both transports share one policy store.
 const (
-	rtBucketIAM = "gcs_bucket_iam"
-	rtObjectIAM = "gcs_object_iam"
+	ResourceTypeBucketIAM = "gcs_bucket_iam"
+	ResourceTypeObjectIAM = "gcs_object_iam"
+
+	rtBucketIAM = ResourceTypeBucketIAM
+	rtObjectIAM = ResourceTypeObjectIAM
 	rtACL       = "gcs_acl"
 )
 

--- a/internal/gcp/store/bigquery/dedup.go
+++ b/internal/gcp/store/bigquery/dedup.go
@@ -1,0 +1,112 @@
+package bigquery
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+const (
+	// insertDedupWindow is how long a streamed insertId is remembered for
+	// duplicate suppression. BigQuery's insertId deduplication is documented as
+	// best-effort over a short window; 10 minutes comfortably covers client
+	// retry attempts without retaining IDs indefinitely.
+	insertDedupWindow = 10 * time.Minute
+
+	// insertDedupMaxPerTable caps how many insertIds are remembered per table.
+	// Once the cap is exceeded the oldest entries are evicted, so a table that
+	// receives only unique insertIds cannot grow the set without bound.
+	insertDedupMaxPerTable = 10000
+)
+
+// insertDedupTracker remembers recently seen insertIds per table so repeated
+// tabledata.insertAll retries are not double-inserted. It is best-effort and
+// process-local: the window is TTL'd and the set is count-bounded.
+type insertDedupTracker struct {
+	mu     sync.Mutex
+	tables map[string]map[string]time.Time // tableKey → insertId → first-seen time
+}
+
+func newInsertDedupTracker() *insertDedupTracker {
+	return &insertDedupTracker{tables: map[string]map[string]time.Time{}}
+}
+
+// filter returns the ascending indices of rows whose non-empty InsertID was
+// already recorded for tableKey, and records the InsertIDs of the remaining
+// rows. now is caller-supplied so the TTL is testable. Holding d.mu across the
+// whole check-and-mark makes concurrent same-id inserts deterministic: exactly
+// one caller sees a row as new.
+func (d *insertDedupTracker) filter(tableKey string, rows []Row, now time.Time) []int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	seen := d.tables[tableKey]
+	if seen == nil {
+		seen = map[string]time.Time{}
+		d.tables[tableKey] = seen
+	}
+	for id, at := range seen {
+		if now.Sub(at) >= insertDedupWindow {
+			delete(seen, id)
+		}
+	}
+
+	var dups []int
+	for i := range rows {
+		id := rows[i].InsertID
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			dups = append(dups, i)
+			continue
+		}
+		seen[id] = now
+	}
+	if len(seen) > insertDedupMaxPerTable {
+		evictOldest(seen, len(seen)-insertDedupMaxPerTable)
+	}
+	return dups
+}
+
+// forget drops all remembered insertIds for a single table.
+func (d *insertDedupTracker) forget(tableKey string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.tables, tableKey)
+}
+
+// reset drops every remembered insertId.
+func (d *insertDedupTracker) reset() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.tables = map[string]map[string]time.Time{}
+}
+
+// forgetPrefix drops all remembered insertIds for tables whose scope key starts
+// with prefix (used when a whole dataset is deleted).
+func (d *insertDedupTracker) forgetPrefix(prefix string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for k := range d.tables {
+		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+			delete(d.tables, k)
+		}
+	}
+}
+
+// evictOldest removes the n oldest entries from seen.
+func evictOldest(seen map[string]time.Time, n int) {
+	type entry struct {
+		id string
+		at time.Time
+	}
+	entries := make([]entry, 0, len(seen))
+	for id, at := range seen {
+		entries = append(entries, entry{id, at})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].at.Before(entries[j].at) })
+	for i := 0; i < n && i < len(entries); i++ {
+		delete(seen, entries[i].id)
+	}
+}

--- a/internal/gcp/store/bigquery/dedup_test.go
+++ b/internal/gcp/store/bigquery/dedup_test.go
@@ -1,0 +1,60 @@
+package bigquery
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestInsertDedupTrackerTTL(t *testing.T) {
+	d := newInsertDedupTracker()
+	base := time.Now()
+	rows := []Row{{InsertID: "a"}}
+
+	if dups := d.filter("t", rows, base); len(dups) != 0 {
+		t.Fatalf("first sighting should not be a duplicate: %v", dups)
+	}
+	if dups := d.filter("t", rows, base.Add(insertDedupWindow-time.Second)); len(dups) != 1 {
+		t.Fatalf("id within the window should be a duplicate: %v", dups)
+	}
+	if dups := d.filter("t", rows, base.Add(insertDedupWindow)); len(dups) != 0 {
+		t.Fatalf("id at the window boundary should have expired: %v", dups)
+	}
+}
+
+func TestInsertDedupTrackerPerTableIsolation(t *testing.T) {
+	d := newInsertDedupTracker()
+	now := time.Now()
+	if dups := d.filter("t1", []Row{{InsertID: "a"}}, now); len(dups) != 0 {
+		t.Fatalf("first table: %v", dups)
+	}
+	if dups := d.filter("t2", []Row{{InsertID: "a"}}, now); len(dups) != 0 {
+		t.Fatalf("same insertId in a different table must not dedup: %v", dups)
+	}
+}
+
+func TestInsertDedupTrackerEmptyIDNeverDedups(t *testing.T) {
+	d := newInsertDedupTracker()
+	now := time.Now()
+	rows := []Row{{InsertID: ""}}
+	d.filter("t", rows, now)
+	if dups := d.filter("t", rows, now); len(dups) != 0 {
+		t.Fatalf("empty insertId must never dedup: %v", dups)
+	}
+	if len(d.tables["t"]) != 0 {
+		t.Fatalf("empty insertId must not be recorded: %v", d.tables["t"])
+	}
+}
+
+func TestInsertDedupTrackerBound(t *testing.T) {
+	d := newInsertDedupTracker()
+	now := time.Now()
+	rows := make([]Row, 0, insertDedupMaxPerTable+250)
+	for i := 0; i < insertDedupMaxPerTable+250; i++ {
+		rows = append(rows, Row{InsertID: fmt.Sprintf("id-%d", i)})
+	}
+	d.filter("t", rows, now)
+	if got := len(d.tables["t"]); got != insertDedupMaxPerTable {
+		t.Fatalf("tracker must be bounded to %d, got %d", insertDedupMaxPerTable, got)
+	}
+}

--- a/internal/gcp/store/bigquery/memory.go
+++ b/internal/gcp/store/bigquery/memory.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	"jaiscloud/internal/clock"
 )
 
 // MemoryStore is an in-memory Store.
@@ -14,6 +16,7 @@ type MemoryStore struct {
 	tables   map[string]Table   // projectID+"/"+datasetID+"/"+tableID → table
 	jobs     map[string]Job     // projectID+"/"+jobID → job
 	rows     map[string][]Row   // projectID+"/"+datasetID+"/"+tableID → rows (seq order)
+	dedup    *insertDedupTracker
 }
 
 // NewMemoryStore returns an empty in-memory store.
@@ -23,6 +26,7 @@ func NewMemoryStore() *MemoryStore {
 		tables:   make(map[string]Table),
 		jobs:     make(map[string]Job),
 		rows:     make(map[string][]Row),
+		dedup:    newInsertDedupTracker(),
 	}
 }
 
@@ -104,6 +108,7 @@ func (s *MemoryStore) DeleteDataset(_ context.Context, projectID, datasetID stri
 			delete(s.rows, k)
 		}
 	}
+	s.dedup.forgetPrefix(prefix)
 	return nil
 }
 
@@ -184,6 +189,7 @@ func (s *MemoryStore) DeleteTable(_ context.Context, projectID, datasetID, table
 	}
 	delete(s.tables, key)
 	delete(s.rows, key)
+	s.dedup.forget(key)
 	return nil
 }
 
@@ -248,13 +254,18 @@ func (s *MemoryStore) ListJobs(_ context.Context, projectID string) ([]Job, erro
 	return result, nil
 }
 
-func (s *MemoryStore) InsertRows(_ context.Context, projectID, datasetID, tableID string, rows []Row) error {
+func (s *MemoryStore) InsertRows(_ context.Context, projectID, datasetID, tableID string, rows []Row) ([]int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	key := tableScope(projectID, datasetID, tableID)
 	t, ok := s.tables[key]
 	if !ok {
-		return ErrNoSuchTable
+		return nil, ErrNoSuchTable
+	}
+	dups := s.dedup.filter(key, rows, clock.Now())
+	dupSet := make(map[int]bool, len(dups))
+	for _, i := range dups {
+		dupSet[i] = true
 	}
 	existing := s.rows[key]
 	var next int64
@@ -263,18 +274,23 @@ func (s *MemoryStore) InsertRows(_ context.Context, projectID, datasetID, tableI
 			next = r.Seq
 		}
 	}
+	added := 0
 	for i := range rows {
+		if dupSet[i] {
+			continue
+		}
 		next++
 		rows[i].ProjectID = projectID
 		rows[i].DatasetID = datasetID
 		rows[i].TableID = tableID
 		rows[i].Seq = next
 		existing = append(existing, rows[i])
+		added++
 	}
 	s.rows[key] = existing
-	t.NumRows += int64(len(rows))
+	t.NumRows += int64(added)
 	s.tables[key] = t
-	return nil
+	return dups, nil
 }
 
 func (s *MemoryStore) ListRows(_ context.Context, projectID, datasetID, tableID string) ([]Row, error) {
@@ -293,4 +309,5 @@ func (s *MemoryStore) Reset(_ context.Context) {
 	s.tables = make(map[string]Table)
 	s.jobs = make(map[string]Job)
 	s.rows = make(map[string][]Row)
+	s.dedup.reset()
 }

--- a/internal/gcp/store/bigquery/postgres.go
+++ b/internal/gcp/store/bigquery/postgres.go
@@ -16,12 +16,13 @@ import (
 // PostgresStore implements Store against jc_bq_datasets / jc_bq_tables /
 // jc_bq_jobs / jc_bq_rows.
 type PostgresStore struct {
-	pool *pgxpool.Pool
+	pool  *pgxpool.Pool
+	dedup *insertDedupTracker
 }
 
 // NewPostgresStore returns a Postgres-backed store.
 func NewPostgresStore(pool *pgxpool.Pool) *PostgresStore {
-	return &PostgresStore{pool: pool}
+	return &PostgresStore{pool: pool, dedup: newInsertDedupTracker()}
 }
 
 // --- Datasets ---
@@ -152,7 +153,11 @@ func (s *PostgresStore) DeleteDataset(ctx context.Context, projectID, datasetID 
 	if tag.RowsAffected() == 0 {
 		return ErrNoSuchDataset
 	}
-	return tx.Commit(ctx)
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	s.dedup.forgetPrefix(datasetScope(projectID, datasetID) + "/")
+	return nil
 }
 
 func (s *PostgresStore) ListDatasets(ctx context.Context, projectID string) ([]Dataset, error) {
@@ -303,7 +308,11 @@ func (s *PostgresStore) DeleteTable(ctx context.Context, projectID, datasetID, t
 	if tag.RowsAffected() == 0 {
 		return ErrNoSuchTable
 	}
-	return tx.Commit(ctx)
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	s.dedup.forget(tableScope(projectID, datasetID, tableID))
+	return nil
 }
 
 func (s *PostgresStore) ListTables(ctx context.Context, projectID, datasetID string) ([]Table, error) {
@@ -403,16 +412,31 @@ func (s *PostgresStore) ListJobs(ctx context.Context, projectID string) ([]Job, 
 
 // --- Rows ---
 
-func (s *PostgresStore) InsertRows(ctx context.Context, projectID, datasetID, tableID string, rows []Row) error {
-	if len(rows) == 0 {
-		if _, err := s.GetTable(ctx, projectID, datasetID, tableID); err != nil {
-			return err
-		}
-		return nil
+func (s *PostgresStore) InsertRows(ctx context.Context, projectID, datasetID, tableID string, rows []Row) ([]int, error) {
+	// Resolve the table up front so a missing table never records insertIds.
+	if _, err := s.GetTable(ctx, projectID, datasetID, tableID); err != nil {
+		return nil, err
 	}
+	key := tableScope(projectID, datasetID, tableID)
+	dups := s.dedup.filter(key, rows, clock.Now())
+	dupSet := make(map[int]bool, len(dups))
+	for _, i := range dups {
+		dupSet[i] = true
+	}
+	keep := make([]Row, 0, len(rows))
+	for i := range rows {
+		if dupSet[i] {
+			continue
+		}
+		keep = append(keep, rows[i])
+	}
+	if len(keep) == 0 {
+		return dups, nil
+	}
+
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer tx.Rollback(ctx)
 
@@ -421,32 +445,35 @@ func (s *PostgresStore) InsertRows(ctx context.Context, projectID, datasetID, ta
 		SELECT COALESCE(MAX(seq), 0) FROM jc_bq_rows
 		WHERE project_id=$1 AND dataset_id=$2 AND table_id=$3
 	`, projectID, datasetID, tableID).Scan(&seq); err != nil {
-		return err
+		return nil, err
 	}
-	for i := range rows {
+	for i := range keep {
 		seq++
-		rows[i].ProjectID = projectID
-		rows[i].DatasetID = datasetID
-		rows[i].TableID = tableID
-		rows[i].Seq = seq
+		keep[i].ProjectID = projectID
+		keep[i].DatasetID = datasetID
+		keep[i].TableID = tableID
+		keep[i].Seq = seq
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO jc_bq_rows (project_id, dataset_id, table_id, seq, data)
 			VALUES ($1,$2,$3,$4,$5)
-		`, projectID, datasetID, tableID, seq, nullableJSONRaw(rows[i].Data, "{}")); err != nil {
-			return err
+		`, projectID, datasetID, tableID, seq, nullableJSONRaw(keep[i].Data, "{}")); err != nil {
+			return nil, err
 		}
 	}
 	tag, err := tx.Exec(ctx, `
 		UPDATE jc_bq_tables SET num_rows = num_rows + $4, update_time = now()
 		WHERE project_id=$1 AND dataset_id=$2 AND table_id=$3
-	`, projectID, datasetID, tableID, len(rows))
+	`, projectID, datasetID, tableID, len(keep))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if tag.RowsAffected() == 0 {
-		return ErrNoSuchTable
+		return nil, ErrNoSuchTable
 	}
-	return tx.Commit(ctx)
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return dups, nil
 }
 
 func (s *PostgresStore) ListRows(ctx context.Context, projectID, datasetID, tableID string) ([]Row, error) {
@@ -476,6 +503,7 @@ func (s *PostgresStore) Reset(ctx context.Context) {
 	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_bq_tables`)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_bq_datasets`)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_bq_jobs`)
+	s.dedup.reset()
 }
 
 // nullableJSONRaw returns a json.RawMessage for a JSONB column, substituting the

--- a/internal/gcp/store/bigquery/postgres_test.go
+++ b/internal/gcp/store/bigquery/postgres_test.go
@@ -61,7 +61,7 @@ func TestPostgresDeleteDatasetCascades(t *testing.T) {
 	if err := s.CreateTable(ctx, "proj", "d", Table{TableID: "t"}); err != nil {
 		t.Fatalf("create table: %v", err)
 	}
-	if err := s.InsertRows(ctx, "proj", "d", "t", []Row{{Data: []byte(`{"a":1}`)}}); err != nil {
+	if _, err := s.InsertRows(ctx, "proj", "d", "t", []Row{{Data: []byte(`{"a":1}`)}}); err != nil {
 		t.Fatalf("insert rows: %v", err)
 	}
 	if err := s.DeleteDataset(ctx, "proj", "d"); err != nil {

--- a/internal/gcp/store/bigquery/snapshot.go
+++ b/internal/gcp/store/bigquery/snapshot.go
@@ -53,6 +53,7 @@ func (s *MemoryStore) Restore(_ context.Context, r io.Reader) error {
 	s.tables = snap.Tables
 	s.jobs = snap.Jobs
 	s.rows = snap.Rows
+	s.dedup.reset()
 	return nil
 }
 

--- a/internal/gcp/store/bigquery/store.go
+++ b/internal/gcp/store/bigquery/store.go
@@ -57,12 +57,14 @@ type Job struct {
 
 // Row is one streamed row under a table. Data holds the row's json object
 // verbatim; Seq is the per-table insertion ordinal used for ordering and
-// pagination.
+// pagination. InsertID is the caller-supplied tabledata.insertAll insertId
+// used for best-effort duplicate suppression (empty means "never dedup").
 type Row struct {
 	ProjectID string          `json:"projectId"`
 	DatasetID string          `json:"datasetId"`
 	TableID   string          `json:"tableId"`
 	Seq       int64           `json:"seq"`
+	InsertID  string          `json:"insertId,omitempty"`
 	Data      json.RawMessage `json:"data,omitempty"`
 }
 
@@ -99,7 +101,12 @@ type Store interface {
 	DeleteJob(ctx context.Context, projectID, jobID string) error
 	ListJobs(ctx context.Context, projectID string) ([]Job, error)
 
-	InsertRows(ctx context.Context, projectID, datasetID, tableID string, rows []Row) error
+	// InsertRows appends rows to a table. Rows whose non-empty InsertID was
+	// already recorded for this table within the best-effort dedup window are
+	// skipped and their indices into rows are returned (ascending) as
+	// duplicateIndexes; every other row is inserted. It is atomic with respect
+	// to concurrent requests carrying the same InsertID.
+	InsertRows(ctx context.Context, projectID, datasetID, tableID string, rows []Row) (duplicateIndexes []int, err error)
 	ListRows(ctx context.Context, projectID, datasetID, tableID string) ([]Row, error)
 
 	Reset(ctx context.Context)

--- a/internal/gcp/store/bigquery/store_test.go
+++ b/internal/gcp/store/bigquery/store_test.go
@@ -63,7 +63,7 @@ func runStoreTests(t *testing.T, s Store) {
 		{Data: []byte(`{"id":1,"name":"alice"}`)},
 		{Data: []byte(`{"id":2,"name":"bob"}`)},
 	}
-	if err := s.InsertRows(ctx, "proj", "Sales", "Orders", rows); err != nil {
+	if _, err := s.InsertRows(ctx, "proj", "Sales", "Orders", rows); err != nil {
 		t.Fatalf("insert rows: %v", err)
 	}
 	gotTable, _ = s.GetTable(ctx, "proj", "Sales", "Orders")
@@ -80,8 +80,26 @@ func runStoreTests(t *testing.T, s Store) {
 	if string(listRows[1].Data) != `{"id":2,"name":"bob"}` {
 		t.Fatalf("row data lost: %s", listRows[1].Data)
 	}
-	if err := s.InsertRows(ctx, "proj", "Sales", "missing", rows); err != ErrNoSuchTable {
+	if _, err := s.InsertRows(ctx, "proj", "Sales", "missing", rows); err != ErrNoSuchTable {
 		t.Fatalf("expected ErrNoSuchTable on row insert into missing table, got %v", err)
+	}
+
+	// insertId dedup: a repeat id is skipped and reported at its index, and a
+	// new id in the same batch is still inserted.
+	first, err := s.InsertRows(ctx, "proj", "Sales", "Orders", []Row{
+		{InsertID: "id-1", Data: []byte(`{"id":3}`)},
+		{InsertID: "id-2", Data: []byte(`{"id":4}`)},
+	})
+	if err != nil || len(first) != 0 {
+		t.Fatalf("first dedup batch: err=%v dups=%v", err, first)
+	}
+	second, err := s.InsertRows(ctx, "proj", "Sales", "Orders", []Row{{InsertID: "id-1", Data: []byte(`{"id":99}`)}})
+	if err != nil || len(second) != 1 || second[0] != 0 {
+		t.Fatalf("expected duplicate at index 0, got err=%v dups=%v", err, second)
+	}
+	gotTable, _ = s.GetTable(ctx, "proj", "Sales", "Orders")
+	if gotTable.NumRows != 4 {
+		t.Fatalf("expected numRows=4 after dedup, got %d", gotTable.NumRows)
 	}
 
 	// Jobs
@@ -142,7 +160,7 @@ func TestMemoryStoreSnapshotRoundTrip(t *testing.T) {
 	s := NewMemoryStore()
 	_ = s.CreateDataset(ctx, "p", Dataset{DatasetID: "d", Labels: map[string]string{"k": "v"}, Config: []byte(`{"friendlyName":"F"}`)})
 	_ = s.CreateTable(ctx, "p", "d", Table{TableID: "t", Schema: []byte(`{"fields":[{"name":"a","type":"STRING"}]}`), Labels: map[string]string{"x": "y"}})
-	_ = s.InsertRows(ctx, "p", "d", "t", []Row{{Data: []byte(`{"a":"hi"}`)}})
+	_, _ = s.InsertRows(ctx, "p", "d", "t", []Row{{Data: []byte(`{"a":"hi"}`)}})
 	_ = s.CreateJob(ctx, "p", Job{JobID: "j", Config: []byte(`{"configuration":{"query":{"query":"SELECT 1"}}}`)})
 
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary

Implements the **P1 medium** tier from `plan_docs/gcp-deferred-debt-plan.md` §7 (four commits, three services). Each was developed in an isolated worktree then combined here.

## Commits

### 1. `feat(gcp/storage): gRPC RewriteObject/MoveObject + bucket/object IAM` (§3.5)
- **`RewriteObject`** — full in-process server-side copy (fresh destination generation, `done=true`), honoring source `generation`/`if_source_*` and the atomic **destination** preconditions via the #60 path (`grpcObjectPrecondition` + `PutObjectData`).
- **`MoveObject`** — copy-then-delete: destination preconditions enforced atomically on the write, source preconditions on the atomic delete; missing source → `NotFound`, mismatch → `FailedPrecondition`. *Flagged:* the two steps aren't one transaction (write ordered first so a failure never loses bytes).
- **IAM** — `Get`/`SetIamPolicy`/`TestIamPermissions` on buckets + objects via the shared `internal/gcp/policy` store (same resource types as the REST provider: `gcs_bucket_iam`/`gcs_object_iam`); `NotFound` on a missing resource.

### 2. `perf(gcp/storage): spill resumable buffers + range-aware ReadObject` (§3.6)
- gRPC `uploadSession` spills to a private temp file past **4 MiB** (mirrors the REST provider), read back at finalize, cleaned on finalize/`Reset`/error.
- `ReadObject` resolves the range from metadata first (zero-length skips read+decrypt entirely); *flagged:* AES-GCM's single tag over the whole ciphertext makes true partial decryption infeasible in the on-disk format — documented in the method comment with the safe improvement applied.

### 3. `fix(gcp/pubsub): honor StreamingPull maxOutstandingMessages/Bytes` (§3.7)
- New `streamFlowControl` tracks outstanding unacked messages by ID (idempotent release). The send loop clamps `Pull` to the count budget, skips when the byte budget is spent, and re-makes-visible claimed-but-over-budget messages. Release on ack + nack (`seconds<=0`); positive deadline extensions keep messages outstanding (real semantics). Blocked poll reconciles out-of-band acks.
- *Flagged:* cross-stream acks are caught by periodic `List` reconciliation, not instantly (the store has no per-stream claim ownership).

### 4. `fix(gcp/bigquery): insertAll insertId dedup + schema validation` (§3.8)
- **`insertId` dedup** via a new bounded/TTL'd per-table tracker (`store/bigquery/dedup.go`: 10-min window, 10k/table, oldest-first eviction, atomic check-and-mark); duplicates are skipped and reported `reason:"duplicate"`. Not persisted (process-local, best-effort like real BQ).
- **Schema validation**: missing `REQUIRED` fields + unknown top-level fields; `skipInvalidRows=false` → top-level `400`, `true` → per-row `insertErrors` with valid rows still inserted; `ignoreUnknownValues` honored. Only presence + unknown-field checks (no type validation — documented).
- `insertErrors`: `[{index, errors:[{reason, location, message, debugInfo}]}]`.

## Verification

`go build ./...`, `go vet ./internal/gcp/...`, `go test -race` on storage/pubsub/bigquery (+ store), full `./internal/gcp/...` clean, `gofmt -l` empty, `paginationcheck` clean.

## Not included

§3.13 D6 gcs-connector spike (needs Docker Spark + empirical pin). P1 large items (Datastore transactions, Monitoring alert eval, Dataproc ops TTL/GC) remain the next tier.