### PR TITLE
fix(gcp/dataproc): age-based TTL sweep for jc_dataproc_operations

### DIFF
--- a/internal/gcp/provider/dataproc/dataproc.go
+++ b/internal/gcp/provider/dataproc/dataproc.go
@@ -50,6 +50,11 @@ type Provider struct {
 	serviceAccountName string
 	projectID          string // default project (from cfg.ProjectID), used as WI fallback
 
+	// operationTTL is how long a completed operation is retained before the
+	// lazy sweep removes it (keeps jc_dataproc_operations bounded; real
+	// operations are GC'd after a similar TTL). Zero disables the sweep.
+	operationTTL time.Duration
+
 	ctx         context.Context
 	cancel      context.CancelFunc
 	wg          sync.WaitGroup
@@ -57,6 +62,11 @@ type Provider struct {
 	cancels     map[string]context.CancelFunc
 	patcherStop func()
 }
+
+// defaultOperationTTL is how long a completed operation is retained before the
+// lazy sweep removes it. Real Dataproc operations are GC'd after a TTL; without
+// a sweep, jc_dataproc_operations grows unbounded.
+const defaultOperationTTL = 24 * time.Hour
 
 // Option configures Provider.
 type Option func(*Provider)
@@ -105,16 +115,23 @@ func WithProjectID(project string) Option {
 	return func(p *Provider) { p.projectID = project }
 }
 
+// WithOperationTTL overrides how long completed operations are retained before
+// the lazy sweep removes them. Zero disables the sweep (tests use a short TTL).
+func WithOperationTTL(d time.Duration) Option {
+	return func(p *Provider) { p.operationTTL = d }
+}
+
 // New returns a Provider backed by the given store.
 func New(s dataprocstore.Store, resources store.ResourceStore, opts ...Option) *Provider {
 	ctx, cancel := context.WithCancel(context.Background())
 	p := &Provider{
-		store:      s,
-		resources:  resources,
-		ctx:        ctx,
-		cancel:     cancel,
-		sparkImage: "spark-dataproc:devbox",
-		cancels:    make(map[string]context.CancelFunc),
+		store:        s,
+		resources:    resources,
+		ctx:          ctx,
+		cancel:       cancel,
+		sparkImage:   "spark-dataproc:devbox",
+		cancels:      make(map[string]context.CancelFunc),
+		operationTTL: defaultOperationTTL,
 	}
 	for _, o := range opts {
 		o(p)
@@ -389,10 +406,24 @@ func (p *Provider) storeOperation(ctx context.Context, nr *model.NormalizedReque
 		respJSON, _ := json.Marshal(response)
 		op.Response = string(respJSON)
 	}
+	p.sweepOperations(ctx)
 	if err := p.store.CreateOperation(ctx, nr.AccountID, region, op); err != nil {
 		return nil, err
 	}
 	return p.operationMap(nr, op), nil
+}
+
+// sweepOperations lazily deletes completed operations older than the retention
+// window. It runs on each operation creation (mirroring the REST provider's
+// resumable-session sweep) so jc_dataproc_operations stays bounded without a
+// background goroutine.
+func (p *Provider) sweepOperations(ctx context.Context) {
+	if p.operationTTL <= 0 {
+		return
+	}
+	if _, err := p.store.DeleteStaleOperations(ctx, clock.Now().UTC().Add(-p.operationTTL)); err != nil {
+		slog.Warn("dataproc: operation sweep failed", "err", err)
+	}
 }
 
 // clusterOperationMetadata renders ClusterOperationMetadata for an operation.

--- a/internal/gcp/provider/dataproc/dataproc_test.go
+++ b/internal/gcp/provider/dataproc/dataproc_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"jaiscloud/internal/clock"
 	"jaiscloud/internal/gcp/resource"
 	dataprocstore "jaiscloud/internal/gcp/store/dataproc"
 	"jaiscloud/internal/model"
@@ -477,4 +478,39 @@ func indexOf(s, sub string) int {
 		}
 	}
 	return -1
+}
+
+// TestOperationTTLSweep verifies the lazy operation-retention sweep: minting a
+// new operation (via any LRO) deletes operations older than the TTL and keeps
+// fresh ones.
+func TestOperationTTLSweep(t *testing.T) {
+	ctx := context.Background()
+	st := dataprocstore.NewMemoryStore()
+	p := New(st, store.NewMemoryResourceStore(), WithOperationTTL(time.Hour))
+
+	if err := st.CreateOperation(ctx, "proj", "us-central1", dataprocstore.Operation{
+		ID: "stale", Done: true, CreateTime: clock.Now().UTC().Add(-2 * time.Hour),
+	}); err != nil {
+		t.Fatalf("seed stale op: %v", err)
+	}
+	if err := st.CreateOperation(ctx, "proj", "us-central1", dataprocstore.Operation{
+		ID: "fresh", Done: true, CreateTime: clock.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed fresh op: %v", err)
+	}
+
+	// Creating a cluster mints an LRO, which triggers the sweep.
+	if _, err := p.CreateCluster(ctx, testNR(map[string]any{
+		"region": "us-central1",
+		"body":   map[string]any{"projectId": "proj", "clusterName": "c1"},
+	})); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := st.GetOperation(ctx, "proj", "us-central1", "stale"); err != dataprocstore.ErrNoSuchOperation {
+		t.Fatalf("stale op should have been swept, got %v", err)
+	}
+	if _, err := st.GetOperation(ctx, "proj", "us-central1", "fresh"); err != nil {
+		t.Fatalf("fresh op should remain, got %v", err)
+	}
 }

--- a/internal/gcp/store/dataproc/memory.go
+++ b/internal/gcp/store/dataproc/memory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"time"
 )
 
 // MemoryStore is an in-memory Store.
@@ -219,6 +220,25 @@ func (s *MemoryStore) UpdateOperation(_ context.Context, projectID, region strin
 	op.Region = region
 	s.operations[key][op.ID] = op
 	return nil
+}
+
+// DeleteStaleOperations removes operations older than cutoff across all scopes.
+func (s *MemoryStore) DeleteStaleOperations(_ context.Context, cutoff time.Time) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for key, ops := range s.operations {
+		for id, op := range ops {
+			if op.CreateTime.Before(cutoff) {
+				delete(ops, id)
+				n++
+			}
+		}
+		if len(ops) == 0 {
+			delete(s.operations, key)
+		}
+	}
+	return n, nil
 }
 
 func (s *MemoryStore) Reset(_ context.Context) {

--- a/internal/gcp/store/dataproc/postgres.go
+++ b/internal/gcp/store/dataproc/postgres.go
@@ -395,6 +395,15 @@ func (s *PostgresStore) UpdateOperation(ctx context.Context, projectID, region s
 	return nil
 }
 
+// DeleteStaleOperations removes operations older than cutoff (all scopes).
+func (s *PostgresStore) DeleteStaleOperations(ctx context.Context, cutoff time.Time) (int, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM jc_dataproc_operations WHERE create_time < $1`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return int(tag.RowsAffected()), nil
+}
+
 func (s *PostgresStore) Reset(ctx context.Context) {
 	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_dataproc_clusters`)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_dataproc_jobs`)

--- a/internal/gcp/store/dataproc/store.go
+++ b/internal/gcp/store/dataproc/store.go
@@ -118,6 +118,12 @@ type Store interface {
 	CreateOperation(ctx context.Context, projectID, region string, op Operation) error
 	GetOperation(ctx context.Context, projectID, region, id string) (Operation, error)
 	UpdateOperation(ctx context.Context, projectID, region string, op Operation) error
+	// DeleteStaleOperations removes operations whose CreateTime predates cutoff
+	// (across every project/region scope), returning the number deleted. It is
+	// the store half of the Dataproc operation-retention sweep: real operations
+	// are GC'd after a TTL, and without this jc_dataproc_operations grows
+	// unbounded (the only other delete is Reset).
+	DeleteStaleOperations(ctx context.Context, cutoff time.Time) (int, error)
 
 	Reset(ctx context.Context)
 }

--- a/internal/gcp/store/dataproc/store_test.go
+++ b/internal/gcp/store/dataproc/store_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 )
 
 // runStoreTests exercises a Store against the shared test matrix. Backend tests
@@ -89,13 +90,34 @@ func runStoreTests(t *testing.T, s Store) {
 	if _, err := s.GetOperation(ctx, "proj", "us-central1", "nope"); err != ErrNoSuchOperation {
 		t.Fatalf("expected ErrNoSuchOperation, got %v", err)
 	}
-	op := Operation{ID: "op-1", Done: true, Metadata: `{"@type":"x"}`, Response: `{}`}
+	op := Operation{ID: "op-1", Done: true, Metadata: `{"@type":"x"}`, Response: `{}`, CreateTime: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)}
 	if err := s.CreateOperation(ctx, "proj", "us-central1", op); err != nil {
 		t.Fatalf("create op: %v", err)
 	}
 	gotOp, err := s.GetOperation(ctx, "proj", "us-central1", "op-1")
 	if err != nil || gotOp.Metadata != `{"@type":"x"}` {
 		t.Fatalf("get op: %v %+v", err, gotOp)
+	}
+
+	// Operation retention sweep: only operations older than the cutoff go.
+	if err := s.CreateOperation(ctx, "proj", "us-central1", Operation{ID: "op-old", Done: true, CreateTime: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)}); err != nil {
+		t.Fatalf("create old op: %v", err)
+	}
+	if err := s.CreateOperation(ctx, "proj", "us-central1", Operation{ID: "op-new", Done: true, CreateTime: time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)}); err != nil {
+		t.Fatalf("create new op: %v", err)
+	}
+	removed, err := s.DeleteStaleOperations(ctx, time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil || removed != 1 {
+		t.Fatalf("DeleteStaleOperations = %d, %v; want 1 removed", removed, err)
+	}
+	if _, err := s.GetOperation(ctx, "proj", "us-central1", "op-old"); err != ErrNoSuchOperation {
+		t.Fatalf("old op should be swept, got %v", err)
+	}
+	if _, err := s.GetOperation(ctx, "proj", "us-central1", "op-new"); err != nil {
+		t.Fatalf("new op should remain, got %v", err)
+	}
+	if _, err := s.GetOperation(ctx, "proj", "us-central1", "op-1"); err != nil {
+		t.Fatalf("fresh op-1 should remain, got %v", err)
 	}
 
 	// Delete cluster


### PR DESCRIPTION
## Summary

Closes the smallest item in the **P1 large** tier (`plan_docs/gcp-deferred-debt-plan.md` §3.4). `jc_dataproc_operations` grew **unbounded** — the only delete was `Reset` (memory: permanent map entries; postgres: `DELETE` only in `Reset`). Real Dataproc GCs operations after a TTL.

## Changes

- **Store** (`internal/gcp/store/dataproc/`): add `DeleteStaleOperations(ctx, cutoff) (int, error)` to the interface.
  - `memory.go` — iterates every project/region scope, drops operations with `CreateTime` before `cutoff`, prunes emptied scopes; returns the count.
  - `postgres.go` — `DELETE FROM jc_dataproc_operations WHERE create_time < $1` (rows affected).
- **Provider** (`internal/gcp/provider/dataproc/dataproc.go`): a **lazy sweep on operation creation** (mirroring the REST provider's resumable-session sweep at `storage.go:2193/2203`) — no background goroutine. New `operationTTL` field (default **24h**) + `WithOperationTTL(d)` option (0 disables); `sweepOperations` is called from `storeOperation` before the new op is persisted.

## Design note

This mirrors the existing in-repo pattern (`provider/storage`'s `sweepSessions`/`sweepStaleStore`), which is deliberate for an emulator: no ticker lifecycle, testable, and bounded by construction. The sweep runs across all scopes (a stale operation in any project/region is eligible), matching a service-wide GC.

## Tests

- Shared store matrix (memory + `gcp_persistence`-gated postgres): only pre-cutoff ops are removed; a fresh op and a known-time op remain; count is exact.
- Provider: minting an LRO (via `CreateCluster`) sweeps a seeded stale op (`now-2h`, TTL 1h) and keeps a fresh one.

## Verification

`go build ./...`, `go vet ./internal/gcp/store/dataproc/... ./internal/gcp/provider/dataproc/...` (+`-tags gcp_persistence`), `go test -race` on both packages, full `./internal/gcp/...` clean, `gofmt -l` empty, `paginationcheck` clean.