### PR TITLE
docs(gcp/monitoring): mark alert-policy evaluation as deliberately CRUD-only

### DIFF
--- a/README-GCP.md
+++ b/README-GCP.md
@@ -190,7 +190,7 @@ A cluster is a logical record only — the emulator never stands up a real Kafka
 
 ### Cloud Monitoring: alert policies are stored, never evaluated
 
-Alert policies can be created, listed, updated, and deleted, but their conditions are never evaluated and no notifications are ever triggered. `GetMonitoredResourceDescriptor` and `CreateServiceTimeSeries` are `Unimplemented`. `ListMetricDescriptors`/`ListMonitoredResourceDescriptors` ignore the `filter` field. `DISTRIBUTION`-typed point values are rejected. `ListTimeSeries` supports only the `metric.type` / `resource.type` equality filter subset — the full Monitoring Query Language is not implemented.
+Alert policies can be created, listed, updated, and deleted, but their conditions are never evaluated and no notifications are ever triggered — **by design**, not as a pending TODO. This intentionally diverges from the AWS emulator, whose CloudWatch analogue implements a full alarm evaluator (threshold comparison, `ALARM`/`OK`/`INSUFFICIENT_DATA` transitions, and SNS actions); that evaluator is untested and the capability is low-value in an emulator, and GCP exposes no NotificationChannel service to fire at. Alert policies therefore stay CRUD-only. `GetMonitoredResourceDescriptor` and `CreateServiceTimeSeries` are `Unimplemented`. `ListMetricDescriptors`/`ListMonitoredResourceDescriptors` ignore the `filter` field. `DISTRIBUTION`-typed point values are rejected. `ListTimeSeries` supports only the `metric.type` / `resource.type` equality filter subset — the full Monitoring Query Language is not implemented.
 
 ### Dataproc: `Reset` does not drain in-flight Spark job goroutines
 

--- a/internal/gcp/grpc/monitoring/service.go
+++ b/internal/gcp/grpc/monitoring/service.go
@@ -3,7 +3,12 @@
 // the Amazon CloudWatch metrics+alarms analogue. It manages the metric
 // descriptor catalog, the time-series data plane, and the alert-policy (alarm)
 // registry. Alert policies are stored verbatim; the emulator does not evaluate
-// conditions or trigger notifications.
+// conditions or trigger notifications. That is deliberate — not a TODO: the AWS
+// CloudWatch analogue implements a full alarm evaluator (a background worker
+// that compares metrics to thresholds, transitions ALARM/OK/INSUFFICIENT_DATA,
+// and fires SNS actions), but it is untested and low-value in an emulator, and
+// GCP has no NotificationChannel service to fire at. Alert policies stay
+// CRUD-only rather than porting that evaluator.
 //
 // Documented limitations:
 //
@@ -13,7 +18,7 @@
 //     filter field and return synthesized (not canonical)
 //     MonitoredResourceDescriptors.
 //   - DISTRIBUTION point values are rejected.
-//   - Alert policies are stored but never evaluated.
+//   - Alert policies are stored but never evaluated (see above — by design).
 //   - ListTimeSeries supports only the metric.type / resource.type equality
 //     filter subset.
 package monitoring


### PR DESCRIPTION
## Summary

Records the decision to **deprioritise GCP Monitoring alert-policy evaluation** in tracked files (the `plan_docs/` inventory is gitignored, so the decision wouldn't otherwise be visible in the repo). Alert policies stay CRUD-only **by design**, not as a pending TODO — this prevents a future contributor from porting an evaluator "for AWS parity".

## AWS investigation (the analogue)

AWS CloudWatch **does** implement a full evaluator:
- `internal/aws/provider/cloudwatch/alarm_evaluator.go` — a 30s background worker that computes the requested statistic over the metric window and compares to `Threshold`/`ComparisonOperator`, transitioning `ALARM`/`OK`/`INSUFFICIENT_DATA`.
- `transitionState` persists the new state + writes alarm history; `cross_service.go` `fireAlarmActions` dispatches to SNS.
- Wired in `cmd/jaiscloud-aws/main.go` as the `cw-alarm-evaluator` worker.

But:
- It is **untested** — there is no `internal/aws/provider/cloudwatch/*_test.go`.
- GCP has **no NotificationChannel service** to fire at (only an `AlertPolicy.notification_channels` field referencing names), so an evaluator would have nowhere to deliver.
- The capability is low-value in an emulator (clients overwhelmingly CRUD alert policies; they don't assert firing).

## Change

- `internal/gcp/grpc/monitoring/service.go` package doc: states the CRUD-only behaviour is **deliberate**, explains the AWS divergence, and marks the limitation as by-design.
- `README-GCP.md` Cloud Monitoring limitations: same, so it's documented where users look.

Comment/doc only — no behaviour change.

## Verification

`go build ./...`, `gofmt -l` clean, `go test ./internal/gcp/grpc/monitoring/...` green.