### PR TITLE
feat(gcp/monitoring): alert-policy evaluation + NotificationChannelService + incidents

### DIFF
--- a/README-GCP.md
+++ b/README-GCP.md
@@ -27,7 +27,7 @@
 | BigLake Iceberg REST Catalog | REST | `org.apache.iceberg.rest.RESTCatalog` surface mounted at `/iceberg/` — namespaces, tables, atomic `CommitTableRequest` requirements/updates, see [Known Limitations](#known-limitations) |
 | Managed Kafka | REST | Metadata-only clusters/topics — see [Known Limitations](#known-limitations) |
 | BigQuery | REST | Metadata + stored rows — no SQL engine, see [Known Limitations](#known-limitations) |
-| Cloud Monitoring | gRPC | Metrics + alert policies — see [Known Limitations](#known-limitations) |
+| Cloud Monitoring | gRPC | Metrics, alert policies (evaluated), notification channels + incidents — see [Known Limitations](#known-limitations) |
 | Cloud Logging | gRPC | Log entries, filtering, log-based routing |
 | Eventarc | REST | Metadata-only triggers/channels + provider discovery — no event-delivery engine, see [Known Limitations](#known-limitations) |
 
@@ -188,9 +188,11 @@ The Datastore gRPC service is intentionally non-transactional. `BeginTransaction
 
 A cluster is a logical record only — the emulator never stands up a real Kafka broker. Consumer groups are not tracked: `ListConsumerGroups` always returns an empty list, and get/update/delete operations on a consumer group return `Unimplemented`.
 
-### Cloud Monitoring: alert policies are stored, never evaluated
+### Cloud Monitoring: alert policies are evaluated for `condition_threshold`
 
-Alert policies can be created, listed, updated, and deleted, but their conditions are never evaluated and no notifications are ever triggered. `GetMonitoredResourceDescriptor` and `CreateServiceTimeSeries` are `Unimplemented`. `ListMetricDescriptors`/`ListMonitoredResourceDescriptors` ignore the `filter` field. `DISTRIBUTION`-typed point values are rejected. `ListTimeSeries` supports only the `metric.type` / `resource.type` equality filter subset — the full Monitoring Query Language is not implemented.
+Alert policies are evaluated by a background worker (30s tick, matching the AWS CloudWatch alarm evaluator). Only `condition_threshold` conditions are evaluated; `condition_absent`, `condition_matched_log`, `condition_monitoring_query_language`, `condition_prometheus_query_language`, and `condition_sql` are stored but never evaluated (and never fire). The evaluated filter subset is equality clauses joined by `AND` on `metric.type`, `resource.type`, `metric.label.{key}`, and `resource.label.{key}`; unknown clauses are ignored. The matching series' latest point in each alignment window is reduced across series (`REDUCE_SUM`/`MEAN`/`MAX`/`MIN`/`COUNT`, default mean), then compared to `threshold_value`; `duration` requires the comparison to hold across every alignment window it spans, and `trigger` count/percent is honored when no reducer is set. A firing policy opens an incident and delivers notifications; a below-threshold evaluation or no matching data closes its open incident and delivers a resolution notification. Incidents have no public API, so they are observable via the snapshot/export surface and logs. `pubsub` channels receive a CloudEvents-style JSON message on `labels.topic`; `email`/`webhook`/`sms` notifications are recorded on the incident and logged but not sent.
+
+`GetMonitoredResourceDescriptor` and `CreateServiceTimeSeries` are `Unimplemented`. `ListMetricDescriptors`/`ListMonitoredResourceDescriptors` ignore the `filter` field. `DISTRIBUTION`-typed point values are rejected. `ListTimeSeries` supports only the `metric.type` / `resource.type` equality filter subset — the full Monitoring Query Language is not implemented. `NotificationChannelService` supports CRUD for `pubsub`/`email`/`webhook`/`sms` channels; `ListNotificationChannelDescriptors`, `GetNotificationChannelDescriptor`, and the verification-code RPCs are `Unimplemented`.
 
 ### Dataproc: `Reset` does not drain in-flight Spark job goroutines
 

--- a/cmd/jaiscloud-gcp/main.go
+++ b/cmd/jaiscloud-gcp/main.go
@@ -287,6 +287,7 @@ func startCmd() *cobra.Command {
 			loggingpb.RegisterLoggingServiceV2Server(gserv.GRPC(), loggingGRPC)
 			monitoringpb.RegisterMetricServiceServer(gserv.GRPC(), monitoringGRPC)
 			monitoringpb.RegisterAlertPolicyServiceServer(gserv.GRPC(), monitoringGRPC)
+			monitoringpb.RegisterNotificationChannelServiceServer(gserv.GRPC(), monitoringGRPC)
 			grpcstoragepb.RegisterStorageServer(gserv.GRPC(), storageGRPC)
 			// Secret Manager's IAM surface (GetIamPolicy/SetIamPolicy/
 			// TestIamPermissions) is served by the SecretManagerService itself

--- a/cmd/jaiscloud-gcp/main.go
+++ b/cmd/jaiscloud-gcp/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -276,6 +277,13 @@ func startCmd() *cobra.Command {
 			kmsGRPC := grpckms.NewService(stores.keys, stores.resources, crypto.NewEnvelopeEncryptor(stores.keys), cfg.ProjectID)
 			loggingGRPC := grpclogging.NewService(stores.logEntries, cfg.ProjectID)
 			monitoringGRPC := grpcmonitoring.NewService(stores.monitoring, cfg.ProjectID)
+			// The background evaluator evaluates alert-policy condition_threshold
+			// conditions, opens/closes incidents, and publishes notifications to
+			// pubsub notification channels via the emulator's Pub/Sub store.
+			monitoringEval := grpcmonitoring.NewEvaluator(stores.monitoring, pubsubNotificationPublisher{
+				messages:  stores.messages,
+				encryptor: crypto.NewEnvelopeEncryptor(stores.keys),
+			})
 			storageGRPC := grpcstorage.NewService(stores.objects, stores.resources, storageP, cfg.ProjectID)
 			datastoreGRPC := grpcdatastore.NewService(stores.entities, cfg.ProjectID)
 			gserv := grpcserver.NewServer(fmt.Sprintf(":%d", grpcPort))
@@ -486,6 +494,13 @@ func startCmd() *cobra.Command {
 
 			srv := gateway.NewServer(cfg, adminHandler, reg, cloudAdapter, certs, gatewayOpts...)
 
+			// Background Cloud Monitoring alert-policy evaluator (30s ticker,
+			// matching the AWS CloudWatch alarm evaluator). Stopped cleanly when
+			// the server shuts down.
+			evalCtx, evalCancel := context.WithCancel(ctx)
+			go monitoringEval.Run(evalCtx)
+			defer evalCancel()
+
 			// Serve gRPC on its own listener (plaintext h2c) alongside the HTTP
 			// gateway. Emulator-mode SDKs point FIRESTORE_EMULATOR_HOST here.
 			go func() {
@@ -548,6 +563,44 @@ func bindFlags(cmd *cobra.Command) {
 	viper.BindPFlag("blob_dir", cmd.Flags().Lookup("blob-dir"))
 	viper.BindPFlag("gcp_metadata_enabled", cmd.Flags().Lookup("gcp-metadata"))
 	viper.BindPFlag("kms_master_key", cmd.Flags().Lookup("kms-master-key"))
+}
+
+// pubsubNotificationPublisher adapts the emulator's Pub/Sub message store to
+// the monitoring evaluator's Publisher interface. Alert-policy notifications
+// are written as ordinary Pub/Sub messages (envelope-encrypted with the server
+// DEK, matching the Publish service) on the channel's labels.topic, which is
+// the observable effect (mirrors AWS CloudWatch alarm -> SNS delivery).
+type pubsubNotificationPublisher struct {
+	messages  pubsubstore.Messages
+	encryptor crypto.EnvelopeEncryptor
+}
+
+// Publish writes a message to the topic named by topic (a full
+// "projects/{p}/topics/{t}" resource name).
+func (p pubsubNotificationPublisher) Publish(ctx context.Context, topic string, data []byte) error {
+	short := topic
+	if i := strings.LastIndex(topic, "/topics/"); i >= 0 {
+		short = topic[i+len("/topics/"):]
+	}
+	rawDEK, wrappedDEK, err := p.encryptor.Wrap(ctx, "", "")
+	if err != nil {
+		return err
+	}
+	ciphertext, err := kmsstore.EncryptData(rawDEK, data, nil)
+	if err != nil {
+		return err
+	}
+	id, err := p.messages.NextID(ctx)
+	if err != nil {
+		return err
+	}
+	return p.messages.Put(ctx, pubsubstore.Message{
+		Topic:       short,
+		MessageID:   id,
+		Data:        base64.StdEncoding.EncodeToString(ciphertext),
+		PublishTime: clock.Now(),
+		WrappedDEK:  wrappedDEK,
+	})
 }
 
 // stores bundles the per-mode store backends constructed by initStores.

--- a/internal/gcp/grpc/monitoring/evaluator.go
+++ b/internal/gcp/grpc/monitoring/evaluator.go
@@ -1,0 +1,646 @@
+package monitoring
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	monitoringpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"jaiscloud/internal/clock"
+	monitoringstore "jaiscloud/internal/gcp/store/monitoring"
+
+	"github.com/google/uuid"
+)
+
+// Publisher publishes a notification payload to a Pub/Sub topic identified by
+// its full resource name (projects/{p}/topics/{t}). It is the evaluator's only
+// side-effecting dependency and is injected so the engine is unit-testable;
+// main.go wires an adapter over the emulator's Pub/Sub message store.
+type Publisher interface {
+	Publish(ctx context.Context, topic string, data []byte) error
+}
+
+// Evaluator is the background alert-policy evaluator. Every tick it lists the
+// alert policies of every known project, evaluates each enabled policy's
+// condition_threshold conditions, combines them with the policy's Combiner,
+// and reconciles incidents: a transition to firing opens an incident and
+// delivers notifications; a transition to not-firing closes the open incident
+// and delivers a resolution notification.
+type Evaluator struct {
+	store     monitoringstore.Store
+	publisher Publisher
+	projects  func() []string
+	tick      time.Duration
+	log       *slog.Logger
+}
+
+// Option configures an Evaluator.
+type Option func(*Evaluator)
+
+// WithTick overrides the evaluation interval (default 30s, matching the AWS
+// CloudWatch evaluator).
+func WithTick(d time.Duration) Option {
+	return func(e *Evaluator) {
+		if d > 0 {
+			e.tick = d
+		}
+	}
+}
+
+// WithProjects injects the project list the evaluator scans. When unset the
+// evaluator derives projects from the store (ListProjects).
+func WithProjects(f func() []string) Option {
+	return func(e *Evaluator) { e.projects = f }
+}
+
+// WithLogger overrides the logger (default slog.Default).
+func WithLogger(l *slog.Logger) Option {
+	return func(e *Evaluator) {
+		if l != nil {
+			e.log = l
+		}
+	}
+}
+
+// NewEvaluator returns an Evaluator over the monitoring store. pub may be nil
+// (pubsub delivery is then skipped and recorded as such).
+func NewEvaluator(store monitoringstore.Store, pub Publisher, opts ...Option) *Evaluator {
+	e := &Evaluator{
+		store:     store,
+		publisher: pub,
+		tick:      30 * time.Second,
+		log:       slog.Default(),
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// errIncidentNotOpen aborts an atomic close when the incident is already
+// closed (a concurrent evaluator won the race); callers treat it as "no
+// transition", not an error.
+var errIncidentNotOpen = errors.New("incident not open")
+
+// Run blocks until ctx is cancelled, evaluating every tick.
+func (e *Evaluator) Run(ctx context.Context) {
+	t := time.NewTicker(e.tick)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			e.EvaluateAll(ctx)
+		}
+	}
+}
+
+// EvaluateAll evaluates every enabled alert policy in every known project once.
+// It is the synchronous entry point used by tests and by Run's ticker.
+func (e *Evaluator) EvaluateAll(ctx context.Context) {
+	projects, err := e.listProjects(ctx)
+	if err != nil {
+		e.log.Warn("monitoring evaluator: list projects failed", "err", err)
+		return
+	}
+	for _, project := range projects {
+		policies, err := e.store.ListAlertPolicies(ctx, project)
+		if err != nil {
+			e.log.Warn("monitoring evaluator: list policies failed", "project", project, "err", err)
+			continue
+		}
+		for _, p := range policies {
+			if p.Enabled != nil && !*p.Enabled {
+				continue
+			}
+			e.evaluatePolicy(ctx, project, p)
+		}
+	}
+}
+
+func (e *Evaluator) listProjects(ctx context.Context) ([]string, error) {
+	if e.projects != nil {
+		return e.projects(), nil
+	}
+	return e.store.ListProjects(ctx)
+}
+
+func (e *Evaluator) evaluatePolicy(ctx context.Context, project string, p monitoringstore.AlertPolicy) {
+	firing, conditionName, reason := e.evaluateConditions(ctx, project, p)
+	e.reconcile(ctx, project, p, firing, conditionName, reason)
+}
+
+// evaluateConditions combines the policy's conditions. AND and
+// AND_WITH_MATCHING_RESOURCE require every condition to fire; OR requires at
+// least one. An empty condition list never fires.
+func (e *Evaluator) evaluateConditions(ctx context.Context, project string, p monitoringstore.AlertPolicy) (bool, string, string) {
+	if len(p.Conditions) == 0 {
+		return false, "", "no conditions"
+	}
+	useOr := monitoringpb.AlertPolicy_ConditionCombinerType(p.Combiner) == monitoringpb.AlertPolicy_OR
+
+	firingName := ""
+	firingReason := ""
+	allFire := true
+	for _, raw := range p.Conditions {
+		cond := &monitoringpb.AlertPolicy_Condition{}
+		if err := protojson.Unmarshal(raw, cond); err != nil {
+			e.log.Warn("monitoring evaluator: unparseable condition", "project", project, "policy", p.ID, "err", err)
+			allFire = false
+			continue
+		}
+		firing, reason := e.evaluateCondition(ctx, project, p, cond)
+		if firing {
+			if firingName == "" {
+				firingName = cond.GetDisplayName()
+				firingReason = reason
+			}
+			continue
+		}
+		allFire = false
+		if !useOr {
+			return false, "", "condition not firing: " + cond.GetDisplayName()
+		}
+	}
+	if useOr {
+		if firingName != "" {
+			return true, firingName, firingReason
+		}
+		return false, "", "no condition firing"
+	}
+	if allFire {
+		return true, firingName, firingReason
+	}
+	return false, "", "not all conditions firing"
+}
+
+// evaluateCondition evaluates a single condition. Only condition_threshold is
+// evaluated; every other condition type is logged and treated as not firing.
+func (e *Evaluator) evaluateCondition(ctx context.Context, project string, p monitoringstore.AlertPolicy, cond *monitoringpb.AlertPolicy_Condition) (bool, string) {
+	mt := cond.GetConditionThreshold()
+	if mt == nil {
+		e.log.Warn("monitoring evaluator: condition type not evaluated",
+			"project", project, "policy", p.ID, "condition", cond.GetDisplayName())
+		return false, "unsupported condition type"
+	}
+	return e.evaluateThreshold(ctx, project, p, mt)
+}
+
+// evaluateThreshold implements the emulator's condition_threshold semantics.
+//
+// Filter subset: equality clauses joined by " AND " on metric.type,
+// resource.type, metric.label.{key}, and resource.label.{key}. Unknown clauses
+// are ignored.
+//
+// The matching series' latest point in each alignment window is taken as the
+// per-series value; a cross-series reducer then collapses them (default: mean
+// across series when no reducer is set). trigger count/percent applies only
+// when no reducer is set (per-series violation counting); with a reducer the
+// single reduced value is compared directly. duration widens the evaluation to
+// consecutive alignment windows that must all satisfy the comparison.
+func (e *Evaluator) evaluateThreshold(ctx context.Context, project string, p monitoringstore.AlertPolicy, mt *monitoringpb.AlertPolicy_Condition_MetricThreshold) (bool, string) {
+	filter := compileMetricFilter(mt.GetFilter())
+	all, err := e.store.ListTimeSeries(ctx, project)
+	if err != nil {
+		e.log.Warn("monitoring evaluator: list time series failed", "project", project, "policy", p.ID, "err", err)
+		return false, "time series read failed"
+	}
+	matching := make([]monitoringstore.TimeSeries, 0, len(all))
+	for _, ts := range all {
+		if filter.match(ts) {
+			matching = append(matching, ts)
+		}
+	}
+	if len(matching) == 0 {
+		return false, "no matching time series"
+	}
+
+	alignment := 60 * time.Second
+	reducer := monitoringpb.Aggregation_REDUCE_NONE
+	if aggs := mt.GetAggregations(); len(aggs) > 0 {
+		if ap := aggs[0].GetAlignmentPeriod(); ap != nil && ap.AsDuration() > 0 {
+			alignment = ap.AsDuration()
+		}
+		reducer = aggs[0].GetCrossSeriesReducer()
+	}
+	var duration time.Duration
+	if d := mt.GetDuration(); d != nil {
+		duration = d.AsDuration()
+	}
+	triggerCount := int32(0)
+	triggerPercent := float64(0)
+	if t := mt.GetTrigger(); t != nil {
+		triggerCount = t.GetCount()
+		triggerPercent = t.GetPercent()
+	}
+	cmp := mt.GetComparison()
+	threshold := mt.GetThresholdValue()
+
+	now := clock.Now()
+	if duration <= alignment {
+		return e.evalWindow(matching, now.Add(-alignment), now, reducer, cmp, threshold, triggerCount, triggerPercent)
+	}
+
+	// The threshold must hold across the whole duration: every consecutive
+	// alignment window covering it must fire.
+	slots := int((duration + alignment - 1) / alignment)
+	for i := 0; i < slots; i++ {
+		end := now.Add(-time.Duration(i) * alignment)
+		start := end.Add(-alignment)
+		firing, reason := e.evalWindow(matching, start, end, reducer, cmp, threshold, triggerCount, triggerPercent)
+		if !firing {
+			return false, fmt.Sprintf("threshold not held for duration (%s)", reason)
+		}
+	}
+	return true, fmt.Sprintf("threshold held for %s", duration)
+}
+
+// evalWindow evaluates one alignment window. start is exclusive, end
+// inclusive. It returns (firing, reason); a window with no data does not fire.
+func (e *Evaluator) evalWindow(series []monitoringstore.TimeSeries, start, end time.Time, reducer monitoringpb.Aggregation_Reducer, cmp monitoringpb.ComparisonType, threshold float64, triggerCount int32, triggerPercent float64) (bool, string) {
+	vals := make([]float64, 0, len(series))
+	for _, ts := range series {
+		if v, ok := seriesLatestInWindow(ts, start, end); ok {
+			vals = append(vals, v)
+		}
+	}
+	if len(vals) == 0 {
+		return false, "insufficient data"
+	}
+
+	if reducer != monitoringpb.Aggregation_REDUCE_NONE {
+		v, _ := reduceValues(reducer, vals)
+		return compareThreshold(v, cmp, threshold), fmt.Sprintf("reduced value %g %s threshold %g", v, comparisonSymbol(cmp), threshold)
+	}
+
+	// No reducer: honor an explicit trigger as per-series violation counting;
+	// otherwise default to the mean across series.
+	if triggerCount > 0 || triggerPercent > 0 {
+		violating := 0
+		for _, v := range vals {
+			if compareThreshold(v, cmp, threshold) {
+				violating++
+			}
+		}
+		switch {
+		case triggerCount > 0:
+			return violating >= int(triggerCount), fmt.Sprintf("%d/%d series violating (trigger count %d)", violating, len(vals), triggerCount)
+		case triggerPercent > 0:
+			pct := float64(violating) / float64(len(vals)) * 100
+			return pct >= triggerPercent, fmt.Sprintf("%.1f%% series violating (trigger percent %.1f%%)", pct, triggerPercent)
+		}
+	}
+
+	v, _ := reduceValues(monitoringpb.Aggregation_REDUCE_MEAN, vals)
+	return compareThreshold(v, cmp, threshold), fmt.Sprintf("mean %g %s threshold %g", v, comparisonSymbol(cmp), threshold)
+}
+
+// seriesLatestInWindow returns the latest point value within (start, end].
+func seriesLatestInWindow(ts monitoringstore.TimeSeries, start, end time.Time) (float64, bool) {
+	var best *monitoringstore.Point
+	for i := range ts.Points {
+		p := &ts.Points[i]
+		if p.EndTime.IsZero() {
+			continue
+		}
+		if p.EndTime.After(start) && !p.EndTime.After(end) {
+			if best == nil || p.EndTime.After(best.EndTime) {
+				best = p
+			}
+		}
+	}
+	if best == nil {
+		return 0, false
+	}
+	return pointValue(best.Value)
+}
+
+// pointValue extracts the numeric value from a stored TypedValue, mirroring how
+// the store reads int64/double/bool.
+func pointValue(v monitoringstore.TypedValue) (float64, bool) {
+	switch {
+	case v.DoubleValue != nil:
+		return *v.DoubleValue, true
+	case v.Int64Value != nil:
+		return float64(*v.Int64Value), true
+	case v.BoolValue != nil:
+		if *v.BoolValue {
+			return 1, true
+		}
+		return 0, true
+	}
+	return 0, false
+}
+
+// reduceValues applies a cross-series reducer. A zero-length input has no
+// value. REDUCE_NONE and unknown reducers fall back to the mean.
+func reduceValues(reducer monitoringpb.Aggregation_Reducer, vals []float64) (float64, bool) {
+	if len(vals) == 0 {
+		return 0, false
+	}
+	switch reducer {
+	case monitoringpb.Aggregation_REDUCE_SUM:
+		var s float64
+		for _, v := range vals {
+			s += v
+		}
+		return s, true
+	case monitoringpb.Aggregation_REDUCE_MAX:
+		m := vals[0]
+		for _, v := range vals[1:] {
+			if v > m {
+				m = v
+			}
+		}
+		return m, true
+	case monitoringpb.Aggregation_REDUCE_MIN:
+		m := vals[0]
+		for _, v := range vals[1:] {
+			if v < m {
+				m = v
+			}
+		}
+		return m, true
+	case monitoringpb.Aggregation_REDUCE_COUNT:
+		return float64(len(vals)), true
+	default: // REDUCE_MEAN, REDUCE_NONE, anything else
+		var s float64
+		for _, v := range vals {
+			s += v
+		}
+		return s / float64(len(vals)), true
+	}
+}
+
+func compareThreshold(v float64, cmp monitoringpb.ComparisonType, threshold float64) bool {
+	switch cmp {
+	case monitoringpb.ComparisonType_COMPARISON_GT:
+		return v > threshold
+	case monitoringpb.ComparisonType_COMPARISON_GE:
+		return v >= threshold
+	case monitoringpb.ComparisonType_COMPARISON_LT:
+		return v < threshold
+	case monitoringpb.ComparisonType_COMPARISON_LE:
+		return v <= threshold
+	case monitoringpb.ComparisonType_COMPARISON_EQ:
+		return v == threshold
+	case monitoringpb.ComparisonType_COMPARISON_NE:
+		return v != threshold
+	}
+	return false
+}
+
+func comparisonSymbol(cmp monitoringpb.ComparisonType) string {
+	switch cmp {
+	case monitoringpb.ComparisonType_COMPARISON_GT:
+		return ">"
+	case monitoringpb.ComparisonType_COMPARISON_GE:
+		return ">="
+	case monitoringpb.ComparisonType_COMPARISON_LT:
+		return "<"
+	case monitoringpb.ComparisonType_COMPARISON_LE:
+		return "<="
+	case monitoringpb.ComparisonType_COMPARISON_EQ:
+		return "=="
+	case monitoringpb.ComparisonType_COMPARISON_NE:
+		return "!="
+	}
+	return "?"
+}
+
+// ─── filter subset ────────────────────────────────────────────────────────────
+
+// metricFilter is the metric.type / resource.type / metric.label.* /
+// resource.label.* equality subset of the Cloud Monitoring filter grammar that
+// the evaluator supports. Unknown clauses are ignored.
+type metricFilter struct {
+	metricType     string
+	resourceType   string
+	metricLabels   map[string]string
+	resourceLabels map[string]string
+}
+
+func compileMetricFilter(s string) metricFilter {
+	f := metricFilter{}
+	for _, clause := range strings.Split(s, " AND ") {
+		key, val, ok := parseEquality(strings.TrimSpace(clause))
+		if !ok {
+			continue
+		}
+		switch {
+		case key == "metric.type":
+			f.metricType = val
+		case key == "resource.type":
+			f.resourceType = val
+		case strings.HasPrefix(key, "metric.label."):
+			if f.metricLabels == nil {
+				f.metricLabels = make(map[string]string)
+			}
+			f.metricLabels[strings.TrimPrefix(key, "metric.label.")] = val
+		case strings.HasPrefix(key, "resource.label."):
+			if f.resourceLabels == nil {
+				f.resourceLabels = make(map[string]string)
+			}
+			f.resourceLabels[strings.TrimPrefix(key, "resource.label.")] = val
+		}
+	}
+	return f
+}
+
+func (f metricFilter) match(ts monitoringstore.TimeSeries) bool {
+	if f.metricType != "" && ts.MetricType != f.metricType {
+		return false
+	}
+	if f.resourceType != "" && ts.ResourceType != f.resourceType {
+		return false
+	}
+	for k, v := range f.metricLabels {
+		if ts.MetricLabels[k] != v {
+			return false
+		}
+	}
+	for k, v := range f.resourceLabels {
+		if ts.ResourceLabels[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// ─── incidents + delivery ─────────────────────────────────────────────────────
+
+func (e *Evaluator) reconcile(ctx context.Context, project string, p monitoringstore.AlertPolicy, firing bool, conditionName, reason string) {
+	if firing {
+		e.openIncident(ctx, project, p, conditionName, reason)
+		return
+	}
+	e.closeIncident(ctx, project, p, reason)
+}
+
+func (e *Evaluator) openIncident(ctx context.Context, project string, p monitoringstore.AlertPolicy, conditionName, reason string) {
+	if _, err := e.store.FindOpenIncident(ctx, project, p.ID); err == nil {
+		return // already open
+	} else if !errors.Is(err, monitoringstore.ErrIncidentNotFound) {
+		e.log.Warn("monitoring evaluator: find open incident failed", "project", project, "policy", p.ID, "err", err)
+		return
+	}
+
+	now := clock.Now()
+	inc := monitoringstore.Incident{
+		ID:            uuid.NewString(),
+		ProjectID:     project,
+		PolicyID:      p.ID,
+		ConditionName: conditionName,
+		State:         monitoringstore.IncidentOpen,
+		StartedAt:     now,
+		Reason:        reason,
+	}
+	if err := e.store.CreateIncident(ctx, inc); err != nil {
+		if !errors.Is(err, monitoringstore.ErrIncidentExists) {
+			e.log.Warn("monitoring evaluator: create incident failed", "project", project, "policy", p.ID, "err", err)
+		}
+		return
+	}
+	e.log.Info("monitoring: incident opened",
+		"project", project, "policy", p.ID, "policyName", p.DisplayName, "incident", inc.ID, "reason", reason)
+
+	notifs := e.deliver(ctx, project, p, inc, "OPEN", reason)
+	if len(notifs) > 0 {
+		_, _ = e.store.UpdateIncidentAtomic(ctx, project, inc.ID, func(cur monitoringstore.Incident) (monitoringstore.Incident, error) {
+			cur.Notifications = append(cur.Notifications, notifs...)
+			return cur, nil
+		})
+	}
+}
+
+func (e *Evaluator) closeIncident(ctx context.Context, project string, p monitoringstore.AlertPolicy, reason string) {
+	open, err := e.store.FindOpenIncident(ctx, project, p.ID)
+	if err != nil {
+		return
+	}
+	now := clock.Now()
+	closed, err := e.store.UpdateIncidentAtomic(ctx, project, open.ID, func(cur monitoringstore.Incident) (monitoringstore.Incident, error) {
+		if cur.State != monitoringstore.IncidentOpen {
+			return cur, errIncidentNotOpen
+		}
+		cur.State = monitoringstore.IncidentClosed
+		cur.EndedAt = now
+		cur.Reason = "resolved: " + reason
+		return cur, nil
+	})
+	if err != nil {
+		if !errors.Is(err, errIncidentNotOpen) {
+			e.log.Warn("monitoring evaluator: close incident failed", "project", project, "policy", p.ID, "err", err)
+		}
+		return
+	}
+	e.log.Info("monitoring: incident closed",
+		"project", project, "policy", p.ID, "policyName", p.DisplayName, "incident", closed.ID, "reason", closed.Reason)
+
+	notifs := e.deliver(ctx, project, p, closed, "CLOSED", closed.Reason)
+	if len(notifs) > 0 {
+		_, _ = e.store.UpdateIncidentAtomic(ctx, project, closed.ID, func(cur monitoringstore.Incident) (monitoringstore.Incident, error) {
+			cur.Notifications = append(cur.Notifications, notifs...)
+			return cur, nil
+		})
+	}
+}
+
+// deliver resolves each notification channel on the policy and attempts a
+// delivery. Only "pubsub" channels are actually published (to the channel's
+// labels.topic via the injected Publisher); email/webhook/sms are recorded on
+// the incident and slog'd but not sent, and every outcome is recorded.
+func (e *Evaluator) deliver(ctx context.Context, project string, p monitoringstore.AlertPolicy, inc monitoringstore.Incident, state, reason string) []monitoringstore.IncidentNotification {
+	if len(p.NotificationChannels) == 0 {
+		return nil
+	}
+	now := clock.Now()
+	out := make([]monitoringstore.IncidentNotification, 0, len(p.NotificationChannels))
+	for _, name := range p.NotificationChannels {
+		cp, id, ok := splitNotificationChannelName(name)
+		if !ok {
+			out = append(out, monitoringstore.IncidentNotification{ChannelName: name, Status: "skipped", Detail: "invalid channel name", DeliveredAt: now})
+			continue
+		}
+		ch, err := e.store.GetNotificationChannel(ctx, cp, id)
+		if err != nil {
+			e.log.Warn("monitoring evaluator: notification channel not found", "project", cp, "channel", id, "err", err)
+			out = append(out, monitoringstore.IncidentNotification{ChannelName: name, Status: "skipped", Detail: "channel not found", DeliveredAt: now})
+			continue
+		}
+		if ch.Enabled != nil && !*ch.Enabled {
+			out = append(out, monitoringstore.IncidentNotification{ChannelName: name, ChannelType: ch.Type, Status: "skipped", Detail: "channel disabled", DeliveredAt: now})
+			continue
+		}
+
+		n := monitoringstore.IncidentNotification{ChannelName: name, ChannelType: ch.Type, DeliveredAt: now}
+		switch ch.Type {
+		case "pubsub":
+			topic := ch.Labels["topic"]
+			if topic == "" {
+				n.Status, n.Detail = "skipped", "pubsub channel has no labels.topic"
+				break
+			}
+			if e.publisher == nil {
+				n.Status, n.Detail = "skipped", "no pubsub publisher wired"
+				break
+			}
+			payload := notificationPayload(project, p, inc, state, reason, now)
+			if err := e.publisher.Publish(ctx, topic, payload); err != nil {
+				e.log.Warn("monitoring evaluator: pubsub notification failed", "project", project, "topic", topic, "err", err)
+				n.Status, n.Detail = "failed", err.Error()
+				break
+			}
+			n.Status = "delivered"
+			e.log.Info("monitoring: notification delivered",
+				"project", project, "policy", p.ID, "incident", inc.ID, "topic", topic, "state", state)
+		case "email", "webhook", "sms":
+			n.Status, n.Detail = "recorded", "recorded but not sent by the emulator"
+			e.log.Info("monitoring: notification recorded (not sent by emulator)",
+				"project", project, "policy", p.ID, "incident", inc.ID, "type", ch.Type, "state", state)
+		default:
+			n.Status, n.Detail = "skipped", "unsupported channel type "+ch.Type
+			e.log.Warn("monitoring evaluator: unsupported notification channel type", "type", ch.Type)
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+// notificationPayload renders a CloudEvents-style JSON envelope. It mirrors the
+// AWS CloudWatch->SNS alarm payload as the observable emulator effect.
+func notificationPayload(project string, p monitoringstore.AlertPolicy, inc monitoringstore.Incident, state, reason string, now time.Time) []byte {
+	envelope := map[string]any{
+		"specversion":     "1.0",
+		"id":              inc.ID,
+		"source":          fmt.Sprintf("//monitoring.googleapis.com/projects/%s/alertPolicies/%s", project, p.ID),
+		"type":            "google.cloud.monitoring.alert.v1.Incident",
+		"time":            now.Format(time.RFC3339),
+		"datacontenttype": "application/json",
+		"data": map[string]any{
+			"state":  state,
+			"reason": reason,
+			"incident": map[string]any{
+				"incidentId":        inc.ID,
+				"policyId":          p.ID,
+				"policyName":        alertPolicyName(project, p.ID),
+				"policyDisplayName": p.DisplayName,
+				"conditionName":     inc.ConditionName,
+				"state":             string(inc.State),
+				"startedAt":         inc.StartedAt.Format(time.RFC3339),
+			},
+		},
+	}
+	b, err := json.Marshal(envelope)
+	if err != nil {
+		return []byte("{}")
+	}
+	return b
+}

--- a/internal/gcp/grpc/monitoring/evaluator_test.go
+++ b/internal/gcp/grpc/monitoring/evaluator_test.go
@@ -1,0 +1,309 @@
+package monitoring
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	monitoringpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"jaiscloud/internal/clock"
+	monitoringstore "jaiscloud/internal/gcp/store/monitoring"
+)
+
+// recordingPublisher is a Publisher that records every delivery.
+type recordingPublisher struct {
+	mu       sync.Mutex
+	topics   []string
+	payloads [][]byte
+	fail     bool
+}
+
+func (p *recordingPublisher) Publish(_ context.Context, topic string, data []byte) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.fail {
+		return errors.New("publish failed")
+	}
+	p.topics = append(p.topics, topic)
+	p.payloads = append(p.payloads, data)
+	return nil
+}
+
+func (p *recordingPublisher) count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.topics)
+}
+
+func newEvalFixture(t *testing.T) (monitoringstore.Store, *recordingPublisher, *Evaluator) {
+	t.Helper()
+	store := monitoringstore.NewMemoryStore()
+	pub := &recordingPublisher{}
+	ev := NewEvaluator(store, pub, WithProjects(func() []string { return []string{"test"} }))
+	return store, pub, ev
+}
+
+func putChannel(t *testing.T, store monitoringstore.Store, project, id, typ string, labels map[string]string) {
+	t.Helper()
+	enabled := true
+	if err := store.CreateNotificationChannel(context.Background(), project, monitoringstore.NotificationChannel{
+		ID: id, Type: typ, DisplayName: id, Labels: labels, Enabled: &enabled,
+	}); err != nil {
+		t.Fatalf("create channel: %v", err)
+	}
+}
+
+func putSeries(t *testing.T, store monitoringstore.Store, project, metricType, resourceType string, labels map[string]string, value float64, end time.Time) {
+	t.Helper()
+	v := value
+	if err := store.CreateTimeSeries(context.Background(), project, monitoringstore.TimeSeries{
+		MetricType:   metricType,
+		MetricLabels: labels,
+		ResourceType: resourceType,
+		MetricKind:   1,
+		ValueType:    3,
+		Points:       []monitoringstore.Point{{EndTime: end, Value: monitoringstore.TypedValue{DoubleValue: &v}}},
+	}); err != nil {
+		t.Fatalf("create time series: %v", err)
+	}
+}
+
+func thresholdCondition(name, filter string, cmp monitoringpb.ComparisonType, threshold float64) *monitoringpb.AlertPolicy_Condition {
+	return &monitoringpb.AlertPolicy_Condition{
+		DisplayName: name,
+		Condition: &monitoringpb.AlertPolicy_Condition_ConditionThreshold{ConditionThreshold: &monitoringpb.AlertPolicy_Condition_MetricThreshold{
+			Filter:         filter,
+			Comparison:     cmp,
+			ThresholdValue: threshold,
+		}},
+	}
+}
+
+var policySeq int
+
+func putPolicy(t *testing.T, store monitoringstore.Store, project string, combiner monitoringpb.AlertPolicy_ConditionCombinerType, channels []string, conds ...*monitoringpb.AlertPolicy_Condition) string {
+	t.Helper()
+	policySeq++
+	id := fmt.Sprintf("ap-%d", policySeq)
+	raw := make([]json.RawMessage, 0, len(conds))
+	for _, c := range conds {
+		b, err := protojson.Marshal(c)
+		if err != nil {
+			t.Fatalf("marshal condition: %v", err)
+		}
+		raw = append(raw, json.RawMessage(b))
+	}
+	enabled := true
+	p := monitoringstore.AlertPolicy{
+		ID: id, DisplayName: "policy " + id, Combiner: int32(combiner), Enabled: &enabled,
+		Conditions: raw, NotificationChannels: channels,
+	}
+	if err := store.CreateAlertPolicy(context.Background(), project, p); err != nil {
+		t.Fatalf("create policy: %v", err)
+	}
+	return id
+}
+
+func cpuFilter() string {
+	return `metric.type = "custom.googleapis.com/cpu" AND resource.type = "global"`
+}
+
+func TestEvaluatorThresholdCrossingOpensIncidentAndDelivers(t *testing.T) {
+	store, pub, ev := newEvalFixture(t)
+	ctx := context.Background()
+	putChannel(t, store, "test", "nc1", "pubsub", map[string]string{"topic": "projects/test/topics/alerts"})
+	policyID := putPolicy(t, store, "test", monitoringpb.AlertPolicy_AND,
+		[]string{"projects/test/notificationChannels/nc1"},
+		thresholdCondition("cpu high", cpuFilter(), monitoringpb.ComparisonType_COMPARISON_GT, 0.9))
+	putSeries(t, store, "test", "custom.googleapis.com/cpu", "global", nil, 0.95, clock.Now())
+
+	ev.EvaluateAll(ctx)
+
+	inc, err := store.FindOpenIncident(ctx, "test", policyID)
+	if err != nil {
+		t.Fatalf("expected an open incident: %v", err)
+	}
+	if inc.State != monitoringstore.IncidentOpen {
+		t.Fatalf("incident state = %q, want OPEN", inc.State)
+	}
+	if pub.count() != 1 {
+		t.Fatalf("published %d notifications, want 1", pub.count())
+	}
+	if pub.topics[0] != "projects/test/topics/alerts" {
+		t.Fatalf("published to %q", pub.topics[0])
+	}
+	if len(inc.Notifications) != 1 || inc.Notifications[0].Status != "delivered" {
+		t.Fatalf("incident notifications = %+v", inc.Notifications)
+	}
+
+	// A second evaluation with the same firing state must not re-open or
+	// re-notify.
+	ev.EvaluateAll(ctx)
+	if pub.count() != 1 {
+		t.Fatalf("published %d notifications after second tick, want 1 (no duplicate)", pub.count())
+	}
+}
+
+func TestEvaluatorBelowThresholdDoesNotFire(t *testing.T) {
+	store, pub, ev := newEvalFixture(t)
+	ctx := context.Background()
+	putChannel(t, store, "test", "nc1", "pubsub", map[string]string{"topic": "projects/test/topics/alerts"})
+	policyID := putPolicy(t, store, "test", monitoringpb.AlertPolicy_AND,
+		[]string{"projects/test/notificationChannels/nc1"},
+		thresholdCondition("cpu high", cpuFilter(), monitoringpb.ComparisonType_COMPARISON_GT, 0.9))
+	putSeries(t, store, "test", "custom.googleapis.com/cpu", "global", nil, 0.5, clock.Now())
+
+	ev.EvaluateAll(ctx)
+
+	if _, err := store.FindOpenIncident(ctx, "test", policyID); !errors.Is(err, monitoringstore.ErrIncidentNotFound) {
+		t.Fatalf("find open incident err = %v, want ErrIncidentNotFound", err)
+	}
+	if pub.count() != 0 {
+		t.Fatalf("published %d notifications, want 0", pub.count())
+	}
+}
+
+func TestEvaluatorResolveClosesIncidentAndNotifies(t *testing.T) {
+	store, pub, ev := newEvalFixture(t)
+	ctx := context.Background()
+	putChannel(t, store, "test", "nc1", "pubsub", map[string]string{"topic": "projects/test/topics/alerts"})
+	policyID := putPolicy(t, store, "test", monitoringpb.AlertPolicy_AND,
+		[]string{"projects/test/notificationChannels/nc1"},
+		thresholdCondition("cpu high", cpuFilter(), monitoringpb.ComparisonType_COMPARISON_GT, 0.9))
+	putSeries(t, store, "test", "custom.googleapis.com/cpu", "global", nil, 0.95, clock.Now().Add(-2*time.Second))
+
+	ev.EvaluateAll(ctx)
+	if _, err := store.FindOpenIncident(ctx, "test", policyID); err != nil {
+		t.Fatalf("expected open incident: %v", err)
+	}
+
+	// A newer point below the threshold resolves the incident.
+	putSeries(t, store, "test", "custom.googleapis.com/cpu", "global", nil, 0.1, clock.Now().Add(-1*time.Second))
+	ev.EvaluateAll(ctx)
+
+	if _, err := store.FindOpenIncident(ctx, "test", policyID); !errors.Is(err, monitoringstore.ErrIncidentNotFound) {
+		t.Fatalf("find open incident after resolve err = %v, want ErrIncidentNotFound", err)
+	}
+	incidents, err := store.ListIncidents(ctx, "test")
+	if err != nil || len(incidents) != 1 {
+		t.Fatalf("incidents = %+v, %v", incidents, err)
+	}
+	if incidents[0].State != monitoringstore.IncidentClosed || incidents[0].EndedAt.IsZero() {
+		t.Fatalf("closed incident = %+v", incidents[0])
+	}
+	if pub.count() != 2 {
+		t.Fatalf("published %d notifications, want 2 (open + resolve)", pub.count())
+	}
+}
+
+func TestEvaluatorCombinerAND(t *testing.T) {
+	store, pub, ev := newEvalFixture(t)
+	ctx := context.Background()
+	// First condition fires, second does not -> AND must not fire.
+	putPolicy(t, store, "test", monitoringpb.AlertPolicy_AND, nil,
+		thresholdCondition("cpu high", cpuFilter(), monitoringpb.ComparisonType_COMPARISON_GT, 0.9),
+		thresholdCondition("mem high", `metric.type = "custom.googleapis.com/mem"`, monitoringpb.ComparisonType_COMPARISON_GT, 0.9))
+	putSeries(t, store, "test", "custom.googleapis.com/cpu", "global", nil, 0.95, clock.Now())
+	putSeries(t, store, "test", "custom.googleapis.com/mem", "global", nil, 0.1, clock.Now())
+
+	ev.EvaluateAll(ctx)
+
+	if pub.count() != 0 {
+		t.Fatalf("AND published %d notifications, want 0", pub.count())
+	}
+	if got, _ := store.ListIncidents(ctx, "test"); len(got) != 0 {
+		t.Fatalf("AND incidents = %+v, want none", got)
+	}
+}
+
+func TestEvaluatorCombinerOR(t *testing.T) {
+	store, pub, ev := newEvalFixture(t)
+	ctx := context.Background()
+	putChannel(t, store, "test", "nc1", "pubsub", map[string]string{"topic": "projects/test/topics/alerts"})
+	putPolicy(t, store, "test", monitoringpb.AlertPolicy_OR,
+		[]string{"projects/test/notificationChannels/nc1"},
+		thresholdCondition("cpu high", cpuFilter(), monitoringpb.ComparisonType_COMPARISON_GT, 0.9),
+		thresholdCondition("mem high", `metric.type = "custom.googleapis.com/mem"`, monitoringpb.ComparisonType_COMPARISON_GT, 0.9))
+	putSeries(t, store, "test", "custom.googleapis.com/cpu", "global", nil, 0.95, clock.Now())
+	putSeries(t, store, "test", "custom.googleapis.com/mem", "global", nil, 0.1, clock.Now())
+
+	ev.EvaluateAll(ctx)
+
+	if pub.count() != 1 {
+		t.Fatalf("OR published %d notifications, want 1", pub.count())
+	}
+	if got, _ := store.ListIncidents(ctx, "test"); len(got) != 1 || got[0].State != monitoringstore.IncidentOpen {
+		t.Fatalf("OR incidents = %+v, want one OPEN", got)
+	}
+}
+
+func TestEvaluatorNoPointsDoesNotFire(t *testing.T) {
+	store, pub, ev := newEvalFixture(t)
+	ctx := context.Background()
+	policyID := putPolicy(t, store, "test", monitoringpb.AlertPolicy_AND, nil,
+		thresholdCondition("cpu high", cpuFilter(), monitoringpb.ComparisonType_COMPARISON_GT, 0.9))
+
+	ev.EvaluateAll(ctx)
+
+	if _, err := store.FindOpenIncident(ctx, "test", policyID); !errors.Is(err, monitoringstore.ErrIncidentNotFound) {
+		t.Fatalf("find open incident err = %v, want ErrIncidentNotFound (no points)", err)
+	}
+	if pub.count() != 0 {
+		t.Fatalf("published %d notifications without data, want 0", pub.count())
+	}
+}
+
+func TestEvaluatorDisabledPolicySkipped(t *testing.T) {
+	store, pub, ev := newEvalFixture(t)
+	ctx := context.Background()
+	b, _ := protojson.Marshal(thresholdCondition("cpu high", cpuFilter(), monitoringpb.ComparisonType_COMPARISON_GT, 0.9))
+	disabled := false
+	if err := store.CreateAlertPolicy(ctx, "test", monitoringstore.AlertPolicy{
+		ID: "ap-disabled", DisplayName: "off", Combiner: int32(monitoringpb.AlertPolicy_AND),
+		Enabled: &disabled, Conditions: []json.RawMessage{b},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	putSeries(t, store, "test", "custom.googleapis.com/cpu", "global", nil, 0.99, clock.Now())
+
+	ev.EvaluateAll(ctx)
+
+	if pub.count() != 0 {
+		t.Fatalf("disabled policy published %d notifications, want 0", pub.count())
+	}
+	if got, _ := store.ListIncidents(ctx, "test"); len(got) != 0 {
+		t.Fatalf("disabled policy incidents = %+v, want none", got)
+	}
+}
+
+func TestEvaluatorCrossSeriesReducer(t *testing.T) {
+	store, _, ev := newEvalFixture(t)
+	ctx := context.Background()
+	// Two series: 0.95 and 0.85; REDUCE_MAX with GT 0.9 fires, REDUCE_MIN does not.
+	aggMax := &monitoringpb.Aggregation{
+		AlignmentPeriod:    durationpb.New(60 * time.Second),
+		CrossSeriesReducer: monitoringpb.Aggregation_REDUCE_MAX,
+	}
+	cond := &monitoringpb.AlertPolicy_Condition{
+		DisplayName: "max cpu",
+		Condition: &monitoringpb.AlertPolicy_Condition_ConditionThreshold{ConditionThreshold: &monitoringpb.AlertPolicy_Condition_MetricThreshold{
+			Filter: cpuFilter(), Aggregations: []*monitoringpb.Aggregation{aggMax},
+			Comparison: monitoringpb.ComparisonType_COMPARISON_GT, ThresholdValue: 0.9,
+		}},
+	}
+	putPolicy(t, store, "test", monitoringpb.AlertPolicy_AND, nil, cond)
+	putSeries(t, store, "test", "custom.googleapis.com/cpu", "global", map[string]string{"instance": "a"}, 0.95, clock.Now())
+	putSeries(t, store, "test", "custom.googleapis.com/cpu", "global", map[string]string{"instance": "b"}, 0.85, clock.Now())
+
+	ev.EvaluateAll(ctx)
+	if got, _ := store.ListIncidents(ctx, "test"); len(got) != 1 {
+		t.Fatalf("REDUCE_MAX incidents = %+v, want one", got)
+	}
+}

--- a/internal/gcp/grpc/monitoring/service.go
+++ b/internal/gcp/grpc/monitoring/service.go
@@ -2,8 +2,10 @@
 // (MetricService + AlertPolicyService) over the shared monitoringstore.Store —
 // the Amazon CloudWatch metrics+alarms analogue. It manages the metric
 // descriptor catalog, the time-series data plane, and the alert-policy (alarm)
-// registry. Alert policies are stored verbatim; the emulator does not evaluate
-// conditions or trigger notifications.
+// registry. Alert policies are stored verbatim; a background evaluator
+// (evaluator.go) evaluates condition_threshold conditions, opens/closes
+// incidents, and delivers notifications to the referenced notification
+// channels.
 //
 // Documented limitations:
 //
@@ -13,9 +15,15 @@
 //     filter field and return synthesized (not canonical)
 //     MonitoredResourceDescriptors.
 //   - DISTRIBUTION point values are rejected.
-//   - Alert policies are stored but never evaluated.
+//   - Only condition_threshold alert conditions are evaluated;
+//     condition_absent, condition_matched_log,
+//     condition_monitoring_query_language, condition_prometheus_query_language,
+//     and condition_sql are stored but never evaluated.
 //   - ListTimeSeries supports only the metric.type / resource.type equality
 //     filter subset.
+//   - NotificationChannelService supports CRUD only;
+//     ListNotificationChannelDescriptors, GetNotificationChannelDescriptor,
+//     and the verification-code RPCs are Unimplemented.
 package monitoring
 
 import (
@@ -46,11 +54,13 @@ import (
 	"github.com/google/uuid"
 )
 
-// Service implements monitoringpb.MetricServiceServer and
-// monitoringpb.AlertPolicyServiceServer over the shared store.
+// Service implements monitoringpb.MetricServiceServer,
+// monitoringpb.AlertPolicyServiceServer, and
+// monitoringpb.NotificationChannelServiceServer over the shared store.
 type Service struct {
 	monitoringpb.UnimplementedMetricServiceServer
 	monitoringpb.UnimplementedAlertPolicyServiceServer
+	monitoringpb.UnimplementedNotificationChannelServiceServer
 
 	store       monitoringstore.Store
 	defaultProj string
@@ -65,10 +75,13 @@ func NewService(store monitoringstore.Store, defaultProj string) *Service {
 func mapError(err error) error {
 	switch {
 	case errors.Is(err, monitoringstore.ErrMetricDescriptorNotFound),
-		errors.Is(err, monitoringstore.ErrAlertPolicyNotFound):
+		errors.Is(err, monitoringstore.ErrAlertPolicyNotFound),
+		errors.Is(err, monitoringstore.ErrNotificationChannelNotFound):
 		return grpcutil.GRPCStatus(model.NewProviderError("NotFound", "resource not found", 404))
 	case errors.Is(err, monitoringstore.ErrAlertPolicyExists):
 		return grpcutil.GRPCStatus(model.NewProviderError("AlreadyExists", "alert policy already exists", 409))
+	case errors.Is(err, monitoringstore.ErrNotificationChannelExists):
+		return grpcutil.GRPCStatus(model.NewProviderError("AlreadyExists", "notification channel already exists", 409))
 	}
 	return grpcutil.GRPCStatus(err)
 }
@@ -130,6 +143,20 @@ func alertPolicyName(project, id string) string {
 func splitAlertPolicyName(name string) (project, id string, ok bool) {
 	parts := strings.Split(name, "/")
 	if len(parts) != 4 || parts[0] != "projects" || parts[2] != "alertPolicies" {
+		return "", "", false
+	}
+	return parts[1], parts[3], true
+}
+
+func notificationChannelName(project, id string) string {
+	return resource.ResourceID(project)("notification-channel", id)
+}
+
+// splitNotificationChannelName parses
+// "projects/{p}/notificationChannels/{id}".
+func splitNotificationChannelName(name string) (project, id string, ok bool) {
+	parts := strings.Split(name, "/")
+	if len(parts) != 4 || parts[0] != "projects" || parts[2] != "notificationChannels" {
 		return "", "", false
 	}
 	return parts[1], parts[3], true
@@ -406,6 +433,98 @@ func (s *Service) DeleteAlertPolicy(ctx context.Context, req *monitoringpb.Delet
 	return &emptypb.Empty{}, nil
 }
 
+// ─── NotificationChannelService ──────────────────────────────────────────────
+
+func (s *Service) ListNotificationChannels(ctx context.Context, req *monitoringpb.ListNotificationChannelsRequest) (*monitoringpb.ListNotificationChannelsResponse, error) {
+	project := s.project(ctx, req.GetName())
+	channels, err := s.store.ListNotificationChannels(ctx, project)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	page, next := pageSlice(channels, req.GetPageSize(), req.GetPageToken())
+	out := make([]*monitoringpb.NotificationChannel, 0, len(page))
+	for _, c := range page {
+		out = append(out, notificationChannelToProto(c, project))
+	}
+	return &monitoringpb.ListNotificationChannelsResponse{
+		NotificationChannels: out,
+		NextPageToken:        next,
+		TotalSize:            int32(len(channels)),
+	}, nil
+}
+
+func (s *Service) GetNotificationChannel(ctx context.Context, req *monitoringpb.GetNotificationChannelRequest) (*monitoringpb.NotificationChannel, error) {
+	project, id, ok := splitNotificationChannelName(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid notification channel name: "+req.GetName(), 400))
+	}
+	c, err := s.store.GetNotificationChannel(ctx, project, id)
+	if err != nil {
+		return nil, mapError(err)
+	}
+	return notificationChannelToProto(c, project), nil
+}
+
+func (s *Service) CreateNotificationChannel(ctx context.Context, req *monitoringpb.CreateNotificationChannelRequest) (*monitoringpb.NotificationChannel, error) {
+	project := s.project(ctx, req.GetName())
+	c := notificationChannelFromProto(req.GetNotificationChannel())
+	if c.Type == "" {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "notification channel type is required", 400))
+	}
+	if c.Enabled == nil {
+		enabled := true
+		c.Enabled = &enabled
+	}
+	now := clock.Now()
+	c.ID = uuid.NewString()
+	c.CreateTime = now
+	c.UpdateTime = now
+	c.VerificationStatus = int32(monitoringpb.NotificationChannel_VERIFIED)
+	if err := s.store.CreateNotificationChannel(ctx, project, c); err != nil {
+		return nil, mapError(err)
+	}
+	return notificationChannelToProto(c, project), nil
+}
+
+func (s *Service) UpdateNotificationChannel(ctx context.Context, req *monitoringpb.UpdateNotificationChannelRequest) (*monitoringpb.NotificationChannel, error) {
+	project, id, ok := splitNotificationChannelName(req.GetNotificationChannel().GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid notification channel name: "+req.GetNotificationChannel().GetName(), 400))
+	}
+	incoming := notificationChannelFromProto(req.GetNotificationChannel())
+	incoming.ID = id
+	incoming.UpdateTime = clock.Now()
+
+	c, err := s.store.UpdateNotificationChannelAtomic(ctx, project, id, func(stored monitoringstore.NotificationChannel) (monitoringstore.NotificationChannel, error) {
+		paths := req.GetUpdateMask().GetPaths()
+		if len(paths) == 0 {
+			// Full replacement, but preserve the immutable create time and
+			// verification status unless explicitly masked.
+			incoming.CreateTime = stored.CreateTime
+			if incoming.VerificationStatus == 0 {
+				incoming.VerificationStatus = stored.VerificationStatus
+			}
+			return incoming, nil
+		}
+		return applyNotificationChannelMask(stored, incoming, paths)
+	})
+	if err != nil {
+		return nil, mapError(err)
+	}
+	return notificationChannelToProto(c, project), nil
+}
+
+func (s *Service) DeleteNotificationChannel(ctx context.Context, req *monitoringpb.DeleteNotificationChannelRequest) (*emptypb.Empty, error) {
+	project, id, ok := splitNotificationChannelName(req.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid notification channel name: "+req.GetName(), 400))
+	}
+	if err := s.store.DeleteNotificationChannel(ctx, project, id); err != nil {
+		return nil, mapError(err)
+	}
+	return &emptypb.Empty{}, nil
+}
+
 // ─── proto ↔ internal transcoding ─────────────────────────────────────────────
 
 func descriptorToProto(d monitoringstore.MetricDescriptor, project string) *metricpb.MetricDescriptor {
@@ -642,6 +761,78 @@ func applyAlertPolicyMask(stored, incoming monitoringstore.AlertPolicy, updateMa
 			return stored, model.NewProviderError("UnsupportedOperation", "unsupported update_mask path: "+path, 501)
 		}
 	}
+	return stored, nil
+}
+
+func notificationChannelToProto(c monitoringstore.NotificationChannel, project string) *monitoringpb.NotificationChannel {
+	out := &monitoringpb.NotificationChannel{
+		Name:               notificationChannelName(project, c.ID),
+		Type:               c.Type,
+		DisplayName:        c.DisplayName,
+		Description:        c.Description,
+		Labels:             c.Labels,
+		UserLabels:         c.UserLabels,
+		VerificationStatus: monitoringpb.NotificationChannel_VerificationStatus(c.VerificationStatus),
+	}
+	if c.Enabled != nil {
+		out.Enabled = wrapperspb.Bool(*c.Enabled)
+	}
+	if !c.CreateTime.IsZero() {
+		out.CreationRecord = &monitoringpb.MutationRecord{
+			MutateTime: timestamppb.New(c.CreateTime),
+		}
+	}
+	if !c.UpdateTime.IsZero() {
+		out.MutationRecords = []*monitoringpb.MutationRecord{{
+			MutateTime: timestamppb.New(c.UpdateTime),
+		}}
+	}
+	return out
+}
+
+func notificationChannelFromProto(p *monitoringpb.NotificationChannel) monitoringstore.NotificationChannel {
+	if p == nil {
+		return monitoringstore.NotificationChannel{}
+	}
+	c := monitoringstore.NotificationChannel{
+		Type:               p.GetType(),
+		DisplayName:        p.GetDisplayName(),
+		Description:        p.GetDescription(),
+		Labels:             p.GetLabels(),
+		UserLabels:         p.GetUserLabels(),
+		VerificationStatus: int32(p.GetVerificationStatus()),
+	}
+	if p.GetEnabled() != nil {
+		v := p.GetEnabled().GetValue()
+		c.Enabled = &v
+	}
+	return c
+}
+
+// applyNotificationChannelMask merges an incoming channel into the stored
+// channel according to the field paths in updateMask. Supported paths are
+// type, display_name, description, labels, user_labels, and enabled. Any other
+// path returns an error mapped to Unimplemented.
+func applyNotificationChannelMask(stored, incoming monitoringstore.NotificationChannel, updateMask []string) (monitoringstore.NotificationChannel, error) {
+	for _, path := range updateMask {
+		switch path {
+		case "type":
+			stored.Type = incoming.Type
+		case "display_name":
+			stored.DisplayName = incoming.DisplayName
+		case "description":
+			stored.Description = incoming.Description
+		case "labels":
+			stored.Labels = incoming.Labels
+		case "user_labels":
+			stored.UserLabels = incoming.UserLabels
+		case "enabled":
+			stored.Enabled = incoming.Enabled
+		default:
+			return stored, model.NewProviderError("UnsupportedOperation", "unsupported update_mask path: "+path, 501)
+		}
+	}
+	stored.UpdateTime = incoming.UpdateTime
 	return stored, nil
 }
 

--- a/internal/gcp/grpc/monitoring/service_test.go
+++ b/internal/gcp/grpc/monitoring/service_test.go
@@ -52,6 +52,115 @@ func testServerWithStore(t *testing.T, store monitoringstore.Store) (monitoringp
 		func() { conn.Close(); srv.Stop() }
 }
 
+func testChannelServer(t *testing.T) (monitoringpb.NotificationChannelServiceClient, func()) {
+	t.Helper()
+	store := monitoringstore.NewMemoryStore()
+	svc := NewService(store, "test")
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	monitoringpb.RegisterNotificationChannelServiceServer(srv, svc)
+	go srv.Serve(ln)
+
+	conn, err := grpc.NewClient(ln.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		srv.Stop()
+		t.Fatalf("dial: %v", err)
+	}
+	return monitoringpb.NewNotificationChannelServiceClient(conn),
+		func() { conn.Close(); srv.Stop() }
+}
+
+func TestNotificationChannelCRUD(t *testing.T) {
+	nc, cleanup := testChannelServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	created, err := nc.CreateNotificationChannel(ctx, &monitoringpb.CreateNotificationChannelRequest{
+		Name: "projects/test",
+		NotificationChannel: &monitoringpb.NotificationChannel{
+			Type:        "pubsub",
+			DisplayName: "Ops topic",
+			Labels:      map[string]string{"topic": "projects/test/topics/ops-alerts"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create channel: %v", err)
+	}
+	if !strings.HasPrefix(created.GetName(), "projects/test/notificationChannels/") {
+		t.Fatalf("created name = %q", created.GetName())
+	}
+	if created.GetType() != "pubsub" || created.GetLabels()["topic"] != "projects/test/topics/ops-alerts" {
+		t.Fatalf("created = %+v", created)
+	}
+	if created.GetEnabled() == nil || !created.GetEnabled().GetValue() {
+		t.Fatalf("created enabled = %v, want true", created.GetEnabled())
+	}
+
+	got, err := nc.GetNotificationChannel(ctx, &monitoringpb.GetNotificationChannelRequest{Name: created.GetName()})
+	if err != nil {
+		t.Fatalf("get channel: %v", err)
+	}
+	if got.GetDisplayName() != "Ops topic" {
+		t.Fatalf("get display name = %q", got.GetDisplayName())
+	}
+
+	list, err := nc.ListNotificationChannels(ctx, &monitoringpb.ListNotificationChannelsRequest{Name: "projects/test"})
+	if err != nil {
+		t.Fatalf("list channels: %v", err)
+	}
+	if len(list.GetNotificationChannels()) != 1 || list.GetTotalSize() != 1 {
+		t.Fatalf("list = %d (total %d), want 1", len(list.GetNotificationChannels()), list.GetTotalSize())
+	}
+
+	// Masked update keeps unmasked fields (the labels) intact.
+	updated, err := nc.UpdateNotificationChannel(ctx, &monitoringpb.UpdateNotificationChannelRequest{
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"display_name"}},
+		NotificationChannel: &monitoringpb.NotificationChannel{
+			Name:        created.GetName(),
+			DisplayName: "Renamed",
+		},
+	})
+	if err != nil {
+		t.Fatalf("update channel: %v", err)
+	}
+	if updated.GetDisplayName() != "Renamed" {
+		t.Fatalf("updated display name = %q", updated.GetDisplayName())
+	}
+	if updated.GetLabels()["topic"] != "projects/test/topics/ops-alerts" {
+		t.Fatalf("labels not preserved across masked update: %+v", updated.GetLabels())
+	}
+
+	if _, err := nc.DeleteNotificationChannel(ctx, &monitoringpb.DeleteNotificationChannelRequest{Name: created.GetName()}); err != nil {
+		t.Fatalf("delete channel: %v", err)
+	}
+	if _, err := nc.GetNotificationChannel(ctx, &monitoringpb.GetNotificationChannelRequest{Name: created.GetName()}); status.Code(err) != codes.NotFound {
+		t.Fatalf("get after delete err = %v, want NotFound", err)
+	}
+}
+
+func TestNotificationChannelValidation(t *testing.T) {
+	nc, cleanup := testChannelServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if _, err := nc.CreateNotificationChannel(ctx, &monitoringpb.CreateNotificationChannelRequest{
+		Name:                "projects/test",
+		NotificationChannel: &monitoringpb.NotificationChannel{DisplayName: "no type"},
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("create without type err = %v, want InvalidArgument", err)
+	}
+	if _, err := nc.GetNotificationChannel(ctx, &monitoringpb.GetNotificationChannelRequest{Name: "projects/test/notAChannel/x"}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("get invalid name err = %v, want InvalidArgument", err)
+	}
+	if _, err := nc.GetNotificationChannel(ctx, &monitoringpb.GetNotificationChannelRequest{Name: "projects/test/notificationChannels/missing"}); status.Code(err) != codes.NotFound {
+		t.Fatalf("get missing err = %v, want NotFound", err)
+	}
+}
+
 func TestMetricDescriptorCRUD(t *testing.T) {
 	mc, _, cleanup := testServer(t)
 	defer cleanup()

--- a/internal/gcp/resource/resource.go
+++ b/internal/gcp/resource/resource.go
@@ -149,6 +149,9 @@ var formatters = map[string]func(project, name string) string{
 		return fmt.Sprintf("projects/%s/metricDescriptors/%s", p, n)
 	},
 	"alert-policy": func(p, n string) string { return fmt.Sprintf("projects/%s/alertPolicies/%s", p, n) },
+	"notification-channel": func(p, n string) string {
+		return fmt.Sprintf("projects/%s/notificationChannels/%s", p, n)
+	},
 	"monitored-resource-descriptor": func(p, n string) string {
 		return fmt.Sprintf("projects/%s/monitoredResourceDescriptors/%s", p, n)
 	},

--- a/internal/gcp/store/migrations/034_monitoring_channels.sql
+++ b/internal/gcp/store/migrations/034_monitoring_channels.sql
@@ -1,0 +1,24 @@
+-- Cloud Monitoring notification channels (v3) — the delivery targets referenced
+-- by alert policies (the CloudWatch SNS-topic analogue).
+--
+--   jc_monitoring_notification_channels   delivery endpoints (pubsub/email/webhook/sms)
+--
+-- Project-scoped and keyed by a server-assigned channel id (the trailing
+-- segment of projects/{project}/notificationChannels/{id}). The type-specific
+-- configuration lives in labels (e.g. {"topic": "projects/p/topics/t"} for a
+-- pubsub channel, {"email_address": "ops@example.com"} for email).
+
+CREATE TABLE IF NOT EXISTS jc_monitoring_notification_channels (
+    project_id          TEXT        NOT NULL,
+    id                  TEXT        NOT NULL,
+    type                TEXT        NOT NULL DEFAULT '',
+    display_name        TEXT        NOT NULL DEFAULT '',
+    description         TEXT        NOT NULL DEFAULT '',
+    labels              JSONB       NOT NULL DEFAULT '{}',
+    user_labels         JSONB       NOT NULL DEFAULT '{}',
+    enabled             BOOL,
+    verification_status INT         NOT NULL DEFAULT 0,
+    create_time         TIMESTAMPTZ,
+    update_time         TIMESTAMPTZ,
+    PRIMARY KEY (project_id, id)
+);

--- a/internal/gcp/store/migrations/035_monitoring_incidents.sql
+++ b/internal/gcp/store/migrations/035_monitoring_incidents.sql
@@ -1,0 +1,26 @@
+-- Cloud Monitoring incidents — the recorded state for fired alert policies.
+--
+--   jc_monitoring_incidents   OPEN/CLOSED incidents opened by the evaluator
+--
+-- GCP exposes incidents only on an internal API (not the public v3 client
+-- library), so the emulator records them here for observability via the
+-- monitoring store's snapshot/export surface and slog. At most one OPEN
+-- incident exists per (project_id, policy_id); the evaluator enforces this
+-- atomically, backed by the partial unique index below.
+
+CREATE TABLE IF NOT EXISTS jc_monitoring_incidents (
+    project_id     TEXT        NOT NULL,
+    id             TEXT        NOT NULL,
+    policy_id      TEXT        NOT NULL,
+    condition_name TEXT        NOT NULL DEFAULT '',
+    state          TEXT        NOT NULL DEFAULT 'OPEN',
+    started_at     TIMESTAMPTZ,
+    ended_at       TIMESTAMPTZ,
+    reason         TEXT        NOT NULL DEFAULT '',
+    notifications  JSONB       NOT NULL DEFAULT '[]',
+    PRIMARY KEY (project_id, id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_jc_monitoring_incidents_open
+    ON jc_monitoring_incidents (project_id, policy_id)
+    WHERE state = 'OPEN';

--- a/internal/gcp/store/monitoring/memory.go
+++ b/internal/gcp/store/monitoring/memory.go
@@ -10,9 +10,11 @@ import (
 // MemoryStore is an in-memory Store.
 type MemoryStore struct {
 	mu          sync.RWMutex
-	descriptors map[string]map[string]MetricDescriptor // project → type → descriptor
-	series      map[string]map[string]*TimeSeries      // project → seriesKey → series
-	policies    map[string]map[string]AlertPolicy      // project → id → policy
+	descriptors map[string]map[string]MetricDescriptor    // project → type → descriptor
+	series      map[string]map[string]*TimeSeries         // project → seriesKey → series
+	policies    map[string]map[string]AlertPolicy         // project → id → policy
+	channels    map[string]map[string]NotificationChannel // project → id → channel
+	incidents   map[string]map[string]Incident            // project → id → incident
 }
 
 // NewMemoryStore returns an empty in-memory store.
@@ -21,6 +23,8 @@ func NewMemoryStore() *MemoryStore {
 		descriptors: make(map[string]map[string]MetricDescriptor),
 		series:      make(map[string]map[string]*TimeSeries),
 		policies:    make(map[string]map[string]AlertPolicy),
+		channels:    make(map[string]map[string]NotificationChannel),
+		incidents:   make(map[string]map[string]Incident),
 	}
 }
 
@@ -170,12 +174,177 @@ func (s *MemoryStore) DeleteAlertPolicy(_ context.Context, project, id string) e
 	return nil
 }
 
+// ─── notification channels ────────────────────────────────────────────────────
+
+func (s *MemoryStore) CreateNotificationChannel(_ context.Context, project string, c NotificationChannel) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.channels[project][c.ID]; ok {
+		return ErrNotificationChannelExists
+	}
+	if s.channels[project] == nil {
+		s.channels[project] = make(map[string]NotificationChannel)
+	}
+	s.channels[project][c.ID] = c
+	return nil
+}
+
+func (s *MemoryStore) GetNotificationChannel(_ context.Context, project, id string) (NotificationChannel, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	c, ok := s.channels[project][id]
+	if !ok {
+		return NotificationChannel{}, ErrNotificationChannelNotFound
+	}
+	return c, nil
+}
+
+func (s *MemoryStore) ListNotificationChannels(_ context.Context, project string) ([]NotificationChannel, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]NotificationChannel, 0, len(s.channels[project]))
+	for _, c := range s.channels[project] {
+		result = append(result, c)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].ID < result[j].ID })
+	return result, nil
+}
+
+func (s *MemoryStore) UpdateNotificationChannelAtomic(_ context.Context, project, id string, mutate func(NotificationChannel) (NotificationChannel, error)) (NotificationChannel, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.channels[project][id]
+	if !ok {
+		return NotificationChannel{}, ErrNotificationChannelNotFound
+	}
+	next, err := mutate(current)
+	if err != nil {
+		return NotificationChannel{}, err
+	}
+	next.ID = id
+	s.channels[project][id] = next
+	return next, nil
+}
+
+func (s *MemoryStore) DeleteNotificationChannel(_ context.Context, project, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.channels[project][id]; !ok {
+		return ErrNotificationChannelNotFound
+	}
+	delete(s.channels[project], id)
+	return nil
+}
+
+// ─── incidents ────────────────────────────────────────────────────────────────
+
+func (s *MemoryStore) CreateIncident(_ context.Context, inc Incident) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if existing, ok := s.incidents[inc.ProjectID][inc.ID]; ok && existing.State == IncidentOpen {
+		return ErrIncidentExists
+	}
+	for _, existing := range s.incidents[inc.ProjectID] {
+		if existing.State == IncidentOpen && existing.PolicyID == inc.PolicyID {
+			return ErrIncidentExists
+		}
+	}
+	if s.incidents[inc.ProjectID] == nil {
+		s.incidents[inc.ProjectID] = make(map[string]Incident)
+	}
+	s.incidents[inc.ProjectID][inc.ID] = inc
+	return nil
+}
+
+func (s *MemoryStore) GetIncident(_ context.Context, project, id string) (Incident, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	inc, ok := s.incidents[project][id]
+	if !ok {
+		return Incident{}, ErrIncidentNotFound
+	}
+	return inc, nil
+}
+
+func (s *MemoryStore) ListIncidents(_ context.Context, project string) ([]Incident, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]Incident, 0, len(s.incidents[project]))
+	for _, inc := range s.incidents[project] {
+		result = append(result, inc)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if !result[i].StartedAt.Equal(result[j].StartedAt) {
+			return result[i].StartedAt.Before(result[j].StartedAt)
+		}
+		return result[i].ID < result[j].ID
+	})
+	return result, nil
+}
+
+func (s *MemoryStore) FindOpenIncident(_ context.Context, project, policyID string) (Incident, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, inc := range s.incidents[project] {
+		if inc.State == IncidentOpen && inc.PolicyID == policyID {
+			return inc, nil
+		}
+	}
+	return Incident{}, ErrIncidentNotFound
+}
+
+func (s *MemoryStore) UpdateIncidentAtomic(_ context.Context, project, id string, mutate func(Incident) (Incident, error)) (Incident, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current, ok := s.incidents[project][id]
+	if !ok {
+		return Incident{}, ErrIncidentNotFound
+	}
+	next, err := mutate(current)
+	if err != nil {
+		return Incident{}, err
+	}
+	next.ID = id
+	s.incidents[project][id] = next
+	return next, nil
+}
+
+// ListProjects returns the distinct projects that hold any monitoring state.
+func (s *MemoryStore) ListProjects(_ context.Context) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	seen := make(map[string]struct{})
+	for p := range s.descriptors {
+		seen[p] = struct{}{}
+	}
+	for p := range s.series {
+		seen[p] = struct{}{}
+	}
+	for p := range s.policies {
+		seen[p] = struct{}{}
+	}
+	for p := range s.channels {
+		seen[p] = struct{}{}
+	}
+	for p := range s.incidents {
+		seen[p] = struct{}{}
+	}
+	result := make([]string, 0, len(seen))
+	for p := range seen {
+		result = append(result, p)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
 func (s *MemoryStore) Reset(_ context.Context) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.descriptors = make(map[string]map[string]MetricDescriptor)
 	s.series = make(map[string]map[string]*TimeSeries)
 	s.policies = make(map[string]map[string]AlertPolicy)
+	s.channels = make(map[string]map[string]NotificationChannel)
+	s.incidents = make(map[string]map[string]Incident)
 }
 
 // seriesKey returns a stable identity key for a time series, derived from its

--- a/internal/gcp/store/monitoring/memory_test.go
+++ b/internal/gcp/store/monitoring/memory_test.go
@@ -193,6 +193,101 @@ func TestMemoryStoreSnapshot(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreNotificationChannelCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+
+	enabled := true
+	c := NotificationChannel{ID: "nc-1", Type: "pubsub", DisplayName: "ops", Labels: map[string]string{"topic": "projects/p1/topics/t"}, Enabled: &enabled}
+	if err := s.CreateNotificationChannel(ctx, "p1", c); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CreateNotificationChannel(ctx, "p1", c); err != ErrNotificationChannelExists {
+		t.Fatalf("duplicate channel err = %v, want ErrNotificationChannelExists", err)
+	}
+	if _, err := s.GetNotificationChannel(ctx, "p1", "missing"); err != ErrNotificationChannelNotFound {
+		t.Fatalf("get missing err = %v, want ErrNotificationChannelNotFound", err)
+	}
+	list, err := s.ListNotificationChannels(ctx, "p1")
+	if err != nil || len(list) != 1 {
+		t.Fatalf("list = %+v, %v", list, err)
+	}
+	updated, err := s.UpdateNotificationChannelAtomic(ctx, "p1", "nc-1", func(cur NotificationChannel) (NotificationChannel, error) {
+		cur.DisplayName = "ops-renamed"
+		return cur, nil
+	})
+	if err != nil || updated.DisplayName != "ops-renamed" {
+		t.Fatalf("update = %+v, %v", updated, err)
+	}
+	if err := s.DeleteNotificationChannel(ctx, "p1", "nc-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DeleteNotificationChannel(ctx, "p1", "nc-1"); err != ErrNotificationChannelNotFound {
+		t.Fatalf("delete missing err = %v, want ErrNotificationChannelNotFound", err)
+	}
+}
+
+func TestMemoryStoreIncidents(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+
+	inc := Incident{ID: "inc-1", ProjectID: "p1", PolicyID: "ap-1", State: IncidentOpen, StartedAt: time.Now().UTC()}
+	if err := s.CreateIncident(ctx, inc); err != nil {
+		t.Fatal(err)
+	}
+	// A second OPEN incident for the same policy is rejected.
+	if err := s.CreateIncident(ctx, Incident{ID: "inc-2", ProjectID: "p1", PolicyID: "ap-1", State: IncidentOpen}); err != ErrIncidentExists {
+		t.Fatalf("second open incident err = %v, want ErrIncidentExists", err)
+	}
+	found, err := s.FindOpenIncident(ctx, "p1", "ap-1")
+	if err != nil || found.ID != "inc-1" {
+		t.Fatalf("find open = %+v, %v", found, err)
+	}
+	if _, err := s.FindOpenIncident(ctx, "p1", "other"); err != ErrIncidentNotFound {
+		t.Fatalf("find other err = %v, want ErrIncidentNotFound", err)
+	}
+	closed, err := s.UpdateIncidentAtomic(ctx, "p1", "inc-1", func(cur Incident) (Incident, error) {
+		cur.State = IncidentClosed
+		cur.EndedAt = time.Now().UTC()
+		return cur, nil
+	})
+	if err != nil || closed.State != IncidentClosed {
+		t.Fatalf("close = %+v, %v", closed, err)
+	}
+	if _, err := s.FindOpenIncident(ctx, "p1", "ap-1"); err != ErrIncidentNotFound {
+		t.Fatalf("find after close err = %v, want ErrIncidentNotFound", err)
+	}
+	if got, err := s.ListIncidents(ctx, "p1"); err != nil || len(got) != 1 {
+		t.Fatalf("list = %+v, %v", got, err)
+	}
+	if got, _ := s.ListProjects(ctx); len(got) != 1 || got[0] != "p1" {
+		t.Fatalf("list projects = %+v", got)
+	}
+}
+
+func TestMemoryStoreSnapshotIncludesChannelsAndIncidents(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	enabled := true
+	_ = s.CreateNotificationChannel(ctx, "p1", NotificationChannel{ID: "nc-1", Type: "email", Labels: map[string]string{"email_address": "a@b.c"}, Enabled: &enabled})
+	_ = s.CreateIncident(ctx, Incident{ID: "inc-1", ProjectID: "p1", PolicyID: "ap-1", State: IncidentClosed, StartedAt: time.Now().UTC()})
+
+	var buf bytes.Buffer
+	if err := s.Snapshot(ctx, &buf); err != nil {
+		t.Fatal(err)
+	}
+	s2 := NewMemoryStore()
+	if err := s2.Restore(ctx, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := s2.ListNotificationChannels(ctx, "p1"); len(got) != 1 || got[0].Labels["email_address"] != "a@b.c" {
+		t.Fatalf("restored channels = %+v", got)
+	}
+	if got, _ := s2.ListIncidents(ctx, "p1"); len(got) != 1 || got[0].State != IncidentClosed {
+		t.Fatalf("restored incidents = %+v", got)
+	}
+}
+
 func TestSeriesKeyDeterministic(t *testing.T) {
 	a := TimeSeries{MetricType: "m", MetricLabels: map[string]string{"x": "1", "y": "2"}, ResourceType: "r", ResourceLabels: map[string]string{"z": "3"}}
 	b := TimeSeries{MetricType: "m", MetricLabels: map[string]string{"y": "2", "x": "1"}, ResourceType: "r", ResourceLabels: map[string]string{"z": "3"}}

--- a/internal/gcp/store/monitoring/postgres.go
+++ b/internal/gcp/store/monitoring/postgres.go
@@ -336,4 +336,275 @@ func (s *PostgresStore) Reset(ctx context.Context) {
 	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_monitoring_metric_descriptors`)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_monitoring_time_series`)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_monitoring_alert_policies`)
+	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_monitoring_notification_channels`)
+	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_monitoring_incidents`)
+}
+
+// ─── notification channels ────────────────────────────────────────────────────
+
+func scanNotificationChannel(scan func(...any) error) (NotificationChannel, error) {
+	var c NotificationChannel
+	var labels, userLabels []byte
+	if err := scan(&c.ID, &c.Type, &c.DisplayName, &c.Description, &labels, &userLabels, &c.Enabled, &c.VerificationStatus, &c.CreateTime, &c.UpdateTime); err != nil {
+		return NotificationChannel{}, err
+	}
+	if len(labels) > 0 {
+		_ = json.Unmarshal(labels, &c.Labels)
+	}
+	if len(userLabels) > 0 {
+		_ = json.Unmarshal(userLabels, &c.UserLabels)
+	}
+	return c, nil
+}
+
+const channelCols = "id, type, display_name, description, labels, user_labels, enabled, verification_status, create_time, update_time"
+
+func (s *PostgresStore) CreateNotificationChannel(ctx context.Context, project string, c NotificationChannel) error {
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO jc_monitoring_notification_channels
+			(project_id, id, type, display_name, description, labels, user_labels, enabled, verification_status, create_time, update_time)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+	`, project, c.ID, c.Type, c.DisplayName, c.Description, jsonb(c.Labels), jsonb(c.UserLabels),
+		c.Enabled, c.VerificationStatus, c.CreateTime, c.UpdateTime)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrNotificationChannelExists
+		}
+		return fmt.Errorf("monitoring CreateNotificationChannel: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresStore) GetNotificationChannel(ctx context.Context, project, id string) (NotificationChannel, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT `+channelCols+` FROM jc_monitoring_notification_channels WHERE project_id=$1 AND id=$2
+	`, project, id)
+	c, err := scanNotificationChannel(row.Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return NotificationChannel{}, ErrNotificationChannelNotFound
+	}
+	return c, err
+}
+
+func (s *PostgresStore) ListNotificationChannels(ctx context.Context, project string) ([]NotificationChannel, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT `+channelCols+` FROM jc_monitoring_notification_channels WHERE project_id=$1 ORDER BY id
+	`, project)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make([]NotificationChannel, 0)
+	for rows.Next() {
+		c, err := scanNotificationChannel(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, c)
+	}
+	return result, rows.Err()
+}
+
+func (s *PostgresStore) UpdateNotificationChannelAtomic(ctx context.Context, project, id string, mutate func(NotificationChannel) (NotificationChannel, error)) (NotificationChannel, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return NotificationChannel{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	row := tx.QueryRow(ctx, `
+		SELECT `+channelCols+` FROM jc_monitoring_notification_channels WHERE project_id=$1 AND id=$2 FOR UPDATE
+	`, project, id)
+	current, err := scanNotificationChannel(row.Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return NotificationChannel{}, ErrNotificationChannelNotFound
+	}
+	if err != nil {
+		return NotificationChannel{}, err
+	}
+
+	next, err := mutate(current)
+	if err != nil {
+		return NotificationChannel{}, err
+	}
+
+	tag, err := tx.Exec(ctx, `
+		UPDATE jc_monitoring_notification_channels
+		SET type=$3, display_name=$4, description=$5, labels=$6, user_labels=$7, enabled=$8, verification_status=$9, update_time=$10
+		WHERE project_id=$1 AND id=$2
+	`, project, id, next.Type, next.DisplayName, next.Description, jsonb(next.Labels), jsonb(next.UserLabels),
+		next.Enabled, next.VerificationStatus, next.UpdateTime)
+	if err != nil {
+		return NotificationChannel{}, fmt.Errorf("monitoring UpdateNotificationChannelAtomic: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return NotificationChannel{}, ErrNotificationChannelNotFound
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return NotificationChannel{}, err
+	}
+	next.ID = id
+	return next, nil
+}
+
+func (s *PostgresStore) DeleteNotificationChannel(ctx context.Context, project, id string) error {
+	tag, err := s.pool.Exec(ctx, `
+		DELETE FROM jc_monitoring_notification_channels WHERE project_id=$1 AND id=$2
+	`, project, id)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotificationChannelNotFound
+	}
+	return nil
+}
+
+// ─── incidents ────────────────────────────────────────────────────────────────
+
+func scanIncident(scan func(...any) error) (Incident, error) {
+	var inc Incident
+	var notifications []byte
+	if err := scan(&inc.ID, &inc.ProjectID, &inc.PolicyID, &inc.ConditionName, &inc.State, &inc.StartedAt, &inc.EndedAt, &inc.Reason, &notifications); err != nil {
+		return Incident{}, err
+	}
+	if len(notifications) > 0 {
+		_ = json.Unmarshal(notifications, &inc.Notifications)
+	}
+	return inc, nil
+}
+
+const incidentCols = "id, project_id, policy_id, condition_name, state, started_at, ended_at, reason, notifications"
+
+func (s *PostgresStore) CreateIncident(ctx context.Context, inc Incident) error {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	var openID string
+	err = tx.QueryRow(ctx, `
+		SELECT id FROM jc_monitoring_incidents
+		WHERE project_id=$1 AND policy_id=$2 AND state=$3
+		LIMIT 1
+	`, inc.ProjectID, inc.PolicyID, IncidentOpen).Scan(&openID)
+	switch {
+	case err == nil:
+		return ErrIncidentExists
+	case errors.Is(err, pgx.ErrNoRows):
+		// no open incident; proceed
+	default:
+		return err
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO jc_monitoring_incidents
+			(project_id, id, policy_id, condition_name, state, started_at, ended_at, reason, notifications)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+	`, inc.ProjectID, inc.ID, inc.PolicyID, inc.ConditionName, inc.State, inc.StartedAt, inc.EndedAt, inc.Reason, jsonb(inc.Notifications)); err != nil {
+		return fmt.Errorf("monitoring CreateIncident: %w", err)
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *PostgresStore) GetIncident(ctx context.Context, project, id string) (Incident, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT `+incidentCols+` FROM jc_monitoring_incidents WHERE project_id=$1 AND id=$2
+	`, project, id)
+	inc, err := scanIncident(row.Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Incident{}, ErrIncidentNotFound
+	}
+	return inc, err
+}
+
+func (s *PostgresStore) ListIncidents(ctx context.Context, project string) ([]Incident, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT `+incidentCols+` FROM jc_monitoring_incidents WHERE project_id=$1 ORDER BY started_at, id
+	`, project)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make([]Incident, 0)
+	for rows.Next() {
+		inc, err := scanIncident(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, inc)
+	}
+	return result, rows.Err()
+}
+
+func (s *PostgresStore) FindOpenIncident(ctx context.Context, project, policyID string) (Incident, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT `+incidentCols+` FROM jc_monitoring_incidents
+		WHERE project_id=$1 AND policy_id=$2 AND state=$3
+		ORDER BY started_at LIMIT 1
+	`, project, policyID, IncidentOpen)
+	inc, err := scanIncident(row.Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Incident{}, ErrIncidentNotFound
+	}
+	return inc, err
+}
+
+func (s *PostgresStore) UpdateIncidentAtomic(ctx context.Context, project, id string, mutate func(Incident) (Incident, error)) (Incident, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return Incident{}, err
+	}
+	defer tx.Rollback(ctx)
+	row := tx.QueryRow(ctx, `
+		SELECT `+incidentCols+` FROM jc_monitoring_incidents WHERE project_id=$1 AND id=$2 FOR UPDATE
+	`, project, id)
+	current, err := scanIncident(row.Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Incident{}, ErrIncidentNotFound
+	}
+	if err != nil {
+		return Incident{}, err
+	}
+	next, err := mutate(current)
+	if err != nil {
+		return Incident{}, err
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE jc_monitoring_incidents
+		SET condition_name=$3, state=$4, started_at=$5, ended_at=$6, reason=$7, notifications=$8
+		WHERE project_id=$1 AND id=$2
+	`, project, id, next.ConditionName, next.State, next.StartedAt, next.EndedAt, next.Reason, jsonb(next.Notifications)); err != nil {
+		return Incident{}, fmt.Errorf("monitoring UpdateIncidentAtomic: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Incident{}, err
+	}
+	next.ID = id
+	return next, nil
+}
+
+// ListProjects returns the distinct projects that hold any monitoring state.
+func (s *PostgresStore) ListProjects(ctx context.Context) ([]string, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT project_id FROM jc_monitoring_metric_descriptors
+		UNION SELECT project_id FROM jc_monitoring_time_series
+		UNION SELECT project_id FROM jc_monitoring_alert_policies
+		UNION SELECT project_id FROM jc_monitoring_notification_channels
+		UNION SELECT project_id FROM jc_monitoring_incidents
+		ORDER BY project_id
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make([]string, 0)
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, err
+		}
+		result = append(result, p)
+	}
+	return result, rows.Err()
 }

--- a/internal/gcp/store/monitoring/snapshot.go
+++ b/internal/gcp/store/monitoring/snapshot.go
@@ -23,11 +23,23 @@ type policyRow struct {
 	Policy  AlertPolicy `json:"policy"`
 }
 
+type channelRow struct {
+	Project string              `json:"project"`
+	Channel NotificationChannel `json:"channel"`
+}
+
+type incidentRow struct {
+	Project  string   `json:"project"`
+	Incident Incident `json:"incident"`
+}
+
 // monitoringSnap is the JSON snapshot shape shared by both backends.
 type monitoringSnap struct {
 	Descriptors []descriptorRow `json:"descriptors"`
 	Series      []seriesRow     `json:"series"`
 	Policies    []policyRow     `json:"policies"`
+	Channels    []channelRow    `json:"channels,omitempty"`
+	Incidents   []incidentRow   `json:"incidents,omitempty"`
 }
 
 // MemoryStore Snapshot/Restore/IsEmpty.
@@ -35,7 +47,8 @@ type monitoringSnap struct {
 func (s *MemoryStore) IsEmpty(_ context.Context) (bool, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return len(s.descriptors) == 0 && len(s.series) == 0 && len(s.policies) == 0, nil
+	return len(s.descriptors) == 0 && len(s.series) == 0 && len(s.policies) == 0 &&
+		len(s.channels) == 0 && len(s.incidents) == 0, nil
 }
 
 func (s *MemoryStore) Snapshot(_ context.Context, w io.Writer) error {
@@ -91,6 +104,38 @@ func (s *MemoryStore) Snapshot(_ context.Context, w io.Writer) error {
 		}
 	}
 
+	projects = projects[:0]
+	for p := range s.channels {
+		projects = append(projects, p)
+	}
+	sort.Strings(projects)
+	for _, p := range projects {
+		ids := make([]string, 0, len(s.channels[p]))
+		for id := range s.channels[p] {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		for _, id := range ids {
+			snap.Channels = append(snap.Channels, channelRow{Project: p, Channel: s.channels[p][id]})
+		}
+	}
+
+	projects = projects[:0]
+	for p := range s.incidents {
+		projects = append(projects, p)
+	}
+	sort.Strings(projects)
+	for _, p := range projects {
+		ids := make([]string, 0, len(s.incidents[p]))
+		for id := range s.incidents[p] {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		for _, id := range ids {
+			snap.Incidents = append(snap.Incidents, incidentRow{Project: p, Incident: s.incidents[p][id]})
+		}
+	}
+
 	return json.NewEncoder(w).Encode(snap)
 }
 
@@ -121,11 +166,27 @@ func (s *MemoryStore) Restore(_ context.Context, r io.Reader) error {
 		}
 		policies[row.Project][row.Policy.ID] = row.Policy
 	}
+	channels := make(map[string]map[string]NotificationChannel)
+	for _, row := range snap.Channels {
+		if channels[row.Project] == nil {
+			channels[row.Project] = make(map[string]NotificationChannel)
+		}
+		channels[row.Project][row.Channel.ID] = row.Channel
+	}
+	incidents := make(map[string]map[string]Incident)
+	for _, row := range snap.Incidents {
+		if incidents[row.Project] == nil {
+			incidents[row.Project] = make(map[string]Incident)
+		}
+		incidents[row.Project][row.Incident.ID] = row.Incident
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.descriptors = descriptors
 	s.series = series
 	s.policies = policies
+	s.channels = channels
+	s.incidents = incidents
 	return nil
 }
 
@@ -137,6 +198,8 @@ func (s *PostgresStore) IsEmpty(ctx context.Context) (bool, error) {
 		SELECT (SELECT count(*) FROM jc_monitoring_metric_descriptors)
 		     + (SELECT count(*) FROM jc_monitoring_time_series)
 		     + (SELECT count(*) FROM jc_monitoring_alert_policies)
+		     + (SELECT count(*) FROM jc_monitoring_notification_channels)
+		     + (SELECT count(*) FROM jc_monitoring_incidents)
 	`).Scan(&n); err != nil {
 		return false, err
 	}
@@ -216,6 +279,59 @@ func (s *PostgresStore) Snapshot(ctx context.Context, w io.Writer) error {
 	}
 	rows.Close()
 
+	rows, err = s.pool.Query(ctx, `
+		SELECT project_id, `+channelCols+` FROM jc_monitoring_notification_channels ORDER BY project_id, id
+	`)
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		var p string
+		var c NotificationChannel
+		var labels, userLabels []byte
+		if err := rows.Scan(&p, &c.ID, &c.Type, &c.DisplayName, &c.Description, &labels, &userLabels, &c.Enabled, &c.VerificationStatus, &c.CreateTime, &c.UpdateTime); err != nil {
+			rows.Close()
+			return err
+		}
+		if len(labels) > 0 {
+			_ = json.Unmarshal(labels, &c.Labels)
+		}
+		if len(userLabels) > 0 {
+			_ = json.Unmarshal(userLabels, &c.UserLabels)
+		}
+		snap.Channels = append(snap.Channels, channelRow{Project: p, Channel: c})
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+
+	rows, err = s.pool.Query(ctx, `
+		SELECT project_id, `+incidentCols+` FROM jc_monitoring_incidents ORDER BY project_id, started_at, id
+	`)
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		var p string
+		var inc Incident
+		var notifications []byte
+		if err := rows.Scan(&p, &inc.ID, &inc.ProjectID, &inc.PolicyID, &inc.ConditionName, &inc.State, &inc.StartedAt, &inc.EndedAt, &inc.Reason, &notifications); err != nil {
+			rows.Close()
+			return err
+		}
+		if len(notifications) > 0 {
+			_ = json.Unmarshal(notifications, &inc.Notifications)
+		}
+		snap.Incidents = append(snap.Incidents, incidentRow{Project: p, Incident: inc})
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+
 	return json.NewEncoder(w).Encode(snap)
 }
 
@@ -236,6 +352,12 @@ func (s *PostgresStore) Restore(ctx context.Context, r io.Reader) error {
 		return err
 	}
 	if _, err := tx.Exec(ctx, `DELETE FROM jc_monitoring_alert_policies`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM jc_monitoring_notification_channels`); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM jc_monitoring_incidents`); err != nil {
 		return err
 	}
 	for _, row := range snap.Descriptors {
@@ -267,6 +389,27 @@ func (s *PostgresStore) Restore(ctx context.Context, r io.Reader) error {
 		`, row.Project, row.Policy.ID, row.Policy.DisplayName, row.Policy.Combiner, row.Policy.Enabled,
 			jsonb(row.Policy.Documentation), jsonb(row.Policy.Conditions), jsonb(row.Policy.NotificationChannels),
 			jsonb(row.Policy.UserLabels)); err != nil {
+			return err
+		}
+	}
+	for _, row := range snap.Channels {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO jc_monitoring_notification_channels
+				(project_id, id, type, display_name, description, labels, user_labels, enabled, verification_status, create_time, update_time)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+		`, row.Project, row.Channel.ID, row.Channel.Type, row.Channel.DisplayName, row.Channel.Description,
+			jsonb(row.Channel.Labels), jsonb(row.Channel.UserLabels), row.Channel.Enabled, row.Channel.VerificationStatus,
+			row.Channel.CreateTime, row.Channel.UpdateTime); err != nil {
+			return err
+		}
+	}
+	for _, row := range snap.Incidents {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO jc_monitoring_incidents
+				(project_id, id, policy_id, condition_name, state, started_at, ended_at, reason, notifications)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+		`, row.Project, row.Incident.ID, row.Incident.PolicyID, row.Incident.ConditionName, row.Incident.State,
+			row.Incident.StartedAt, row.Incident.EndedAt, row.Incident.Reason, jsonb(row.Incident.Notifications)); err != nil {
 			return err
 		}
 	}

--- a/internal/gcp/store/monitoring/store.go
+++ b/internal/gcp/store/monitoring/store.go
@@ -18,9 +18,13 @@ import (
 // Sentinel errors returned by the store, mapped to gRPC status codes by the
 // service (errors.Is-compatible, matching the datastore/logging conventions).
 var (
-	ErrMetricDescriptorNotFound = errors.New("MetricDescriptorNotFound")
-	ErrAlertPolicyNotFound      = errors.New("AlertPolicyNotFound")
-	ErrAlertPolicyExists        = errors.New("AlertPolicyExists")
+	ErrMetricDescriptorNotFound    = errors.New("MetricDescriptorNotFound")
+	ErrAlertPolicyNotFound         = errors.New("AlertPolicyNotFound")
+	ErrAlertPolicyExists           = errors.New("AlertPolicyExists")
+	ErrNotificationChannelNotFound = errors.New("NotificationChannelNotFound")
+	ErrNotificationChannelExists   = errors.New("NotificationChannelExists")
+	ErrIncidentNotFound            = errors.New("IncidentNotFound")
+	ErrIncidentExists              = errors.New("IncidentExists")
 )
 
 // LabelDescriptor mirrors google.api.LabelDescriptor (the label key, its value
@@ -91,6 +95,62 @@ type AlertPolicy struct {
 	UserLabels           map[string]string `json:"userLabels,omitempty"`
 }
 
+// NotificationChannel is a stored notification destination (the CloudWatch
+// SNS-topic analogue). ID is the server-assigned channel id (the trailing
+// segment of the resource name). Labels carry the type-specific configuration
+// (e.g. {"topic": "projects/p/topics/t"} for pubsub, {"email_address": "..."}
+// for email). VerificationStatus carries the numeric
+// google.monitoring.v3.NotificationChannel.VerificationStatus enum value.
+type NotificationChannel struct {
+	ID                 string            `json:"id,omitempty"`
+	Type               string            `json:"type,omitempty"`
+	DisplayName        string            `json:"displayName,omitempty"`
+	Description        string            `json:"description,omitempty"`
+	Labels             map[string]string `json:"labels,omitempty"`
+	UserLabels         map[string]string `json:"userLabels,omitempty"`
+	Enabled            *bool             `json:"enabled,omitempty"`
+	VerificationStatus int32             `json:"verificationStatus,omitempty"`
+	CreateTime         time.Time         `json:"createTime,omitempty"`
+	UpdateTime         time.Time         `json:"updateTime,omitempty"`
+}
+
+// IncidentState is the lifecycle state of a monitoring incident. GCP exposes
+// incidents only on an internal API (not the v3 client library), so the
+// emulator records them for observability via snapshots and slog.
+type IncidentState string
+
+const (
+	IncidentOpen   IncidentState = "OPEN"
+	IncidentClosed IncidentState = "CLOSED"
+)
+
+// IncidentNotification records one attempted notification delivery for an
+// incident. Status is "delivered" (pubsub publish succeeded), "recorded"
+// (email/webhook/sms — recorded but not sent by the emulator), "failed", or
+// "skipped" (channel disabled/missing/unsupported type).
+type IncidentNotification struct {
+	ChannelName string    `json:"channelName,omitempty"`
+	ChannelType string    `json:"channelType,omitempty"`
+	Status      string    `json:"status"`
+	Detail      string    `json:"detail,omitempty"`
+	DeliveredAt time.Time `json:"deliveredAt"`
+}
+
+// Incident is a fired alert-policy incident. ID is a server-assigned uuid.
+// ConditionName is the display name of the condition that fired (the combined
+// policy state is tracked at policy granularity, so this is informational).
+type Incident struct {
+	ID            string                 `json:"id"`
+	ProjectID     string                 `json:"projectId"`
+	PolicyID      string                 `json:"policyId"`
+	ConditionName string                 `json:"conditionName,omitempty"`
+	State         IncidentState          `json:"state"`
+	StartedAt     time.Time              `json:"startedAt"`
+	EndedAt       time.Time              `json:"endedAt,omitempty"`
+	Reason        string                 `json:"reason,omitempty"`
+	Notifications []IncidentNotification `json:"notifications,omitempty"`
+}
+
 // Store is the Cloud Monitoring store. All state is project-scoped.
 type Store interface {
 	// Metric descriptor catalog.
@@ -117,6 +177,32 @@ type Store interface {
 	// other fields.
 	UpdateAlertPolicyAtomic(ctx context.Context, project, id string, mutate func(AlertPolicy) (AlertPolicy, error)) (AlertPolicy, error)
 	DeleteAlertPolicy(ctx context.Context, project, id string) error
+
+	// Notification channel registry.
+	CreateNotificationChannel(ctx context.Context, project string, c NotificationChannel) error
+	GetNotificationChannel(ctx context.Context, project, id string) (NotificationChannel, error)
+	ListNotificationChannels(ctx context.Context, project string) ([]NotificationChannel, error)
+	// UpdateNotificationChannelAtomic performs a locked get-mutate-set cycle so
+	// a masked PATCH cannot lose a concurrent PATCH's changes (mirrors
+	// UpdateAlertPolicyAtomic).
+	UpdateNotificationChannelAtomic(ctx context.Context, project, id string, mutate func(NotificationChannel) (NotificationChannel, error)) (NotificationChannel, error)
+	DeleteNotificationChannel(ctx context.Context, project, id string) error
+
+	// Incident registry (recorded state for fired alert policies).
+	// CreateIncident returns ErrIncidentExists when an OPEN incident already
+	// exists for the policy.
+	CreateIncident(ctx context.Context, inc Incident) error
+	GetIncident(ctx context.Context, project, id string) (Incident, error)
+	ListIncidents(ctx context.Context, project string) ([]Incident, error)
+	// FindOpenIncident returns the OPEN incident for a policy, or
+	// ErrIncidentNotFound when none is open.
+	FindOpenIncident(ctx context.Context, project, policyID string) (Incident, error)
+	UpdateIncidentAtomic(ctx context.Context, project, id string, mutate func(Incident) (Incident, error)) (Incident, error)
+
+	// ListProjects returns the distinct project ids that hold any monitoring
+	// state (descriptors, series, policies, channels, or incidents) so the
+	// background evaluator can scope its work without a separate registry.
+	ListProjects(ctx context.Context) ([]string, error)
 
 	Reset(ctx context.Context)
 }


### PR DESCRIPTION
## Summary

Reverses the earlier "CRUD-only by design" decision and implements **Cloud Monitoring alerting** to match/exceed the AWS CloudWatch analogue (`alarm_evaluator.go` evaluates metrics, transitions state, and fires SNS actions). Emulator-scoped but substantively real.

## Commits

### 1. `feat(gcp/monitoring): NotificationChannelService + incident store`
- **`NotificationChannelService`** (real v3 surface, was absent): Create/Get/List/Update/Delete over a new store (`jc_monitoring_channels`, migration `034`); types `pubsub`/`email`/`webhook`/`sms`; masked atomic updates; registered in `main.go`.
- **Incident store** (`jc_monitoring_incidents`, migration `035`): open/close state per policy (GCP exposes incidents only via an internal API — this v3 library has none, so **no invented RPC**; incidents are persisted + observable via the store snapshot/export).
- Memory+postgres parity, Snapshotter/Restorer.

### 2. `feat(gcp/monitoring): alert-policy evaluator + incidents + channel delivery`
- **Evaluator** (`evaluator.go`): 30s ticker (matches AWS) + synchronous `EvaluateAll`; iterates projects/policies, skips disabled.
- **`condition_threshold`** evaluation: filter subset (`metric.type`, `resource.type`, `metric.label.*`, `resource.label.*` equality joined by `AND`), alignment window + cross-series reducer (`SUM/MEAN/MAX/MIN/COUNT`), `comparison`, `threshold_value`, `duration`, `trigger` (count/percent). `Combiner` AND/OR. No matching points → **not firing**.
- **Incidents**: transition to firing opens an incident + delivers; resolve closes it + delivers the resolution.
- **Delivery**: `pubsub` channels → publish a CloudEvents-style notification to `labels.topic` via the emulator's Pub/Sub store (mirrors AWS's SNS delivery, observable); `email`/`webhook`/`sms` → recorded on the incident + logged.
- Wired into `main.go` as a start/stop goroutine with a Pub/Sub publisher adapter.

## Explicitly NOT evaluated (documented in README + code)
`condition_absent`/`condition_matched_log`/MQL/PromQL/SQL conditions; denominator/ratio filters; forecast; trigger-with-reducer (honored only without a reducer); `ListNotificationChannelDescriptors`/verification-code RPCs → `Unimplemented`.

## Verification

`go build ./...`, `go vet ./internal/gcp/...` (+`-tags gcp_persistence`), `go test -race` on monitoring store/service, full `./internal/gcp/...` clean, `gofmt -l` empty, `paginationcheck` clean. Tests cover threshold crossing → OPEN + pubsub delivery, below-threshold no-fire, resolve-closes, combiner AND/OR, no-points, disabled skip, REduce_MAX, and channel CRUD.