### PR TITLE
feat(gcp/datastore): transactions (BeginTransaction/Lookup/RunQuery/Commit/Rollback + read-set OCC)

### DIFF
--- a/internal/gcp/grpc/datastore/commit_edge_test.go
+++ b/internal/gcp/grpc/datastore/commit_edge_test.go
@@ -1,0 +1,120 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	datastorepb "cloud.google.com/go/datastore/apiv1/datastorepb"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// commitNonTxn runs a single-mutation non-transactional Commit, returning the
+// first MutationResult and the error.
+func commitNonTxn(t *testing.T, client datastorepb.DatastoreClient, m *datastorepb.Mutation) (*datastorepb.MutationResult, error) {
+	t.Helper()
+	resp, err := client.Commit(context.Background(), &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{m},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetMutationResults()[0], nil
+}
+
+// TestNonTransactionalConflictDetected covers the non-txn Commit's per-mutation
+// conflict_detection_strategy outcome for every mutation kind: a stale
+// base_version sets mutation_results[i].conflict_detected=true (the commit
+// itself still SUCCEEDS in the non-transactional path) and the write is not
+// applied.
+func TestNonTransactionalConflictDetected(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	upsertTask(t, client, "a", 1) // version 1
+	stale := int64(999)
+
+	mutate := func(m *datastorepb.Mutation) *datastorepb.Mutation {
+		m.ConflictDetectionStrategy = &datastorepb.Mutation_BaseVersion{BaseVersion: stale}
+		return m
+	}
+	cases := []*datastorepb.Mutation{
+		mutate(&datastorepb.Mutation{Operation: &datastorepb.Mutation_Insert{Insert: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(9)})}}),
+		mutate(&datastorepb.Mutation{Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(9)})}}),
+		mutate(&datastorepb.Mutation{Operation: &datastorepb.Mutation_Update{Update: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(9)})}}),
+		mutate(&datastorepb.Mutation{Operation: &datastorepb.Mutation_Delete{Delete: nameKey("Task", "a")}}),
+	}
+	for _, m := range cases {
+		mr, err := commitNonTxn(t, client, m)
+		if err != nil {
+			t.Fatalf("conflicting commit returned error for %T: %v", m.GetOperation(), err)
+		}
+		if !mr.GetConflictDetected() {
+			t.Fatalf("%T: conflict_detected = false, want true", m.GetOperation())
+		}
+	}
+	// None of the conflicting writes may have applied.
+	if got := lookupTask(t, client, "a", nil).GetEntity().GetProperties()["n"].GetIntegerValue(); got != 1 {
+		t.Fatalf("a.n = %d after conflicting commits, want 1", got)
+	}
+}
+
+// TestNonTransactionalUpsertAutoAllocatesKey covers the non-txn Upsert
+// incomplete-key branch (Insert is covered elsewhere).
+func TestNonTransactionalUpsertAutoAllocatesKey(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	mr, err := commitNonTxn(t, client, &datastorepb.Mutation{
+		Operation: &datastorepb.Mutation_Upsert{Upsert: entity(incompleteKey("Task"), map[string]*datastorepb.Value{"n": intVal(1)})},
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	k := mr.GetKey()
+	if k == nil || len(k.GetPath()) == 0 || k.GetPath()[len(k.GetPath())-1].GetId() == 0 {
+		t.Fatalf("upsert auto-allocated key missing id: %v", k)
+	}
+}
+
+// TestNonTransactionalNoOperationMutation covers the non-txn Commit's default
+// branch: a mutation with no operation is INVALID_ARGUMENT.
+func TestNonTransactionalNoOperationMutation(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	if _, err := commitNonTxn(t, client, &datastorepb.Mutation{}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("no-operation mutation err = %v, want InvalidArgument", err)
+	}
+}
+
+// TestNonTransactionalInvalidKeys covers the resolveEntity / entityFromProto /
+// deleteKey error branches. A namespaced key is rejected by canonicalKey, which
+// each mutation kind surfaces as INVALID_ARGUMENT; an incomplete Update key is
+// rejected by the service's explicit empty-key check.
+func TestNonTransactionalInvalidKeys(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	namespaced := &datastorepb.Key{
+		PartitionId: &datastorepb.PartitionId{ProjectId: "test", NamespaceId: "ns"},
+		Path:        []*datastorepb.Key_PathElement{{Kind: "Task", IdType: &datastorepb.Key_PathElement_Name{Name: "a"}}},
+	}
+	cases := []struct {
+		name string
+		m    *datastorepb.Mutation
+	}{
+		{"insert namespaced key", &datastorepb.Mutation{Operation: &datastorepb.Mutation_Insert{Insert: entity(namespaced, map[string]*datastorepb.Value{"n": intVal(1)})}}},
+		{"upsert namespaced key", &datastorepb.Mutation{Operation: &datastorepb.Mutation_Upsert{Upsert: entity(namespaced, map[string]*datastorepb.Value{"n": intVal(1)})}}},
+		{"update namespaced key", &datastorepb.Mutation{Operation: &datastorepb.Mutation_Update{Update: entity(namespaced, map[string]*datastorepb.Value{"n": intVal(1)})}}},
+		{"delete namespaced key", &datastorepb.Mutation{Operation: &datastorepb.Mutation_Delete{Delete: namespaced}}},
+		{"update incomplete key", &datastorepb.Mutation{Operation: &datastorepb.Mutation_Update{Update: entity(incompleteKey("Task"), map[string]*datastorepb.Value{"n": intVal(1)})}}},
+	}
+	for _, tc := range cases {
+		if _, err := commitNonTxn(t, client, tc.m); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("%s err = %v, want InvalidArgument", tc.name, err)
+		}
+	}
+}

--- a/internal/gcp/grpc/datastore/service.go
+++ b/internal/gcp/grpc/datastore/service.go
@@ -2,25 +2,42 @@
 // (google.datastore.v1.Datastore) over the shared datastorestore.Store, so
 // entities written via the Go SDK are stored and queried consistently.
 //
-// The emulator is intentionally non-transactional: it does not implement
-// optimistic-concurrency transactions. BeginTransaction mints an opaque id so
-// SDK init paths that poll the transaction surface do not error, and
-// Rollback is a no-op, but a TRANSACTIONAL Commit (or a Commit carrying a
-// transaction selector) is rejected with Unimplemented rather than being
-// silently committed as a non-transactional write.
+// Transactions follow real Datastore's read-set optimistic-concurrency model.
+// BeginTransaction returns an opaque token and registers an empty read-set;
+// Lookup/RunQuery calls carrying that token record the entities they observe;
+// and a TRANSACTIONAL Commit re-validates every observed entity's version and
+// then applies all mutations atomically (see the Service.Commit logic and the
+// store's Commit method). A conflict aborts the commit with ABORTED and applies
+// nothing; a per-mutation Precondition mismatch aborts it with
+// FAILED_PRECONDITION.
+//
+// Two internal approximations are documented and never surface as new RPCs or
+// fields:
+//
+//   - RunQuery read validation: real Datastore validates a query's read
+//     *range* at commit. The emulator records the version of every entity the
+//     query returned and re-validates those entities, which catches a
+//     concurrent modification to any returned entity but not the appearance or
+//     disappearance of a would-be match outside the result set.
+//   - Transaction TTL: real read-write transactions expire after ~270s. The
+//     emulator lazily evicts a read-set once it is older than txnTTL, returning
+//     InvalidArgument for any later use (the same as an unknown token).
 package datastore
 
 import (
 	"bytes"
 	"context"
 	"errors"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	datastorepb "cloud.google.com/go/datastore/apiv1/datastorepb"
 
+	"jaiscloud/internal/clock"
 	grpcutil "jaiscloud/internal/gcp/grpc"
 	datastorestore "jaiscloud/internal/gcp/store/datastore"
 	"jaiscloud/internal/model"
@@ -30,18 +47,143 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// txnTTL bounds a transaction's lifetime, mirroring real Datastore's ~270s
+// read-write transaction timeout. Expiry is enforced lazily on each access
+// rather than by a background sweeper.
+const txnTTL = 270 * time.Second
+
 // Service implements datastorepb.DatastoreServer over the shared store.
 type Service struct {
 	datastorepb.UnimplementedDatastoreServer
 
 	store       datastorestore.Store
 	defaultProj string
+
+	// txnMu guards readSets: the in-memory transaction read-set registry
+	// (transactions are ephemeral and never persisted).
+	txnMu    sync.Mutex
+	readSets map[string]*readSet
+}
+
+// readSet is an open transaction's observed entities (canonical key → observed
+// state) plus its start time for TTL expiry.
+type readSet struct {
+	reads map[string]datastorestore.ReadRef
+	start time.Time
 }
 
 // NewService returns a Datastore gRPC service backed by the shared store.
 // defaultProj is the config-default project used when a request carries none.
 func NewService(store datastorestore.Store, defaultProj string) *Service {
-	return &Service{store: store, defaultProj: defaultProj}
+	return &Service{
+		store:       store,
+		defaultProj: defaultProj,
+		readSets:    make(map[string]*readSet),
+	}
+}
+
+// ─── transaction registry ─────────────────────────────────────────────────────
+
+// txnLocked returns the read-set for an *active* transaction, evicting it if
+// its TTL has elapsed, or nil when it is unknown/expired. The caller must hold
+// txnMu.
+func (s *Service) txnLocked(txn string) *readSet {
+	rs := s.readSets[txn]
+	if rs == nil {
+		return nil
+	}
+	if clock.Now().Sub(rs.start) > txnTTL {
+		delete(s.readSets, txn)
+		return nil
+	}
+	return rs
+}
+
+// recordRead registers an entity observation in a transaction's read-set.
+// Non-transactional calls (empty token) and unknown/expired transactions are
+// ignored. Missing entities are recorded with Exists=false (Version 0) so a
+// concurrent create aborts the eventual commit.
+func (s *Service) recordRead(txn []byte, key string, exists bool, version int64) {
+	if len(txn) == 0 {
+		return
+	}
+	s.txnMu.Lock()
+	defer s.txnMu.Unlock()
+	rs := s.txnLocked(string(txn))
+	if rs == nil {
+		return
+	}
+	if rs.reads == nil {
+		rs.reads = make(map[string]datastorestore.ReadRef)
+	}
+	rs.reads[key] = datastorestore.ReadRef{Key: key, Exists: exists, Version: version}
+}
+
+// readSetFor returns the transaction's observations as a slice sorted by key,
+// or nil when the token is empty/unknown/expired/there were no reads.
+func (s *Service) readSetFor(txn []byte) []datastorestore.ReadRef {
+	if len(txn) == 0 {
+		return nil
+	}
+	s.txnMu.Lock()
+	defer s.txnMu.Unlock()
+	rs := s.txnLocked(string(txn))
+	if rs == nil || len(rs.reads) == 0 {
+		return nil
+	}
+	out := make([]datastorestore.ReadRef, 0, len(rs.reads))
+	for _, r := range rs.reads {
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}
+
+// clearReadSet discards a transaction's read-set after commit/rollback.
+func (s *Service) clearReadSet(txn []byte) {
+	if len(txn) == 0 {
+		return
+	}
+	s.txnMu.Lock()
+	defer s.txnMu.Unlock()
+	delete(s.readSets, string(txn))
+}
+
+// requireActive returns an InvalidArgument error when transaction is non-empty
+// but not currently active (rolled back, already committed, expired, or never
+// begun). An empty transaction denotes a non-transactional operation and always
+// passes, so it still works for unknown-token detection in Commit.
+func (s *Service) requireActive(transaction []byte) error {
+	if len(transaction) == 0 {
+		return nil
+	}
+	s.txnMu.Lock()
+	defer s.txnMu.Unlock()
+	if s.txnLocked(string(transaction)) == nil {
+		return model.NewProviderError("InvalidArgument",
+			"transaction is no longer active (rolled back, committed, expired, or never begun)", 400)
+	}
+	return nil
+}
+
+// mapTxnStoreError translates a store.Commit sentinel into the transactional
+// commit statuses real Datastore uses: a read-set conflict is ABORTED (retry
+// the whole transaction), a per-mutation Precondition mismatch is
+// FAILED_PRECONDITION, and an existence mismatch matches the non-transactional
+// mapping. A conflict or precondition failure aborts the whole commit.
+func mapTxnStoreError(err error) error {
+	switch {
+	case errors.Is(err, datastorestore.ErrAborted):
+		return mapError(model.NewProviderError("Aborted", "transaction was aborted due to concurrent modification", 409))
+	case errors.Is(err, datastorestore.ErrConflict):
+		return mapError(model.NewProviderError("FailedPrecondition", "precondition failed", 400))
+	case errors.Is(err, datastorestore.ErrEntityExists):
+		return mapError(model.NewProviderError("AlreadyExists", "entity already exists", 409))
+	case errors.Is(err, datastorestore.ErrEntityNotFound):
+		return mapError(model.NewProviderError("FailedPrecondition", "entity not found", 404))
+	default:
+		return mapError(err)
+	}
 }
 
 // mapError translates a store/service error into a gRPC status error. The
@@ -54,9 +196,9 @@ func mapError(err error) error {
 	return grpcutil.GRPCStatus(err)
 }
 
-// txnSeq mints opaque transaction ids for BeginTransaction (non-transactional
-// operations do not need full OCC; a unique id suffices so SDK init paths that
-// poll the txn surface do not error).
+// txnSeq mints the opaque transaction tokens returned by BeginTransaction.
+// Real handles are opaque bytes; a process-unique token is all the registry
+// needs to key a transaction's read-set.
 var txnSeq int64
 
 func (s *Service) project(ctx context.Context, reqProject string) string {
@@ -69,14 +211,29 @@ func (s *Service) project(ctx context.Context, reqProject string) string {
 // ─── Datastore service ────────────────────────────────────────────────────────
 
 func (s *Service) Commit(ctx context.Context, req *datastorepb.CommitRequest) (*datastorepb.CommitResponse, error) {
-	// The emulator is non-transactional: a TRANSACTIONAL commit (or one carrying
-	// a transaction selector) is rejected rather than silently applied as a
-	// non-transactional write. See the package doc.
-	if req.GetMode() == datastorepb.CommitRequest_TRANSACTIONAL || len(req.GetTransaction()) > 0 {
-		return nil, mapError(model.NewProviderError("UnsupportedOperation", "transactions are not supported by this emulator", 501))
+	project := s.project(ctx, req.GetProjectId())
+	txn := req.GetTransaction()
+
+	// Dispatch on the proto's commit mode. MODE_UNSPECIFIED (the zero value) is
+	// treated as non-transactional unless a transaction selector is present —
+	// the behavior non-transactional SDK commits rely on; a TRANSACTIONAL
+	// commit always requires a transaction handle.
+	transactional := false
+	switch req.GetMode() {
+	case datastorepb.CommitRequest_TRANSACTIONAL:
+		if len(txn) == 0 {
+			return nil, mapError(model.NewProviderError("InvalidArgument", "TRANSACTIONAL commit requires a transaction", 400))
+		}
+		transactional = true
+	case datastorepb.CommitRequest_NON_TRANSACTIONAL:
+		transactional = false
+	default:
+		transactional = len(txn) > 0
+	}
+	if transactional {
+		return s.commitTransactional(ctx, project, txn, req.GetMutations())
 	}
 
-	project := s.project(ctx, req.GetProjectId())
 	results := make([]*datastorepb.MutationResult, 0, len(req.GetMutations()))
 	for _, m := range req.GetMutations() {
 		pre := mutationPrecondition(m)
@@ -163,6 +320,88 @@ func (s *Service) Commit(ctx context.Context, req *datastorepb.CommitRequest) (*
 	}, nil
 }
 
+// commitTransactional implements the Datastore transaction commit protocol. It
+// re-validates the transaction's read-set and applies every mutation
+// atomically: any read-set conflict aborts the whole commit with ABORTED and
+// applies nothing, while a per-mutation Precondition mismatch aborts it with
+// FAILED_PRECONDITION. The transaction is terminated on every attempt that
+// reaches the store (real Datastore requires a fresh BeginTransaction to retry
+// an aborted one).
+//
+// Entity resolution (key parsing and auto-ID allocation) happens before the
+// store commit. ID allocation is not rolled back if the commit aborts — an
+// internal approximation matching real Datastore, where allocated IDs are
+// monotonic and may be skipped.
+func (s *Service) commitTransactional(ctx context.Context, project string, txn []byte, mutations []*datastorepb.Mutation) (*datastorepb.CommitResponse, error) {
+	if err := s.requireActive(txn); err != nil {
+		return nil, mapError(err)
+	}
+	reads := s.readSetFor(txn)
+
+	writes := make([]datastorestore.Write, 0, len(mutations))
+	allocatedKeys := make([]*datastorepb.Key, len(mutations))
+	for i, m := range mutations {
+		pre := mutationPrecondition(m)
+		switch op := m.GetOperation().(type) {
+		case *datastorepb.Mutation_Insert:
+			e, allocated, err := s.resolveEntity(ctx, project, op.Insert)
+			if err != nil {
+				return nil, mapError(err)
+			}
+			writes = append(writes, datastorestore.Write{Op: datastorestore.WriteInsert, Key: e.Key, Entity: e, Precondition: pre})
+			if allocated {
+				allocatedKeys[i] = keyProto(e.Key, project)
+			}
+		case *datastorepb.Mutation_Upsert:
+			e, allocated, err := s.resolveEntity(ctx, project, op.Upsert)
+			if err != nil {
+				return nil, mapError(err)
+			}
+			writes = append(writes, datastorestore.Write{Op: datastorestore.WriteUpsert, Key: e.Key, Entity: e, Precondition: pre})
+			if allocated {
+				allocatedKeys[i] = keyProto(e.Key, project)
+			}
+		case *datastorepb.Mutation_Update:
+			e, err := entityFromProto(op.Update)
+			if err != nil {
+				return nil, mapError(err)
+			}
+			if e.Key == "" {
+				return nil, mapError(model.NewProviderError("InvalidArgument", "update key is incomplete", 400))
+			}
+			writes = append(writes, datastorestore.Write{Op: datastorestore.WriteUpdate, Key: e.Key, Entity: e, Precondition: pre})
+		case *datastorepb.Mutation_Delete:
+			key, err := deleteKey(op.Delete)
+			if err != nil {
+				return nil, mapError(err)
+			}
+			writes = append(writes, datastorestore.Write{Op: datastorestore.WriteDelete, Key: key, Precondition: pre})
+		default:
+			return nil, mapError(model.NewProviderError("InvalidArgument", "mutation has no operation", 400))
+		}
+	}
+
+	commitTime := clock.Now()
+	applied, err := s.store.Commit(ctx, project, reads, writes)
+	s.clearReadSet(txn)
+	if err != nil {
+		return nil, mapTxnStoreError(err)
+	}
+
+	results := make([]*datastorepb.MutationResult, 0, len(applied))
+	for i := range applied {
+		mr := &datastorepb.MutationResult{Version: applied[i].Version}
+		if allocatedKeys[i] != nil {
+			mr.Key = allocatedKeys[i]
+		}
+		results = append(results, mr)
+	}
+	return &datastorepb.CommitResponse{
+		MutationResults: results,
+		CommitTime:      timestamppb.New(commitTime),
+	}, nil
+}
+
 // mutationPrecondition translates a Mutation's conflict_detection_strategy
 // oneof (base_version or update_time — real Datastore's per-mutation
 // optimistic-concurrency precondition) into a store Precondition. Returns nil
@@ -181,6 +420,13 @@ func mutationPrecondition(m *datastorepb.Mutation) *datastorestore.Precondition 
 }
 
 func (s *Service) Lookup(ctx context.Context, req *datastorepb.LookupRequest) (*datastorepb.LookupResponse, error) {
+	// The transaction selector lives in ReadOptions (read_options.transaction),
+	// matching the real proto. ReadOptions.new_transaction (implicit begin) is
+	// not supported; such a read is treated as non-transactional.
+	txn := req.GetReadOptions().GetTransaction()
+	if err := s.requireActive(txn); err != nil {
+		return nil, mapError(err)
+	}
 	project := s.project(ctx, req.GetProjectId())
 	resp := &datastorepb.LookupResponse{}
 	for _, k := range req.GetKeys() {
@@ -194,6 +440,10 @@ func (s *Service) Lookup(ctx context.Context, req *datastorepb.LookupRequest) (*
 		e, err := s.store.Get(ctx, project, key)
 		switch {
 		case errors.Is(err, datastorestore.ErrEntityNotFound):
+			// Record the miss (version 0) so a concurrent create aborts the
+			// eventual commit — real Datastore records absent keys in the
+			// read-set too.
+			s.recordRead(txn, key, false, 0)
 			resp.Missing = append(resp.Missing, &datastorepb.EntityResult{
 				Entity:  &datastorepb.Entity{Key: keyProto(key, project)},
 				Version: 1,
@@ -202,6 +452,7 @@ func (s *Service) Lookup(ctx context.Context, req *datastorepb.LookupRequest) (*
 			return nil, mapError(err)
 		default:
 			_ = kind
+			s.recordRead(txn, key, true, e.Version)
 			resp.Found = append(resp.Found, &datastorepb.EntityResult{
 				Entity: entityToProto(e, project),
 				// Real, per-entity version — clients read this and pass it
@@ -215,6 +466,11 @@ func (s *Service) Lookup(ctx context.Context, req *datastorepb.LookupRequest) (*
 }
 
 func (s *Service) RunQuery(ctx context.Context, req *datastorepb.RunQueryRequest) (*datastorepb.RunQueryResponse, error) {
+	// See Lookup: the transaction selector lives in ReadOptions.
+	txn := req.GetReadOptions().GetTransaction()
+	if err := s.requireActive(txn); err != nil {
+		return nil, mapError(err)
+	}
 	project := s.project(ctx, req.GetProjectId())
 	batch := &datastorepb.QueryResultBatch{
 		EntityResultType: datastorepb.EntityResult_FULL,
@@ -249,6 +505,11 @@ func (s *Service) RunQuery(ctx context.Context, req *datastorepb.RunQueryRequest
 				continue
 			}
 		}
+		// Internal approximation: real Datastore validates the query's read
+		// *range* at commit; the emulator records the version of every entity
+		// the query returned and re-validates exactly those entities (see the
+		// package doc).
+		s.recordRead(txn, e.Key, true, e.Version)
 		batch.EntityResults = append(batch.EntityResults, &datastorepb.EntityResult{
 			Entity:  entityToProto(e, project),
 			Version: e.Version,
@@ -258,12 +519,19 @@ func (s *Service) RunQuery(ctx context.Context, req *datastorepb.RunQueryRequest
 }
 
 func (s *Service) BeginTransaction(ctx context.Context, req *datastorepb.BeginTransactionRequest) (*datastorepb.BeginTransactionResponse, error) {
-	return &datastorepb.BeginTransactionResponse{
-		Transaction: []byte("txn-" + strconv.FormatInt(atomic.AddInt64(&txnSeq, 1), 10)),
-	}, nil
+	txn := []byte("txn-" + strconv.FormatInt(atomic.AddInt64(&txnSeq, 1), 10))
+	s.txnMu.Lock()
+	if s.readSets == nil {
+		s.readSets = make(map[string]*readSet)
+	}
+	s.readSets[string(txn)] = &readSet{reads: make(map[string]datastorestore.ReadRef), start: clock.Now()}
+	s.txnMu.Unlock()
+	return &datastorepb.BeginTransactionResponse{Transaction: txn}, nil
 }
 
 func (s *Service) Rollback(ctx context.Context, req *datastorepb.RollbackRequest) (*datastorepb.RollbackResponse, error) {
+	// Idempotent for an unknown/expired transaction, matching real Datastore.
+	s.clearReadSet(req.GetTransaction())
 	return &datastorepb.RollbackResponse{}, nil
 }
 

--- a/internal/gcp/grpc/datastore/txn_test.go
+++ b/internal/gcp/grpc/datastore/txn_test.go
@@ -1,0 +1,309 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	datastorepb "cloud.google.com/go/datastore/apiv1/datastorepb"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// readTxn builds ReadOptions carrying an explicit transaction selector, as the
+// real proto does (read_options.transaction).
+func readTxn(txn []byte) *datastorepb.ReadOptions {
+	return &datastorepb.ReadOptions{
+		ConsistencyType: &datastorepb.ReadOptions_Transaction{Transaction: txn},
+	}
+}
+
+func beginTxn(t *testing.T, client datastorepb.DatastoreClient) []byte {
+	t.Helper()
+	resp, err := client.BeginTransaction(context.Background(), &datastorepb.BeginTransactionRequest{ProjectId: "test"})
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if len(resp.GetTransaction()) == 0 {
+		t.Fatal("begin returned an empty transaction")
+	}
+	return resp.GetTransaction()
+}
+
+func upsertTask(t *testing.T, client datastorepb.DatastoreClient, name string, n int64) int64 {
+	t.Helper()
+	resp, err := client.Commit(context.Background(), &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", name), map[string]*datastorepb.Value{"n": intVal(n)})},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("upsert %s: %v", name, err)
+	}
+	return resp.GetMutationResults()[0].GetVersion()
+}
+
+func lookupTask(t *testing.T, client datastorepb.DatastoreClient, name string, txn []byte) *datastorepb.EntityResult {
+	t.Helper()
+	req := &datastorepb.LookupRequest{ProjectId: "test", Keys: []*datastorepb.Key{nameKey("Task", name)}}
+	if txn != nil {
+		req.ReadOptions = readTxn(txn)
+	}
+	resp, err := client.Lookup(context.Background(), req)
+	if err != nil {
+		t.Fatalf("lookup %s: %v", name, err)
+	}
+	if len(resp.GetFound()) == 1 {
+		return resp.GetFound()[0]
+	}
+	return nil
+}
+
+func txnCommit(t *testing.T, client datastorepb.DatastoreClient, txn []byte, muts ...*datastorepb.Mutation) (*datastorepb.CommitResponse, error) {
+	t.Helper()
+	return client.Commit(context.Background(), &datastorepb.CommitRequest{
+		ProjectId:           "test",
+		Mode:                datastorepb.CommitRequest_TRANSACTIONAL,
+		TransactionSelector: &datastorepb.CommitRequest_Transaction{Transaction: txn},
+		Mutations:           muts,
+	})
+}
+
+func TestTransactionLookupThenCommitSucceeds(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	upsertTask(t, client, "a", 1)
+	txn := beginTxn(t, client)
+
+	found := lookupTask(t, client, "a", txn)
+	if found == nil {
+		t.Fatal("transactional lookup did not find the entity")
+	}
+	if found.GetVersion() != 1 {
+		t.Fatalf("read version = %d, want 1", found.GetVersion())
+	}
+
+	resp, err := txnCommit(t, client, txn, &datastorepb.Mutation{
+		Operation: &datastorepb.Mutation_Update{Update: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(2)})},
+	})
+	if err != nil {
+		t.Fatalf("transactional commit: %v", err)
+	}
+	if resp.GetCommitTime() == nil {
+		t.Fatal("transactional commit must set commit_time")
+	}
+	if got := resp.GetMutationResults()[0].GetVersion(); got != 2 {
+		t.Fatalf("commit result version = %d, want 2", got)
+	}
+	if got := lookupTask(t, client, "a", nil).GetEntity().GetProperties()["n"].GetIntegerValue(); got != 2 {
+		t.Fatalf("n after commit = %d, want 2", got)
+	}
+}
+
+func TestTransactionReadConflictAbortsAndNothingApplied(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	upsertTask(t, client, "a", 1)
+	txn := beginTxn(t, client)
+	if found := lookupTask(t, client, "a", txn); found == nil {
+		t.Fatal("transactional lookup did not find the entity")
+	}
+
+	// A concurrent non-transactional writer modifies the entity after the read.
+	upsertTask(t, client, "a", 2)
+
+	_, err := txnCommit(t, client, txn, &datastorepb.Mutation{
+		Operation: &datastorepb.Mutation_Update{Update: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(99)})},
+	})
+	if status.Code(err) != codes.Aborted {
+		t.Fatalf("commit err = %v, want Aborted", err)
+	}
+
+	// The aborted transaction's write must not have applied.
+	if got := lookupTask(t, client, "a", nil).GetEntity().GetProperties()["n"].GetIntegerValue(); got != 2 {
+		t.Fatalf("n = %d after aborted commit, want 2", got)
+	}
+
+	// Any commit attempt terminates the transaction: reusing the token is now
+	// invalid (real Datastore requires a fresh BeginTransaction to retry).
+	if _, err := txnCommit(t, client, txn, &datastorepb.Mutation{
+		Operation: &datastorepb.Mutation_Update{Update: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(3)})},
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("reused transaction err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestTransactionRollbackDiscards(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+	_ = ctx
+
+	txn := beginTxn(t, client)
+	if _, err := client.Rollback(ctx, &datastorepb.RollbackRequest{ProjectId: "test", Transaction: txn}); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+
+	if _, err := txnCommit(t, client, txn, &datastorepb.Mutation{
+		Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(1)})},
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("commit after rollback err = %v, want InvalidArgument", err)
+	}
+
+	// Rollback is idempotent even for an unknown token.
+	if _, err := client.Rollback(ctx, &datastorepb.RollbackRequest{ProjectId: "test", Transaction: []byte("nonexistent")}); err != nil {
+		t.Fatalf("rollback unknown: %v", err)
+	}
+}
+
+func TestTransactionPreconditionMismatchFailsPrecondition(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	upsertTask(t, client, "a", 1)
+	txn := beginTxn(t, client)
+
+	_, err := txnCommit(t, client, txn, &datastorepb.Mutation{
+		Operation:                 &datastorepb.Mutation_Update{Update: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(99)})},
+		ConflictDetectionStrategy: &datastorepb.Mutation_BaseVersion{BaseVersion: 12345},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("commit err = %v, want FailedPrecondition", err)
+	}
+	if got := lookupTask(t, client, "a", nil).GetEntity().GetProperties()["n"].GetIntegerValue(); got != 1 {
+		t.Fatalf("n = %d after precondition failure, want 1", got)
+	}
+}
+
+func TestTransactionalWithoutTransactionIsInvalid(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mode:      datastorepb.CommitRequest_TRANSACTIONAL,
+		// no transaction
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(1)})},
+		}},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestUnknownTransactionCommitIsInvalid(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	_, err := txnCommit(t, client, []byte("does-not-exist"), &datastorepb.Mutation{
+		Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(1)})},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestNonTransactionalCommitUnchanged(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// No mode, no transaction: the historical non-transactional path.
+	resp, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Insert{Insert: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(1)})},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("non-transactional commit: %v", err)
+	}
+	if resp.GetCommitTime() != nil {
+		t.Fatal("non-transactional commit must not set commit_time")
+	}
+	if got := resp.GetMutationResults()[0].GetVersion(); got != 1 {
+		t.Fatalf("version = %d, want 1", got)
+	}
+}
+
+// TestTwoTransactionsSameEntityOneAborts is the no-lost-update guarantee at the
+// service level: two transactions that both read the same version race to
+// commit; one wins and the other aborts.
+func TestTwoTransactionsSameEntityOneAborts(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	upsertTask(t, client, "a", 1)
+	txnA := beginTxn(t, client)
+	txnB := beginTxn(t, client)
+	if lookupTask(t, client, "a", txnA) == nil || lookupTask(t, client, "a", txnB) == nil {
+		t.Fatal("both transactions must observe the entity")
+	}
+
+	if _, err := txnCommit(t, client, txnA, &datastorepb.Mutation{
+		Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(100)})},
+	}); err != nil {
+		t.Fatalf("txn A commit: %v", err)
+	}
+	if _, err := txnCommit(t, client, txnB, &datastorepb.Mutation{
+		Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(200)})},
+	}); status.Code(err) != codes.Aborted {
+		t.Fatalf("txn B commit err = %v, want Aborted", err)
+	}
+
+	// A's write survived; B's did not (no lost update).
+	if got := lookupTask(t, client, "a", nil).GetEntity().GetProperties()["n"].GetIntegerValue(); got != 100 {
+		t.Fatalf("n = %d, want 100 (B must not have overwritten A)", got)
+	}
+}
+
+func TestTransactionLookupMissingThenCreatedAborts(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	txn := beginTxn(t, client)
+	if got := lookupTask(t, client, "a", txn); got != nil {
+		t.Fatal("entity should not exist yet")
+	}
+
+	// A concurrent create of the key read as missing.
+	upsertTask(t, client, "a", 1)
+
+	if _, err := txnCommit(t, client, txn, &datastorepb.Mutation{
+		Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(99)})},
+	}); status.Code(err) != codes.Aborted {
+		t.Fatalf("commit err = %v, want Aborted", err)
+	}
+}
+
+func TestTransactionRunQueryRecordsReads(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	upsertTask(t, client, "a", 1)
+	upsertTask(t, client, "b", 1)
+
+	txn := beginTxn(t, client)
+	q := &datastorepb.Query{Kind: []*datastorepb.KindExpression{{Name: "Task"}}}
+	if _, err := client.RunQuery(ctx, &datastorepb.RunQueryRequest{
+		ProjectId:   "test",
+		ReadOptions: readTxn(txn),
+		QueryType:   &datastorepb.RunQueryRequest_Query{Query: q},
+	}); err != nil {
+		t.Fatalf("transactional runquery: %v", err)
+	}
+
+	// Modify one of the entities the query returned.
+	upsertTask(t, client, "b", 2)
+
+	// A commit with no mutations still validates the read-set and must abort.
+	if _, err := txnCommit(t, client, txn); status.Code(err) != codes.Aborted {
+		t.Fatalf("commit err = %v, want Aborted", err)
+	}
+}

--- a/internal/gcp/grpc/datastore/txn_test.go
+++ b/internal/gcp/grpc/datastore/txn_test.go
@@ -3,11 +3,15 @@ package datastore
 import (
 	"context"
 	"testing"
+	"time"
 
 	datastorepb "cloud.google.com/go/datastore/apiv1/datastorepb"
 
+	"jaiscloud/internal/clock"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // readTxn builds ReadOptions carrying an explicit transaction selector, as the
@@ -305,5 +309,218 @@ func TestTransactionRunQueryRecordsReads(t *testing.T) {
 	// A commit with no mutations still validates the read-set and must abort.
 	if _, err := txnCommit(t, client, txn); status.Code(err) != codes.Aborted {
 		t.Fatalf("commit err = %v, want Aborted", err)
+	}
+}
+
+// ─── coverage additions ──────────────────────────────────────────────────────
+
+// TestTransactionCommitMixedMutations exercises the Upsert and Delete branches
+// of the transactional path (the other tests only commit Insert/Update).
+func TestTransactionCommitMixedMutations(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	upsertTask(t, client, "a", 1)
+	upsertTask(t, client, "b", 1)
+	txn := beginTxn(t, client)
+	if lookupTask(t, client, "a", txn) == nil {
+		t.Fatal("transactional lookup did not find a")
+	}
+
+	resp, err := txnCommit(t, client, txn,
+		&datastorepb.Mutation{Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", "c"), map[string]*datastorepb.Value{"n": intVal(7)})}},
+		&datastorepb.Mutation{Operation: &datastorepb.Mutation_Delete{Delete: nameKey("Task", "b")}},
+		&datastorepb.Mutation{Operation: &datastorepb.Mutation_Update{Update: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(2)})}},
+	)
+	if err != nil {
+		t.Fatalf("transactional commit: %v", err)
+	}
+	if len(resp.GetMutationResults()) != 3 {
+		t.Fatalf("mutation_results = %d, want 3", len(resp.GetMutationResults()))
+	}
+	if got := lookupTask(t, client, "c", nil).GetEntity().GetProperties()["n"].GetIntegerValue(); got != 7 {
+		t.Fatalf("c.n = %d, want 7 (upsert)", got)
+	}
+	if r := lookupTask(t, client, "b", nil); r != nil {
+		t.Fatalf("b should have been deleted, got %+v", r)
+	}
+	if got := lookupTask(t, client, "a", nil).GetEntity().GetProperties()["n"].GetIntegerValue(); got != 2 {
+		t.Fatalf("a.n = %d, want 2 (update)", got)
+	}
+}
+
+// TestTransactionCommitAutoAllocatesID covers the allocated-key branch: an
+// Insert with an incomplete key inside a transaction gets a server-allocated
+// id, returned in mutation_results[i].key.
+func TestTransactionCommitAutoAllocatesID(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	txn := beginTxn(t, client)
+	resp, err := txnCommit(t, client, txn, &datastorepb.Mutation{
+		Operation: &datastorepb.Mutation_Insert{Insert: entity(incompleteKey("Task"), map[string]*datastorepb.Value{"n": intVal(1)})},
+	})
+	if err != nil {
+		t.Fatalf("transactional commit: %v", err)
+	}
+	k := resp.GetMutationResults()[0].GetKey()
+	if k == nil {
+		t.Fatal("an auto-allocated insert must return the allocated key")
+	}
+	path := k.GetPath()
+	if len(path) == 0 || path[len(path)-1].GetId() == 0 {
+		t.Fatalf("auto-allocated key has no id: %v", k)
+	}
+
+	// An Upsert with an incomplete key auto-allocates too.
+	txn2 := beginTxn(t, client)
+	resp2, err := txnCommit(t, client, txn2, &datastorepb.Mutation{
+		Operation: &datastorepb.Mutation_Upsert{Upsert: entity(incompleteKey("Task"), map[string]*datastorepb.Value{"n": intVal(2)})},
+	})
+	if err != nil {
+		t.Fatalf("transactional upsert commit: %v", err)
+	}
+	k2 := resp2.GetMutationResults()[0].GetKey()
+	if k2 == nil || len(k2.GetPath()) == 0 || k2.GetPath()[len(k2.GetPath())-1].GetId() == 0 {
+		t.Fatalf("upsert auto-allocated key missing id: %v", k2)
+	}
+}
+
+// TestTransactionIncompleteUpdateKeyInvalid covers the transactional path's
+// incomplete-Update-key rejection.
+func TestTransactionIncompleteUpdateKeyInvalid(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	txn := beginTxn(t, client)
+	_, err := txnCommit(t, client, txn, &datastorepb.Mutation{
+		Operation: &datastorepb.Mutation_Update{Update: entity(incompleteKey("Task"), map[string]*datastorepb.Value{"n": intVal(1)})},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("err = %v, want InvalidArgument", err)
+	}
+}
+
+// TestRollbackEmptyTransactionIdempotent covers Rollback with no transaction
+// (a no-op, matching real Datastore's tolerance of an unknown transaction).
+func TestRollbackEmptyTransactionIdempotent(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if _, err := client.Rollback(ctx, &datastorepb.RollbackRequest{ProjectId: "test"}); err != nil {
+		t.Fatalf("rollback with no transaction = %v, want nil", err)
+	}
+	if _, err := client.Rollback(ctx, &datastorepb.RollbackRequest{ProjectId: "test", Transaction: []byte("unknown")}); err != nil {
+		t.Fatalf("rollback with unknown transaction = %v, want nil", err)
+	}
+}
+
+// TestTransactionUpdateTimePreconditionMismatch covers the Mutation_UpdateTime
+// conflict-detection branch (the other tests only use base_version).
+func TestTransactionUpdateTimePreconditionMismatch(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	upsertTask(t, client, "a", 1)
+	txn := beginTxn(t, client)
+	if lookupTask(t, client, "a", txn) == nil {
+		t.Fatal("transactional lookup did not find a")
+	}
+
+	_, err := txnCommit(t, client, txn, &datastorepb.Mutation{
+		Operation:                 &datastorepb.Mutation_Update{Update: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(2)})},
+		ConflictDetectionStrategy: &datastorepb.Mutation_UpdateTime{UpdateTime: timestamppb.New(time.Now().Add(-time.Hour))},
+	})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("commit err = %v, want FailedPrecondition", err)
+	}
+	if got := lookupTask(t, client, "a", nil).GetEntity().GetProperties()["n"].GetIntegerValue(); got != 1 {
+		t.Fatalf("n = %d after precondition failure, want 1", got)
+	}
+}
+
+// TestTransactionCommitNoOperationMutation covers the transactional path's
+// default branch: a mutation carrying no operation is INVALID_ARGUMENT.
+func TestTransactionCommitNoOperationMutation(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	txn := beginTxn(t, client)
+	if _, err := txnCommit(t, client, txn, &datastorepb.Mutation{}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("commit err = %v, want InvalidArgument", err)
+	}
+}
+
+// TestCommitExplicitNonTransactional covers the explicit NON_TRANSACTIONAL mode
+// (the other tests rely on the MODE_UNSPECIFIED default).
+func TestCommitExplicitNonTransactional(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	resp, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mode:      datastorepb.CommitRequest_NON_TRANSACTIONAL,
+		Mutations: []*datastorepb.Mutation{{
+			Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", "x"), map[string]*datastorepb.Value{"n": intVal(1)})},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if resp.GetCommitTime() != nil {
+		t.Fatal("non-transactional commit must not set commit_time")
+	}
+	if got := lookupTask(t, client, "x", nil); got == nil {
+		t.Fatal("upsert did not apply")
+	}
+}
+
+// TestTransactionExpiredTTL verifies that a transaction past its TTL is evicted
+// and can no longer be committed (real Datastore expires transactions too).
+func TestTransactionExpiredTTL(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	clock.SetGlobalClock(clock.FixedClock{T: time.Now()})
+	defer clock.SetGlobalClock(clock.RealClock{})
+
+	txn := beginTxn(t, client)
+	// Advance well past the ~270s transaction TTL.
+	clock.SetGlobalClock(clock.FixedClock{T: time.Now().Add(10 * time.Minute)})
+
+	_, err := txnCommit(t, client, txn, &datastorepb.Mutation{
+		Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Task", "a"), map[string]*datastorepb.Value{"n": intVal(1)})},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expired transaction err = %v, want InvalidArgument", err)
+	}
+}
+
+// TestLookupRunQueryUnknownTransaction verifies a non-empty but unknown
+// transaction selector is rejected on reads (not silently ignored).
+func TestLookupRunQueryUnknownTransaction(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+	bogus := []byte("not-a-real-transaction")
+
+	_, err := client.Lookup(ctx, &datastorepb.LookupRequest{
+		ProjectId:   "test",
+		Keys:        []*datastorepb.Key{nameKey("Task", "a")},
+		ReadOptions: readTxn(bogus),
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("lookup unknown transaction err = %v, want InvalidArgument", err)
+	}
+
+	_, err = client.RunQuery(ctx, &datastorepb.RunQueryRequest{
+		ProjectId:   "test",
+		QueryType:   &datastorepb.RunQueryRequest_Query{Query: &datastorepb.Query{Kind: []*datastorepb.KindExpression{{Name: "Task"}}}},
+		ReadOptions: readTxn(bogus),
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("runquery unknown transaction err = %v, want InvalidArgument", err)
 	}
 }

--- a/internal/gcp/store/datastore/commit_test.go
+++ b/internal/gcp/store/datastore/commit_test.go
@@ -1,0 +1,160 @@
+package datastore
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// seed inserts an entity via ApplyMutation so it gets a server-stamped version
+// (1), the version a transaction read-set records.
+func seed(t *testing.T, s *MemoryStore, project string, e Entity) Entity {
+	t.Helper()
+	applied, err := s.ApplyMutation(context.Background(), project, MutationInsert, e, nil)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	return applied
+}
+
+func TestMemoryStoreCommitAppliesAllWritesAtomically(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	a := seed(t, s, "p1", testEntity("Task", "a", map[string]Value{"n": num(1)}))
+	b := seed(t, s, "p1", testEntity("Task", "b", map[string]Value{"n": num(1)}))
+
+	writes := []Write{
+		{Op: WriteUpdate, Key: a.Key, Entity: testEntity("Task", "a", map[string]Value{"n": num(2)})},
+		{Op: WriteInsert, Key: KeyOfName("Task", "c"), Entity: testEntity("Task", "c", map[string]Value{"n": num(3)})},
+		{Op: WriteDelete, Key: b.Key},
+	}
+	applied, err := s.Commit(ctx, "p1", nil, writes)
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if len(applied) != 3 {
+		t.Fatalf("applied = %d, want 3", len(applied))
+	}
+	if applied[0].Version != 2 {
+		t.Fatalf("update version = %d, want 2", applied[0].Version)
+	}
+	if applied[1].Version != 1 {
+		t.Fatalf("insert version = %d, want 1", applied[1].Version)
+	}
+
+	got, _ := s.Get(ctx, "p1", a.Key)
+	if n := got.Properties["n"].IntegerValue; n == nil || *n != 2 {
+		t.Fatalf("a.n = %v, want 2", got.Properties["n"])
+	}
+	if _, err := s.Get(ctx, "p1", KeyOfName("Task", "c")); err != nil {
+		t.Fatalf("c should have been inserted: %v", err)
+	}
+	if _, err := s.Get(ctx, "p1", b.Key); !errors.Is(err, ErrEntityNotFound) {
+		t.Fatalf("b should have been deleted, got %v", err)
+	}
+}
+
+func TestMemoryStoreCommitReadSetConflictAborts(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	a := seed(t, s, "p1", testEntity("Task", "a", map[string]Value{"n": num(1)}))
+
+	reads := []ReadRef{{Key: a.Key, Exists: true, Version: a.Version}}
+
+	// A concurrent writer advances the entity after the read was recorded.
+	if _, err := s.ApplyMutation(ctx, "p1", MutationUpdate, testEntity("Task", "a", map[string]Value{"n": num(2)}), nil); err != nil {
+		t.Fatalf("concurrent update: %v", err)
+	}
+
+	writes := []Write{{Op: WriteUpdate, Key: a.Key, Entity: testEntity("Task", "a", map[string]Value{"n": num(99)})}}
+	if _, err := s.Commit(ctx, "p1", reads, writes); !errors.Is(err, ErrAborted) {
+		t.Fatalf("commit = %v, want ErrAborted", err)
+	}
+	got, _ := s.Get(ctx, "p1", a.Key)
+	if n := got.Properties["n"].IntegerValue; n == nil || *n != 2 {
+		t.Fatalf("entity changed despite abort: n = %v, want 2", got.Properties["n"])
+	}
+}
+
+func TestMemoryStoreCommitMissingReadDetectsCreate(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	a := testEntity("Task", "a", map[string]Value{"n": num(1)})
+
+	// The key was read as absent.
+	reads := []ReadRef{{Key: a.Key, Exists: false, Version: 0}}
+
+	// A concurrent writer creates it.
+	if _, err := s.ApplyMutation(ctx, "p1", MutationInsert, a, nil); err != nil {
+		t.Fatalf("concurrent insert: %v", err)
+	}
+
+	writes := []Write{{Op: WriteUpsert, Key: a.Key, Entity: testEntity("Task", "a", map[string]Value{"n": num(99)})}}
+	if _, err := s.Commit(ctx, "p1", reads, writes); !errors.Is(err, ErrAborted) {
+		t.Fatalf("commit = %v, want ErrAborted", err)
+	}
+}
+
+func TestMemoryStoreCommitPreconditionMismatchAborts(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	a := seed(t, s, "p1", testEntity("Task", "a", map[string]Value{"n": num(1)}))
+
+	stale := int64(0)
+	writes := []Write{{
+		Op:           WriteUpdate,
+		Key:          a.Key,
+		Entity:       testEntity("Task", "a", map[string]Value{"n": num(99)}),
+		Precondition: &Precondition{BaseVersion: &stale},
+	}}
+	if _, err := s.Commit(ctx, "p1", nil, writes); !errors.Is(err, ErrConflict) {
+		t.Fatalf("commit = %v, want ErrConflict", err)
+	}
+	got, _ := s.Get(ctx, "p1", a.Key)
+	if n := got.Properties["n"].IntegerValue; n == nil || *n != 1 {
+		t.Fatalf("entity changed despite precondition failure: n = %v, want 1", got.Properties["n"])
+	}
+}
+
+// TestMemoryStoreCommitConcurrentSameEntity is the no-lost-update guarantee:
+// two commits that both observed the same entity version race; exactly one
+// wins and the other aborts without applying.
+func TestMemoryStoreCommitConcurrentSameEntity(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	a := seed(t, s, "p1", testEntity("Task", "a", map[string]Value{"n": num(1)}))
+	reads := []ReadRef{{Key: a.Key, Exists: true, Version: a.Version}}
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			writes := []Write{{Op: WriteUpsert, Key: a.Key, Entity: testEntity("Task", "a", map[string]Value{"n": num(int64(100 + i))})}}
+			_, errs[i] = s.Commit(ctx, "p1", reads, writes)
+		}(i)
+	}
+	wg.Wait()
+
+	aborted := 0
+	succeeded := 0
+	for _, err := range errs {
+		switch {
+		case err == nil:
+			succeeded++
+		case errors.Is(err, ErrAborted):
+			aborted++
+		default:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if succeeded != 1 || aborted != 1 {
+		t.Fatalf("succeeded=%d aborted=%d, want 1 and 1", succeeded, aborted)
+	}
+	got, _ := s.Get(ctx, "p1", a.Key)
+	if got.Version != 2 {
+		t.Fatalf("final version = %d, want 2 (exactly one write applied)", got.Version)
+	}
+}

--- a/internal/gcp/store/datastore/memory.go
+++ b/internal/gcp/store/datastore/memory.go
@@ -130,6 +130,51 @@ func (s *MemoryStore) DeleteConflictChecked(_ context.Context, project, key stri
 	return nil
 }
 
+// Commit applies reads+writes atomically under one lock: the read-set is
+// re-validated and every write is validated before any write is applied, so a
+// concurrent mutation can neither land between the checks and the apply nor be
+// observed half-applied. See Store.Commit's doc comment for the error contract.
+func (s *MemoryStore) Commit(_ context.Context, project string, reads []ReadRef, writes []Write) ([]Entity, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// 1. Re-validate the transaction read-set.
+	for _, r := range reads {
+		current, exists := s.entities[project][r.Key]
+		if r.Exists != exists {
+			return nil, ErrAborted
+		}
+		if exists && current.Version != r.Version {
+			return nil, ErrAborted
+		}
+	}
+
+	// 2. Validate every write and compute the entity to persist, without
+	//    mutating anything yet (all-or-nothing).
+	applied := make([]Entity, len(writes))
+	for i, w := range writes {
+		current, exists := s.entities[project][w.Key]
+		e, err := resolveWrite(current, exists, w)
+		if err != nil {
+			return nil, err
+		}
+		applied[i] = e
+	}
+
+	// 3. Apply all writes now that every validation has passed.
+	for i, w := range writes {
+		if w.Op == WriteDelete {
+			delete(s.entities[project], w.Key)
+			continue
+		}
+		if s.entities[project] == nil {
+			s.entities[project] = make(map[string]Entity)
+		}
+		s.entities[project][w.Key] = applied[i]
+	}
+	return applied, nil
+}
+
 func (s *MemoryStore) ListKind(_ context.Context, project, kind string) ([]Entity, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/gcp/store/datastore/postgres.go
+++ b/internal/gcp/store/datastore/postgres.go
@@ -42,7 +42,15 @@ func scanEntity(scan func(...any) error) (Entity, error) {
 	if e.Properties == nil {
 		e.Properties = map[string]Value{}
 	}
-	e.Key = e.Kind + "/" + nameOrID
+	// Rebuild the canonical (length-prefixed) key form the rest of the store
+	// uses (KeyOfID/KeyOfName). The name_or_id column is the tagged identifier
+	// ("id:<n>"/"name:<s>"), not the canonical key, so — unlike the
+	// pre-#42 "kind/name_or_id" join — it round-trips through SplitKey.
+	if id, name, isID := ParseIDOrName(nameOrID); isID {
+		e.Key = KeyOfID(e.Kind, id)
+	} else {
+		e.Key = KeyOfName(e.Kind, name)
+	}
 	return e, nil
 }
 
@@ -239,6 +247,115 @@ func (s *PostgresStore) DeleteConflictChecked(ctx context.Context, project, key 
 		return err
 	}
 	return tx.Commit(ctx)
+}
+
+// Commit mirrors MemoryStore's, in one Serializable transaction with each
+// read-set and write row locked (SELECT ... FOR UPDATE), so the read-set and
+// precondition validations and the apply are atomic: no concurrent mutation
+// can slip in between them. See Store.Commit's doc comment for the error
+// contract.
+func (s *PostgresStore) Commit(ctx context.Context, project string, reads []ReadRef, writes []Write) ([]Entity, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	// 1. Re-validate the transaction read-set under row locks.
+	for _, r := range reads {
+		kind, nameOrID, ok := SplitKey(r.Key)
+		if !ok {
+			return nil, ErrInvalidKey
+		}
+		var version int64
+		err := tx.QueryRow(ctx, `
+			SELECT version FROM jc_datastore_entities
+			WHERE project=$1 AND kind=$2 AND name_or_id=$3 FOR UPDATE
+		`, project, kind, nameOrID).Scan(&version)
+		exists := true
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			exists = false
+		case err != nil:
+			return nil, err
+		}
+		if r.Exists != exists {
+			return nil, ErrAborted
+		}
+		if exists && version != r.Version {
+			return nil, ErrAborted
+		}
+	}
+
+	// 2. Validate every write under a row lock and compute the entity to
+	//    persist, without mutating anything yet (all-or-nothing).
+	applied := make([]Entity, len(writes))
+	for i, w := range writes {
+		kind, nameOrID, ok := SplitKey(w.Key)
+		if !ok {
+			return nil, ErrInvalidKey
+		}
+		row := tx.QueryRow(ctx, `
+			SELECT `+entityCols+` FROM jc_datastore_entities
+			WHERE project=$1 AND kind=$2 AND name_or_id=$3 FOR UPDATE
+		`, project, kind, nameOrID)
+		current, err := scanEntity(row.Scan)
+		exists := true
+		switch {
+		case errors.Is(err, pgx.ErrNoRows):
+			exists = false
+		case err != nil:
+			return nil, err
+		}
+		e, err := resolveWrite(current, exists, w)
+		if err != nil {
+			return nil, err
+		}
+		applied[i] = e
+	}
+
+	// 3. Apply all writes now that every validation has passed.
+	for i, w := range writes {
+		kind, nameOrID, ok := SplitKey(w.Key)
+		if !ok {
+			return nil, ErrInvalidKey
+		}
+		if w.Op == WriteDelete {
+			if _, err := tx.Exec(ctx, `DELETE FROM jc_datastore_entities WHERE project=$1 AND kind=$2 AND name_or_id=$3`, project, kind, nameOrID); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		e := applied[i]
+		if w.Op == WriteInsert {
+			// A plain INSERT (not upsert) preserves insert's existence
+			// semantics: a concurrent insert of the same key surfaces as a
+			// unique violation instead of silently overwriting.
+			if _, err := tx.Exec(ctx, `
+				INSERT INTO jc_datastore_entities (project, kind, name_or_id, properties, version, update_time)
+				VALUES ($1,$2,$3,$4,$5,$6)
+			`, project, kind, nameOrID, propertiesJSON(e.Properties), e.Version, e.UpdateTime); err != nil {
+				var pgErr *pgconn.PgError
+				if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+					return nil, ErrEntityExists
+				}
+				return nil, err
+			}
+			continue
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO jc_datastore_entities (project, kind, name_or_id, properties, version, update_time)
+			VALUES ($1,$2,$3,$4,$5,$6)
+			ON CONFLICT (project, kind, name_or_id) DO UPDATE
+				SET properties=EXCLUDED.properties, version=EXCLUDED.version, update_time=EXCLUDED.update_time
+		`, project, kind, nameOrID, propertiesJSON(e.Properties), e.Version, e.UpdateTime); err != nil {
+			return nil, err
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return applied, nil
 }
 
 func (s *PostgresStore) ListKind(ctx context.Context, project, kind string) ([]Entity, error) {

--- a/internal/gcp/store/datastore/postgres_test.go
+++ b/internal/gcp/store/datastore/postgres_test.go
@@ -1,0 +1,100 @@
+//go:build gcp_persistence
+
+package datastore
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	gcpstore "jaiscloud/internal/gcp/store"
+	"jaiscloud/internal/store"
+)
+
+// newPostgresStoreForTest connects to JAISCLOUD_DSN, runs migrations, and
+// returns a reset PostgresStore. Skips when the DSN is unset.
+func newPostgresStoreForTest(t *testing.T) *PostgresStore {
+	t.Helper()
+	dsn := os.Getenv("JAISCLOUD_DSN")
+	if dsn == "" {
+		t.Skip("JAISCLOUD_DSN not set — skipping Postgres test")
+	}
+	ctx := context.Background()
+	pg, err := store.NewPostgresResourceStore(ctx, dsn, "gcp")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pg.Close)
+	if err := store.RunMigrations(ctx, pg.Pool(), "gcp", gcpstore.MigrationFS, "gcp"); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	s := NewPostgresStore(pg.Pool())
+	s.Reset(ctx)
+	return s
+}
+
+// TestPostgresStoreCommit mirrors the memory commit cases against Postgres so
+// the transactional Commit path (read-set validation + atomic apply) is
+// exercised on the durable backend, not just in memory.
+func TestPostgresStoreCommit(t *testing.T) {
+	ctx := context.Background()
+	s := newPostgresStoreForTest(t)
+
+	a, err := s.ApplyMutation(ctx, "p1", MutationInsert, testEntity("Task", "a", map[string]Value{"n": num(1)}), nil)
+	if err != nil {
+		t.Fatalf("seed a: %v", err)
+	}
+	b, err := s.ApplyMutation(ctx, "p1", MutationInsert, testEntity("Task", "b", map[string]Value{"n": num(1)}), nil)
+	if err != nil {
+		t.Fatalf("seed b: %v", err)
+	}
+
+	// All writes applied atomically: update a, insert c, delete b.
+	applied, err := s.Commit(ctx, "p1", nil, []Write{
+		{Op: WriteUpdate, Key: a.Key, Entity: testEntity("Task", "a", map[string]Value{"n": num(2)})},
+		{Op: WriteInsert, Key: KeyOfName("Task", "c"), Entity: testEntity("Task", "c", map[string]Value{"n": num(3)})},
+		{Op: WriteDelete, Key: b.Key},
+	})
+	if err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if len(applied) != 3 {
+		t.Fatalf("applied = %d, want 3", len(applied))
+	}
+	if applied[0].Version != 2 || applied[1].Version != 1 {
+		t.Fatalf("applied versions = %d,%d want 2,1", applied[0].Version, applied[1].Version)
+	}
+	if got, _ := s.Get(ctx, "p1", a.Key); got.Properties["n"].IntegerValue == nil || *got.Properties["n"].IntegerValue != 2 {
+		t.Fatalf("a.n not updated: %+v", got.Properties["n"])
+	}
+	if _, err := s.Get(ctx, "p1", KeyOfName("Task", "c")); err != nil {
+		t.Fatalf("c should exist: %v", err)
+	}
+	if _, err := s.Get(ctx, "p1", b.Key); !errors.Is(err, ErrEntityNotFound) {
+		t.Fatalf("b should be deleted, got %v", err)
+	}
+
+	// A stale read-set aborts the whole commit with ErrAborted, applying nothing.
+	reads := []ReadRef{{Key: a.Key, Exists: true, Version: 2}}
+	if _, err := s.ApplyMutation(ctx, "p1", MutationUpdate, testEntity("Task", "a", map[string]Value{"n": num(9)}), nil); err != nil {
+		t.Fatalf("bump a: %v", err)
+	}
+	if _, err := s.Commit(ctx, "p1", reads, []Write{
+		{Op: WriteUpdate, Key: a.Key, Entity: testEntity("Task", "a", map[string]Value{"n": num(10)})},
+	}); !errors.Is(err, ErrAborted) {
+		t.Fatalf("stale read-set commit = %v, want ErrAborted", err)
+	}
+	if got, _ := s.Get(ctx, "p1", a.Key); *got.Properties["n"].IntegerValue != 9 {
+		t.Fatalf("aborted commit must not apply: a.n = %d, want 9", *got.Properties["n"].IntegerValue)
+	}
+
+	// A per-write precondition mismatch aborts with ErrConflict.
+	cur, _ := s.Get(ctx, "p1", a.Key)
+	stale := int64(999)
+	if _, err := s.Commit(ctx, "p1", nil, []Write{
+		{Op: WriteUpdate, Key: cur.Key, Entity: cur, Precondition: &Precondition{BaseVersion: &stale}},
+	}); !errors.Is(err, ErrConflict) {
+		t.Fatalf("precondition commit = %v, want ErrConflict", err)
+	}
+}

--- a/internal/gcp/store/datastore/store.go
+++ b/internal/gcp/store/datastore/store.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"jaiscloud/internal/clock"
 )
 
 // Sentinel errors returned by the store, mapped to gRPC status codes by the
@@ -25,6 +27,11 @@ var (
 	// conflict_detected=true) rather than aborting the whole Commit — see
 	// ApplyMutation's doc comment.
 	ErrConflict = errors.New("Conflict")
+	// ErrAborted is returned by Commit when a transaction read-set entry no
+	// longer matches the entity's current state. No write in the batch was
+	// applied; the caller must retry the whole transaction. Mirrors real
+	// Datastore's ABORTED (transaction contention).
+	ErrAborted = errors.New("Aborted")
 )
 
 // GeoPoint is a Datastore geo_point_value ({latitude, longitude}).
@@ -82,6 +89,38 @@ const (
 	MutationUpsert
 )
 
+// WriteOp identifies the operation a Write applies within Store.Commit. It is
+// the multi-mutation analogue of MutationKind, extended with a delete (which
+// ApplyMutation does not handle — a delete has no stored entity to return).
+type WriteOp int
+
+const (
+	WriteInsert WriteOp = iota
+	WriteUpdate
+	WriteUpsert
+	WriteDelete
+)
+
+// ReadRef records an entity observed within a transaction, for optimistic
+// concurrency re-validation at commit time. Key is the store's canonical key
+// string; Exists is false when the key was read as absent (Version is then 0).
+type ReadRef struct {
+	Key     string
+	Exists  bool
+	Version int64
+}
+
+// Write is a single mutation applied atomically within Store.Commit. Key is
+// the canonical store key holding the target (for WriteDelete, the entity
+// being deleted; for the others it must equal Entity.Key). Entity is ignored
+// for WriteDelete.
+type Write struct {
+	Op           WriteOp
+	Key          string
+	Entity       Entity
+	Precondition *Precondition
+}
+
 // Precondition is the optional per-mutation conflict-detection condition from
 // Datastore's real Mutation.conflict_detection_strategy oneof. At most one of
 // BaseVersion/UpdateTime should be set; nil (no Precondition at all) always
@@ -136,6 +175,23 @@ type Store interface {
 	// treats a missing entity as version 0) — anything else returns
 	// ErrConflict.
 	DeleteConflictChecked(ctx context.Context, project, key string, precondition *Precondition) error
+
+	// Commit applies a batch of writes atomically (all-or-nothing) after
+	// (1) re-validating the transaction read-set and (2) validating each
+	// write's Precondition and existence requirement. No check-then-apply gap
+	// exists between any step: in memory the whole sequence runs under one
+	// lock, and in Postgres inside one Serializable transaction with each
+	// touched row locked (SELECT ... FOR UPDATE).
+	//
+	// Returns ErrAborted when a read-set entry no longer matches, ErrConflict
+	// when a write precondition fails, ErrEntityExists for an Insert whose key
+	// already exists, or ErrEntityNotFound for an Update whose key is absent.
+	// In every error case NO write is applied.
+	//
+	// On success the returned slice is aligned with writes and carries the
+	// server-stamped Version for each applied entity (a delete yields
+	// Entity{Key: <key>}).
+	Commit(ctx context.Context, project string, reads []ReadRef, writes []Write) ([]Entity, error)
 	// ListKind returns every entity of the given kind in the project, sorted by
 	// key. An empty kind returns every entity in the project.
 	ListKind(ctx context.Context, project, kind string) ([]Entity, error)
@@ -170,6 +226,47 @@ func preconditionMatches(current Entity, exists bool, p *Precondition) bool {
 		return current.UpdateTime.Equal(*p.UpdateTime)
 	}
 	return true
+}
+
+// resolveWrite validates one Write against the entity currently stored at its
+// key (current, exists) and returns the entity to persist with its
+// server-stamped Version/UpdateTime, or an error. For WriteDelete the returned
+// entity is Entity{Key: w.Key} (the caller performs the delete). Shared by the
+// memory and Postgres Commit implementations so both enforce identical
+// semantics: a precondition mismatch (ErrConflict) takes priority over an
+// existence mismatch (ErrEntityExists / ErrEntityNotFound), exactly as
+// ApplyMutation does.
+func resolveWrite(current Entity, exists bool, w Write) (Entity, error) {
+	if !preconditionMatches(current, exists, w.Precondition) {
+		return Entity{}, ErrConflict
+	}
+	switch w.Op {
+	case WriteInsert:
+		if exists {
+			return Entity{}, ErrEntityExists
+		}
+		e := w.Entity
+		e.Version = 1
+		e.UpdateTime = clock.Now()
+		return e, nil
+	case WriteUpdate:
+		if !exists {
+			return Entity{}, ErrEntityNotFound
+		}
+		e := w.Entity
+		e.Version = current.Version + 1
+		e.UpdateTime = clock.Now()
+		return e, nil
+	case WriteUpsert:
+		e := w.Entity
+		e.Version = current.Version + 1
+		e.UpdateTime = clock.Now()
+		return e, nil
+	case WriteDelete:
+		return Entity{Key: w.Key}, nil
+	default:
+		return Entity{}, ErrInvalidKey
+	}
 }
 
 // KeyOfID returns the canonical key string for a numeric-ID key:


### PR DESCRIPTION
## Summary

Implements **Cloud Datastore (Firestore in Datastore mode) transactions** using the real `google.datastore.v1.Datastore` transaction protocol — the same optimistic **read-set OCC** model already used by the Firestore sibling. Previously `BeginTransaction` minted an id, `Rollback` was a no-op, and a `TRANSACTIONAL` `Commit` was rejected `Unimplemented`.

**AWS-parity rationale:** DynamoDB — Datastore's analogue — implements transactions (`TransactWriteItems` in a single Serializable tx with condition checks + `TransactionConflict`; `TransactGetItems`). This closes that gap without inventing any non-GCP surface.

## Protocol (GCP-native)
- **Registry**: `txnMu` + `readSets map[string]*readSet` keyed by the opaque token; lazy ~270s TTL expiry (internal, documented).
- **`BeginTransaction`** → registers an empty read-set, returns the token.
- **`Lookup` / `RunQuery`** → read the real `ReadOptions.transaction` selector; record each read entity's `(key, version)` (missing → version 0) in the read-set. Unknown token → `INVALID_ARGUMENT`.
- **`Commit`**:
  - `NON_TRANSACTIONAL` (or no txn) → existing per-mutation path, unchanged.
  - `TRANSACTIONAL` requires a token → else `INVALID_ARGUMENT`; unknown/expired token → `INVALID_ARGUMENT`.
  - Transactional: **atomically** re-validate every read-set key against current state — any change → **`ABORTED`** with nothing applied — then apply **all** mutations atomically, still enforcing each mutation's `Precondition` (`FAILED_PRECONDITION` on mismatch). Returns `commit_time` + `mutation_results`; discards the txn.
- **`Rollback`** → discards the read-set; idempotent.

## Store
New atomic `Store.Commit(ctx, project, reads, writes)` — one lock (memory) / one `pgx.Serializable` tx with `SELECT … FOR UPDATE` (postgres) — validates the read-set + every write, then applies all writes. Shared `resolveWrite` keeps memory/postgres semantics identical; new sentinel `ErrAborted`. Also fixed postgres `scanEntity` to rebuild the canonical length-prefixed key (`KeyOfID`/`KeyOfName`) instead of the stale `kind/name_or_id` join (required for read-set round-tripping).

## Documented approximations (internal only)
- **`RunQuery` read validation** tracks the returned entities' versions (real Datastore validates the query's read *range*): catches modification to any returned entity; does not catch a would-be match appearing/disappearing outside the result set.
- ~270s transaction TTL; auto-allocated IDs are not rolled back on abort (both real-Datastore-faithful).

## Not in scope
`RunAggregationQuery` (still `Unimplemented`); no new RPCs/fields; single entity-group only.

## Tests
Service: lookup→commit success; read conflict → `ABORTED` + unchanged + token consumed; rollback→commit `INVALID_ARGUMENT`; `base_version` mismatch → `FAILED_PRECONDITION`; `TRANSACTIONAL` w/o token → `INVALID_ARGUMENT`; non-transactional unchanged; two concurrent txns on one entity → one `ABORTED` (no lost update). Store: all-writes atomic; read-conflict aborts; goroutine race → exactly one success/one `ErrAborted`.

## Verification
`go build ./...`, `go vet` (+`-tags gcp_persistence`), `go test -race` on datastore service/store, full `./internal/gcp/...` clean, `gofmt -l` empty.