### PR TITLE
feat(gcp/datastore): ReserveIds + RunAggregationQuery

### DIFF
--- a/internal/gcp/grpc/datastore/reserve_agg_test.go
+++ b/internal/gcp/grpc/datastore/reserve_agg_test.go
@@ -1,0 +1,443 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+
+	datastorepb "cloud.google.com/go/datastore/apiv1/datastorepb"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ─── ReserveIds ───────────────────────────────────────────────────────────────
+
+func TestReserveIdsAdvancesAllocator(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Reserve numeric IDs 1..3 that AllocateIds would otherwise issue first.
+	if _, err := client.ReserveIds(ctx, &datastorepb.ReserveIdsRequest{
+		ProjectId: "test",
+		Keys:      []*datastorepb.Key{idKey("Task", 1), idKey("Task", 2), idKey("Task", 3)},
+	}); err != nil {
+		t.Fatalf("reserve ids: %v", err)
+	}
+
+	resp, err := client.AllocateIds(ctx, &datastorepb.AllocateIdsRequest{
+		ProjectId: "test",
+		Keys:      []*datastorepb.Key{incompleteKey("Task"), incompleteKey("Task")},
+	})
+	if err != nil {
+		t.Fatalf("allocate ids: %v", err)
+	}
+	if len(resp.GetKeys()) != 2 {
+		t.Fatalf("allocated %d keys, want 2", len(resp.GetKeys()))
+	}
+	for i, k := range resp.GetKeys() {
+		id := k.GetPath()[0].GetId()
+		if id <= 3 {
+			t.Fatalf("allocated id[%d] = %d, want > 3 (reserved IDs must not be reissued)", i, id)
+		}
+	}
+}
+
+// TestReserveIdsThenAllocateSkipsReserved checks the exact-next-ID case: after
+// reserving the ID that would have been allocated next, the allocator moves
+// past it.
+func TestReserveIdsThenAllocateSkipsReserved(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if _, err := client.ReserveIds(ctx, &datastorepb.ReserveIdsRequest{
+		ProjectId: "test",
+		Keys:      []*datastorepb.Key{idKey("Task", 1)},
+	}); err != nil {
+		t.Fatalf("reserve ids: %v", err)
+	}
+
+	resp, err := client.AllocateIds(ctx, &datastorepb.AllocateIdsRequest{
+		ProjectId: "test",
+		Keys:      []*datastorepb.Key{incompleteKey("Task")},
+	})
+	if err != nil {
+		t.Fatalf("allocate ids: %v", err)
+	}
+	if got := resp.GetKeys()[0].GetPath()[0].GetId(); got == 1 {
+		t.Fatalf("allocated reserved id 1")
+	}
+}
+
+func TestReserveIdsNameKeyIsNoOp(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if _, err := client.ReserveIds(ctx, &datastorepb.ReserveIdsRequest{
+		ProjectId: "test",
+		Keys:      []*datastorepb.Key{nameKey("Task", "foo")},
+	}); err != nil {
+		t.Fatalf("reserve name key: %v", err)
+	}
+
+	// A name cannot collide with numeric allocation, so the allocator is
+	// untouched and the first allocated ID is still 1.
+	resp, err := client.AllocateIds(ctx, &datastorepb.AllocateIdsRequest{
+		ProjectId: "test",
+		Keys:      []*datastorepb.Key{incompleteKey("Task")},
+	})
+	if err != nil {
+		t.Fatalf("allocate ids: %v", err)
+	}
+	if got := resp.GetKeys()[0].GetPath()[0].GetId(); got != 1 {
+		t.Fatalf("allocated id = %d, want 1 (name reservation must not advance the allocator)", got)
+	}
+}
+
+func TestReserveIdsIncompleteKeyInvalid(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := client.ReserveIds(ctx, &datastorepb.ReserveIdsRequest{
+		ProjectId: "test",
+		Keys:      []*datastorepb.Key{incompleteKey("Task")},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("reserve incomplete key err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestReserveIdsDatabaseScopedInvalid(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	_, err := client.ReserveIds(ctx, &datastorepb.ReserveIdsRequest{
+		ProjectId:  "test",
+		DatabaseId: "other-db",
+		Keys:       []*datastorepb.Key{idKey("Task", 1)},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("reserve with database id err = %v, want InvalidArgument", err)
+	}
+}
+
+// ─── RunAggregationQuery ──────────────────────────────────────────────────────
+
+func eqFilter(prop string, v *datastorepb.Value) *datastorepb.Filter {
+	return &datastorepb.Filter{FilterType: &datastorepb.Filter_PropertyFilter{PropertyFilter: &datastorepb.PropertyFilter{
+		Property: &datastorepb.PropertyReference{Name: prop},
+		Op:       datastorepb.PropertyFilter_EQUAL,
+		Value:    v,
+	}}}
+}
+
+func countAgg(alias string) *datastorepb.AggregationQuery_Aggregation {
+	return &datastorepb.AggregationQuery_Aggregation{
+		Alias:    alias,
+		Operator: &datastorepb.AggregationQuery_Aggregation_Count_{Count: &datastorepb.AggregationQuery_Aggregation_Count{}},
+	}
+}
+
+func sumAgg(prop, alias string) *datastorepb.AggregationQuery_Aggregation {
+	return &datastorepb.AggregationQuery_Aggregation{
+		Alias: alias,
+		Operator: &datastorepb.AggregationQuery_Aggregation_Sum_{Sum: &datastorepb.AggregationQuery_Aggregation_Sum{
+			Property: &datastorepb.PropertyReference{Name: prop},
+		}},
+	}
+}
+
+func avgAgg(prop, alias string) *datastorepb.AggregationQuery_Aggregation {
+	return &datastorepb.AggregationQuery_Aggregation{
+		Alias: alias,
+		Operator: &datastorepb.AggregationQuery_Aggregation_Avg_{Avg: &datastorepb.AggregationQuery_Aggregation_Avg{
+			Property: &datastorepb.PropertyReference{Name: prop},
+		}},
+	}
+}
+
+func aggRequest(kind string, filter *datastorepb.Filter, aggs ...*datastorepb.AggregationQuery_Aggregation) *datastorepb.RunAggregationQueryRequest {
+	return &datastorepb.RunAggregationQueryRequest{
+		ProjectId: "test",
+		QueryType: &datastorepb.RunAggregationQueryRequest_AggregationQuery{
+			AggregationQuery: &datastorepb.AggregationQuery{
+				QueryType: &datastorepb.AggregationQuery_NestedQuery{
+					NestedQuery: &datastorepb.Query{
+						Kind:   []*datastorepb.KindExpression{{Name: kind}},
+						Filter: filter,
+					},
+				},
+				Aggregations: aggs,
+			},
+		},
+	}
+}
+
+// aggProps runs the request and returns the single result's alias → value map.
+func aggProps(t *testing.T, client datastorepb.DatastoreClient, req *datastorepb.RunAggregationQueryRequest) map[string]*datastorepb.Value {
+	t.Helper()
+	resp, err := client.RunAggregationQuery(context.Background(), req)
+	if err != nil {
+		t.Fatalf("run aggregation query: %v", err)
+	}
+	batch := resp.GetBatch()
+	if batch == nil {
+		t.Fatal("aggregation response has no batch")
+	}
+	if batch.GetMoreResults() != datastorepb.QueryResultBatch_NO_MORE_RESULTS {
+		t.Fatalf("more_results = %v, want NO_MORE_RESULTS", batch.GetMoreResults())
+	}
+	if batch.GetReadTime() == nil {
+		t.Fatal("aggregation batch must set read_time")
+	}
+	if len(batch.GetAggregationResults()) != 1 {
+		t.Fatalf("aggregation_results = %d, want 1", len(batch.GetAggregationResults()))
+	}
+	return batch.GetAggregationResults()[0].GetAggregateProperties()
+}
+
+// seedMetrics writes the fixture shared by the count/sum/avg tests.
+func seedMetrics(t *testing.T, client datastorepb.DatastoreClient) {
+	t.Helper()
+	ctx := context.Background()
+	props := []map[string]*datastorepb.Value{
+		{"group": strVal("alpha"), "score": intVal(10)},
+		{"group": strVal("alpha"), "score": intVal(20)},
+		{"group": strVal("beta"), "score": intVal(30)},
+		{"group": strVal("alpha"), "ratio": doubleVal(1.5)},
+		{"group": strVal("alpha"), "score": strVal("not-a-number")},
+	}
+	for i, p := range props {
+		key := nameKey("Metric", "m"+string(rune('a'+i)))
+		if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+			ProjectId: "test",
+			Mutations: []*datastorepb.Mutation{{Operation: &datastorepb.Mutation_Upsert{Upsert: entity(key, p)}}},
+		}); err != nil {
+			t.Fatalf("seed metric %d: %v", i, err)
+		}
+	}
+}
+
+func TestRunAggregationQueryCount(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	seedMetrics(t, client)
+
+	props := aggProps(t, client, aggRequest("Metric", nil, countAgg("total")))
+	total, ok := props["total"]
+	if !ok {
+		t.Fatalf("alias total missing from %v", props)
+	}
+	if got := total.GetIntegerValue(); got != 5 {
+		t.Fatalf("count = %d, want 5", got)
+	}
+}
+
+func TestRunAggregationQueryCountWithFilter(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	seedMetrics(t, client)
+
+	props := aggProps(t, client, aggRequest("Metric", eqFilter("group", strVal("alpha")), countAgg("total")))
+	if got := props["total"].GetIntegerValue(); got != 4 {
+		t.Fatalf("filtered count = %d, want 4", got)
+	}
+}
+
+func TestRunAggregationQuerySumInteger(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	seedMetrics(t, client)
+
+	// d has no score and e's score is a string: both are skipped.
+	props := aggProps(t, client, aggRequest("Metric", nil, sumAgg("score", "sum_score")))
+	if _, isDouble := props["sum_score"].GetValueType().(*datastorepb.Value_DoubleValue); isDouble {
+		t.Fatalf("integer-property sum returned a double: %v", props["sum_score"])
+	}
+	if got := props["sum_score"].GetIntegerValue(); got != 60 {
+		t.Fatalf("sum(score) = %d, want 60", got)
+	}
+}
+
+func TestRunAggregationQuerySumDouble(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	seedMetrics(t, client)
+
+	props := aggProps(t, client, aggRequest("Metric", nil, sumAgg("ratio", "sum_ratio")))
+	if got := props["sum_ratio"].GetDoubleValue(); got != 1.5 {
+		t.Fatalf("sum(ratio) = %v, want 1.5", got)
+	}
+}
+
+// TestRunAggregationQuerySumMixedIsDouble covers the proto rule that a sum is a
+// double as soon as any contributing value is a double.
+func TestRunAggregationQuerySumMixedIsDouble(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	for _, e := range []struct {
+		name string
+		val  *datastorepb.Value
+	}{
+		{"a", intVal(1)},
+		{"b", doubleVal(2.5)},
+	} {
+		if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+			ProjectId: "test",
+			Mutations: []*datastorepb.Mutation{{Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Mix", e.name), map[string]*datastorepb.Value{"v": e.val})}}},
+		}); err != nil {
+			t.Fatalf("seed %s: %v", e.name, err)
+		}
+	}
+
+	props := aggProps(t, client, aggRequest("Mix", nil, sumAgg("v", "s")))
+	if _, isInt := props["s"].GetValueType().(*datastorepb.Value_IntegerValue); isInt {
+		t.Fatalf("mixed integer/double sum returned an integer: %v", props["s"])
+	}
+	if got := props["s"].GetDoubleValue(); got != 3.5 {
+		t.Fatalf("mixed sum = %v, want 3.5", got)
+	}
+}
+
+func TestRunAggregationQueryAvg(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	seedMetrics(t, client)
+
+	// 10 + 20 + 30 over the three numeric scores; d/e skipped.
+	props := aggProps(t, client, aggRequest("Metric", nil, avgAgg("score", "avg_score")))
+	if _, isDouble := props["avg_score"].GetValueType().(*datastorepb.Value_DoubleValue); !isDouble {
+		t.Fatalf("avg must return a double: %v", props["avg_score"])
+	}
+	if got := props["avg_score"].GetDoubleValue(); got != 20 {
+		t.Fatalf("avg(score) = %v, want 20", got)
+	}
+}
+
+// TestRunAggregationQueryAvgEmptyIsNull covers the proto rule that avg of an
+// empty contributing set is NULL.
+func TestRunAggregationQueryAvgEmptyIsNull(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if _, err := client.Commit(ctx, &datastorepb.CommitRequest{
+		ProjectId: "test",
+		Mutations: []*datastorepb.Mutation{{Operation: &datastorepb.Mutation_Upsert{Upsert: entity(nameKey("Empty", "a"), map[string]*datastorepb.Value{})}}},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// No entity carries "n": sum is 0, avg is NULL.
+	props := aggProps(t, client, aggRequest("Empty", nil, sumAgg("n", "s"), avgAgg("n", "a")))
+	if got := props["s"].GetIntegerValue(); got != 0 {
+		t.Fatalf("empty sum = %d, want 0", got)
+	}
+	if props["a"].GetNullValue() != 0 { // structpb.NullValue_NULL_VALUE == 0
+		t.Fatalf("empty avg = %v, want NULL", props["a"])
+	}
+}
+
+// TestRunAggregationQueryAliasesAndDefaults covers multiple aliases in one
+// result and the server-generated "property_<n>" alias for an unnamed
+// aggregation.
+func TestRunAggregationQueryAliasesAndDefaults(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	seedMetrics(t, client)
+
+	props := aggProps(t, client, aggRequest("Metric", nil, countAgg("total"), sumAgg("score", "")))
+	if _, ok := props["total"]; !ok {
+		t.Fatalf("explicit alias total missing from %v", props)
+	}
+	if _, ok := props["property_1"]; !ok {
+		t.Fatalf("default alias property_1 missing from %v", props)
+	}
+	if got := props["property_1"].GetIntegerValue(); got != 60 {
+		t.Fatalf("property_1 = %d, want 60", got)
+	}
+}
+
+// TestRunAggregationQueryRecordsReads proves RunAggregationQuery is
+// transaction-aware: a conflicting write after the aggregation aborts a
+// transactional commit that carries no mutations (read-set validation only).
+func TestRunAggregationQueryRecordsReads(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	upsertTask(t, client, "a", 1)
+	upsertTask(t, client, "b", 1)
+
+	txn := beginTxn(t, client)
+	req := aggRequest("Task", nil, countAgg("total"))
+	req.ReadOptions = readTxn(txn)
+	if _, err := client.RunAggregationQuery(ctx, req); err != nil {
+		t.Fatalf("transactional aggregation: %v", err)
+	}
+
+	// Modify one of the entities the nested query returned.
+	upsertTask(t, client, "b", 2)
+
+	if _, err := txnCommit(t, client, txn); status.Code(err) != codes.Aborted {
+		t.Fatalf("commit err = %v, want Aborted", err)
+	}
+}
+
+func TestRunAggregationQueryUnknownTransactionInvalid(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	req := aggRequest("Task", nil, countAgg("total"))
+	req.ReadOptions = readTxn([]byte("not-a-real-transaction"))
+	_, err := client.RunAggregationQuery(context.Background(), req)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestRunAggregationQueryGQLInvalid(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	_, err := client.RunAggregationQuery(context.Background(), &datastorepb.RunAggregationQueryRequest{
+		ProjectId: "test",
+		QueryType: &datastorepb.RunAggregationQueryRequest_GqlQuery{GqlQuery: &datastorepb.GqlQuery{}},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("GQL aggregation err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestRunAggregationQueryNoAggregationsInvalid(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	_, err := client.RunAggregationQuery(context.Background(), aggRequest("Task", nil))
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("no-aggregation err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestRunAggregationQueryNoNestedQueryInvalid(t *testing.T) {
+	client, cleanup := testServer(t)
+	defer cleanup()
+
+	_, err := client.RunAggregationQuery(context.Background(), &datastorepb.RunAggregationQueryRequest{
+		ProjectId: "test",
+		QueryType: &datastorepb.RunAggregationQueryRequest_AggregationQuery{
+			AggregationQuery: &datastorepb.AggregationQuery{
+				Aggregations: []*datastorepb.AggregationQuery_Aggregation{countAgg("total")},
+			},
+		},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("missing nested query err = %v, want InvalidArgument", err)
+	}
+}

--- a/internal/gcp/grpc/datastore/service.go
+++ b/internal/gcp/grpc/datastore/service.go
@@ -518,6 +518,219 @@ func (s *Service) RunQuery(ctx context.Context, req *datastorepb.RunQueryRequest
 	return &datastorepb.RunQueryResponse{Batch: batch}, nil
 }
 
+// RunAggregationQuery implements the Datastore aggregation-query RPC over the
+// structured AggregationQuery form. It runs the wrapped nested query with the
+// same engine RunQuery uses (ListKind + matchesFilter) and reduces the matching
+// entities to one result per aggregation (count/sum/avg), keyed by alias.
+//
+// The GQL aggregation form is not supported by the emulator's query engine and
+// fails loud with InvalidArgument rather than returning a silent empty result,
+// mirroring RunQuery. Zero aggregations is rejected as well: the proto requires
+// a minimum of one, so a request without any is malformed.
+//
+// Transaction-aware: a ReadOptions.transaction selector must name an *active*
+// transaction, and every entity the nested query returns is recorded in the
+// transaction's read-set — exactly as RunQuery does — so a transactional
+// commit re-validates them (real Datastore's RunAggregationQuery participates
+// in transactions). Non-transactional calls are unaffected.
+func (s *Service) RunAggregationQuery(ctx context.Context, req *datastorepb.RunAggregationQueryRequest) (*datastorepb.RunAggregationQueryResponse, error) {
+	if err := rejectDatabaseID(req.GetDatabaseId()); err != nil {
+		return nil, mapError(err)
+	}
+	// See RunQuery: the transaction selector lives in ReadOptions.
+	txn := req.GetReadOptions().GetTransaction()
+	if err := s.requireActive(txn); err != nil {
+		return nil, mapError(err)
+	}
+	project := s.project(ctx, req.GetProjectId())
+
+	var aq *datastorepb.AggregationQuery
+	switch qt := req.GetQueryType().(type) {
+	case *datastorepb.RunAggregationQueryRequest_AggregationQuery:
+		aq = qt.AggregationQuery
+	case *datastorepb.RunAggregationQueryRequest_GqlQuery:
+		return nil, mapError(model.NewProviderError("InvalidArgument", "GQL aggregation queries are not supported", 400))
+	default:
+		return nil, mapError(model.NewProviderError("InvalidArgument", "run aggregation query request has no query", 400))
+	}
+	if aq == nil {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "aggregation query is missing", 400))
+	}
+	nested := aq.GetNestedQuery()
+	if nested == nil {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "aggregation query is missing its nested query", 400))
+	}
+	aggs := aq.GetAggregations()
+	if len(aggs) == 0 {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "aggregation query must contain at least one aggregation", 400))
+	}
+	if len(aggs) > maxAggregations {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "aggregation query supports at most five aggregations", 400))
+	}
+
+	kind := ""
+	if len(nested.GetKind()) > 0 {
+		kind = nested.GetKind()[0].GetName()
+	}
+	entities, err := s.store.ListKind(ctx, project, kind)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	// Reduce the nested query once, recording every matching entity in the
+	// transaction read-set (the same approximation RunQuery makes: the version
+	// of each returned entity is re-validated at commit).
+	matching := make([]datastorestore.Entity, 0, len(entities))
+	for _, e := range entities {
+		match, err := matchesFilter(e, nested.GetFilter())
+		if err != nil {
+			return nil, mapError(err)
+		}
+		if !match {
+			continue
+		}
+		s.recordRead(txn, e.Key, true, e.Version)
+		matching = append(matching, e)
+	}
+
+	// A non-grouped aggregation query returns a single AggregationResult whose
+	// aggregate_properties map holds one entry per aggregation.
+	result := &datastorepb.AggregationResult{AggregateProperties: make(map[string]*datastorepb.Value, len(aggs))}
+	unnamed := 0
+	for _, agg := range aggs {
+		alias := agg.GetAlias()
+		if alias == "" {
+			// Real Datastore auto-names an unaliased aggregation
+			// "property_<incremental_id>", sharing one counter across the
+			// whole query (proto AggregationQuery.Aggregation.alias docs).
+			unnamed++
+			alias = "property_" + strconv.Itoa(unnamed)
+		}
+		if _, dup := result.AggregateProperties[alias]; dup {
+			return nil, mapError(model.NewProviderError("InvalidArgument", "duplicate aggregation alias: "+alias, 400))
+		}
+		val, err := aggregate(agg, matching, project)
+		if err != nil {
+			return nil, mapError(err)
+		}
+		result.AggregateProperties[alias] = val
+	}
+
+	return &datastorepb.RunAggregationQueryResponse{
+		Batch: &datastorepb.AggregationResultBatch{
+			AggregationResults: []*datastorepb.AggregationResult{result},
+			MoreResults:        datastorepb.QueryResultBatch_NO_MORE_RESULTS,
+			ReadTime:           timestamppb.New(clock.Now()),
+		},
+	}, nil
+}
+
+// maxAggregations is the proto cap on aggregations per AggregationQuery.
+const maxAggregations = 5
+
+// aggregate computes one aggregation over the entities the nested query
+// returned and returns its wire Value.
+func aggregate(agg *datastorepb.AggregationQuery_Aggregation, entities []datastorestore.Entity, project string) (*datastorepb.Value, error) {
+	switch op := agg.GetOperator().(type) {
+	case *datastorepb.AggregationQuery_Aggregation_Count_:
+		n := int64(len(entities))
+		if upTo := op.Count.GetUpTo(); upTo != nil {
+			if upTo.GetValue() < 0 {
+				return nil, model.NewProviderError("InvalidArgument", "count up_to must be non-negative", 400)
+			}
+			if n > upTo.GetValue() {
+				n = upTo.GetValue()
+			}
+		}
+		return valueToProto(datastorestore.Value{IntegerValue: &n}, project), nil
+	case *datastorepb.AggregationQuery_Aggregation_Sum_:
+		return aggregateSum(op.Sum.GetProperty().GetName(), entities, project)
+	case *datastorepb.AggregationQuery_Aggregation_Avg_:
+		return aggregateAvg(op.Avg.GetProperty().GetName(), entities, project)
+	default:
+		return nil, model.NewProviderError("InvalidArgument", "aggregation has no operator", 400)
+	}
+}
+
+// aggregateSum sums the named property over entities, following the proto's
+// documented Sum behavior:
+//   - only integer and double values contribute; a missing property or a
+//     non-numeric value (string, bool, null, key, array, ...) is skipped;
+//   - an empty contributing set yields integer 0;
+//   - the result is a 64-bit integer when every contributing value is an
+//     integer and the sum does not overflow int64; otherwise it is a double.
+func aggregateSum(name string, entities []datastorestore.Entity, project string) (*datastorepb.Value, error) {
+	if name == "" {
+		return nil, model.NewProviderError("InvalidArgument", "sum aggregation requires a property", 400)
+	}
+	var (
+		isum     int64
+		fsum     float64
+		allInt   = true
+		overflow bool
+	)
+	for _, e := range entities {
+		v, ok := e.Properties[name]
+		if !ok {
+			continue
+		}
+		switch {
+		case v.IntegerValue != nil:
+			iv := *v.IntegerValue
+			if (iv > 0 && isum+iv < isum) || (iv < 0 && isum+iv > isum) {
+				overflow = true
+			}
+			isum += iv
+			fsum += float64(iv)
+		case v.DoubleValue != nil:
+			allInt = false
+			fsum += *v.DoubleValue
+		default:
+			continue
+		}
+	}
+	if allInt && !overflow {
+		return valueToProto(datastorestore.Value{IntegerValue: &isum}, project), nil
+	}
+	return valueToProto(datastorestore.Value{DoubleValue: &fsum}, project), nil
+}
+
+// aggregateAvg averages the named property over entities, following the
+// proto's documented Avg behavior: only integer and double values contribute;
+// a missing property or a non-numeric value is skipped; an empty contributing
+// set yields NULL; and the result is always a double.
+func aggregateAvg(name string, entities []datastorestore.Entity, project string) (*datastorepb.Value, error) {
+	if name == "" {
+		return nil, model.NewProviderError("InvalidArgument", "avg aggregation requires a property", 400)
+	}
+	var (
+		sum float64
+		n   int64
+	)
+	for _, e := range entities {
+		v, ok := e.Properties[name]
+		if !ok {
+			continue
+		}
+		switch {
+		case v.IntegerValue != nil:
+			sum += float64(*v.IntegerValue)
+			n++
+		case v.DoubleValue != nil:
+			sum += *v.DoubleValue
+			n++
+		default:
+			continue
+		}
+	}
+	if n == 0 {
+		s := "NULL_VALUE"
+		return valueToProto(datastorestore.Value{NullValue: &s}, project), nil
+	}
+	avg := sum / float64(n)
+	return valueToProto(datastorestore.Value{DoubleValue: &avg}, project), nil
+}
+
 func (s *Service) BeginTransaction(ctx context.Context, req *datastorepb.BeginTransactionRequest) (*datastorepb.BeginTransactionResponse, error) {
 	txn := []byte("txn-" + strconv.FormatInt(atomic.AddInt64(&txnSeq, 1), 10))
 	s.txnMu.Lock()
@@ -560,6 +773,47 @@ func (s *Service) AllocateIds(ctx context.Context, req *datastorepb.AllocateIdsR
 		resp.Keys = append(resp.Keys, completed)
 	}
 	return resp, nil
+}
+
+// ReserveIds implements the Datastore ReserveIds RPC: the supplied complete
+// keys' numeric IDs will never be handed out by a later AllocateIds. Each key
+// is canonicalized; a numeric-ID key advances the project's ID allocator past
+// that ID (store.AdvanceIDs), while a name key is a no-op because names never
+// collide with the numeric-ID space (the same split advanceAllocator makes).
+// An incomplete key is rejected with InvalidArgument, as real Datastore
+// requires complete key paths.
+//
+// The emulator is single-project and single-database; a non-empty DatabaseId
+// is rejected (see rejectDatabaseID). The response is empty by design.
+func (s *Service) ReserveIds(ctx context.Context, req *datastorepb.ReserveIdsRequest) (*datastorepb.ReserveIdsResponse, error) {
+	if err := rejectDatabaseID(req.GetDatabaseId()); err != nil {
+		return nil, mapError(err)
+	}
+	project := s.project(ctx, req.GetProjectId())
+	for _, k := range req.GetKeys() {
+		key, _, complete, err := canonicalKey(k)
+		if err != nil {
+			return nil, mapError(err)
+		}
+		if !complete {
+			return nil, mapError(model.NewProviderError("InvalidArgument", "reserve ids requires complete keys", 400))
+		}
+		if err := s.advanceAllocator(ctx, project, key); err != nil {
+			return nil, mapError(err)
+		}
+	}
+	return &datastorepb.ReserveIdsResponse{}, nil
+}
+
+// rejectDatabaseID rejects a non-empty request DatabaseId. The emulator
+// serves a single default database per project, so a named database cannot be
+// honored; failing loud mirrors canonicalKey's rejection of database-scoped
+// keys rather than silently reading/writing the default database.
+func rejectDatabaseID(databaseID string) error {
+	if databaseID != "" {
+		return model.NewProviderError("InvalidArgument", "database-scoped requests are not supported", 400)
+	}
+	return nil
 }
 
 // resolveEntity transcodes a mutation entity and, when its key path is


### PR DESCRIPTION
## Summary

Implements the last two `Unimplemented` Datastore gRPC methods — `ReserveIds` and `RunAggregationQuery` — with real `google.datastore.v1.Datastore` semantics.

## `ReserveIds`
- Complete numeric-ID key → `store.AdvanceIDs` so a later `AllocateIds` never reissues it (name keys are a no-op).
- Incomplete key → `INVALID_ARGUMENT`; namespaced/ancestor/database-scoped keys inherit `canonicalKey`'s rejection; non-empty `DatabaseId` → `INVALID_ARGUMENT` (single-project/single-DB emulator, fails loud).

## `RunAggregationQuery`
- The `AggregationQuery` form: `nested_query` (kind + filter, via the existing `ListKind` + `matchesFilter` path) + `aggregations[]` with `count`/`sum`/`avg` and aliases.
- `count` → int64 (honors `up_to`); `sum` → int64 when all contributors are integers (no overflow) else double; `avg` → double, `NULL` when no contributors; non-numeric/missing properties don't contribute (documented).
- Returns `AggregationResultBatch` (`NO_MORE_RESULTS`, `ReadTime`); empty alias auto-named `property_<n>`; duplicate alias → `INVALID_ARGUMENT`.
- **Transaction-aware**: honors `ReadOptions.transaction` exactly like `RunQuery` (records the read-set; a conflicting transactional commit aborts).
- Fail-loud, not silent: `GqlQuery` aggregation form, zero/`>5` aggregations, and missing nested query → `INVALID_ARGUMENT`.

## Not in scope (documented)
GQL aggregation; grouped aggregations; nested-query features beyond kind+filter (order/limit/projection/distinct_on — ignored as `RunQuery` already does); the same transaction range-read approximation as `RunQuery`.

## Verification

`go build ./...`, `go vet`, `go test -race` on the datastore service, full `./internal/gcp/...` clean, `gofmt -l` empty. 18 new tests: reserve-advances-allocator (bulk + exact-next), name no-op, incomplete/DB-scoped `INVALID_ARGUMENT`; count/count+filter/int-sum/double-sum/mixed→double/avg/empty-avg→NULL/aliases; transaction read-set abort; GQL/zero-aggregation/missing-query `INVALID_ARGUMENT`.