### PR TITLE
fix(gcp/firestore): bound the Listen change feed + per-target resume tokens

### DIFF
--- a/internal/gcp/grpc/firestore/listen.go
+++ b/internal/gcp/grpc/firestore/listen.go
@@ -41,6 +41,14 @@ type listenTarget struct {
 	query     *firestoreprovider.StructuredQuery
 	parent    string
 	documents []string
+
+	// seq is this target's own delivered sequence position: the highest
+	// change-feed sequence it has been brought up to (by snapshot, incremental
+	// replay, or a live delta). Real Firestore resume tokens are per-target;
+	// encoding seq rather than the global head in this target's TargetChange
+	// frames is the emulator's approximation of that cursor (see the package
+	// doc's Listen fidelity note).
+	seq uint64
 }
 
 func (t listenTarget) isQuery() bool { return t.query != nil }
@@ -51,7 +59,7 @@ func (t listenTarget) isQuery() bool { return t.query != nil }
 type listenSession struct {
 	srv     *Service
 	stream  firestorepb.Firestore_ListenServer
-	targets map[int32]listenTarget
+	targets map[int32]*listenTarget
 	nextID  int32
 
 	// lastReadTime is the most recent read_time handed out on this stream.
@@ -84,7 +92,7 @@ func (s *Service) Listen(stream firestorepb.Firestore_ListenServer) error {
 	ls := &listenSession{
 		srv:     s,
 		stream:  stream,
-		targets: make(map[int32]listenTarget),
+		targets: make(map[int32]*listenTarget),
 	}
 
 	sub := s.svc.SubscribeChange()
@@ -153,7 +161,8 @@ func (ls *listenSession) handleAddTarget(t *firestorepb.Target) error {
 	if err != nil {
 		return err
 	}
-	ls.targets[id] = target
+	lt := &target
+	ls.targets[id] = lt
 
 	if err := ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_TargetChange{
 		TargetChange: &firestorepb.TargetChange{
@@ -164,32 +173,55 @@ func (ls *listenSession) handleAddTarget(t *firestorepb.Target) error {
 		return err
 	}
 
-	// A valid resume token replays only the deltas after it; an absent or
-	// invalid token falls back to the full initial snapshot.
+	// Capture the feed position this target is about to observe, before reading
+	// the snapshot/replay. Any write published after this point is still
+	// buffered on the stream subscription and delivered by handleChange, so
+	// advancing the cursor to it can never advertise a delta that was not (or
+	// will not be) delivered — unlike reading the head after the snapshot, which
+	// could run past a buffered event. Reads that land between this position and
+	// the snapshot store-read are seen twice (snapshot + delta), never lost.
+	base := ls.srv.svc.CurrentSeq()
+
+	// A valid, unexpired resume token replays only this target's deltas after
+	// it; an absent, malformed, evicted, or pre-reset token falls back to the
+	// full initial snapshot. seq == 0 is treated as the start of time (not a
+	// resumable position) because the change log records only writes, not a
+	// document history, so replaying from zero cannot reconstruct documents
+	// that predate the log.
 	incremental := false
 	if rt, ok := t.GetResumeType().(*firestorepb.Target_ResumeToken); ok {
-		if seq, valid := DecodeResumeToken(rt.ResumeToken); valid {
+		if seq, valid := DecodeResumeToken(rt.ResumeToken); valid && seq > 0 && ls.srv.svc.ReplayableFrom(seq) {
 			incremental = true
 			for _, ev := range ls.srv.svc.ChangesSince(seq) {
-				if ls.targetMatches(target, ev) {
+				if ls.targetMatches(*lt, ev) {
 					if err := ls.sendChange(id, ev); err != nil {
 						return err
+					}
+					if ev.Seq > lt.seq {
+						lt.seq = ev.Seq
 					}
 				}
 			}
 		}
 	}
 	if !incremental {
-		if err := ls.sendSnapshot(id, target); err != nil {
+		if err := ls.sendSnapshot(id, *lt); err != nil {
 			return err
 		}
+	}
+
+	// The target is now caught up through `base` (and through any later delta it
+	// replayed). Deltas published after `base` arrive via handleChange and advance
+	// the cursor from there.
+	if base > lt.seq {
+		lt.seq = base
 	}
 
 	if err := ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_TargetChange{
 		TargetChange: &firestorepb.TargetChange{
 			TargetChangeType: firestorepb.TargetChange_CURRENT,
 			TargetIds:        []int32{id},
-			ResumeToken:      EncodeResumeToken(ls.srv.svc.CurrentSeq()),
+			ResumeToken:      EncodeResumeToken(lt.seq),
 			ReadTime:         timestamppb.New(ls.nextReadTime()),
 		},
 	}}); err != nil {
@@ -205,16 +237,40 @@ func (ls *listenSession) handleAddTarget(t *firestorepb.Target) error {
 }
 
 // sendNoChange emits a NO_CHANGE frame with empty target_ids (meaning "all
-// targets on this stream"), a monotonic read_time, and the current change-feed
-// resume token. The SDK concludes a snapshot epoch on this frame.
+// targets on this stream"), a monotonic read_time, and a resume token covering
+// all targets. The SDK concludes a snapshot epoch on this frame.
 func (ls *listenSession) sendNoChange() error {
 	return ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_TargetChange{
 		TargetChange: &firestorepb.TargetChange{
 			TargetChangeType: firestorepb.TargetChange_NO_CHANGE,
 			ReadTime:         timestamppb.New(ls.nextReadTime()),
-			ResumeToken:      EncodeResumeToken(ls.srv.svc.CurrentSeq()),
+			ResumeToken:      EncodeResumeToken(ls.allTargetsSeq()),
 		},
 	}})
+}
+
+// allTargetsSeq returns the resume position advertised on the empty target_ids
+// NO_CHANGE frame. The proto defines that token as covering "all targets", which
+// a single 8-byte token cannot represent exactly once targets sit at different
+// positions; real Firestore instead pairs each resume token with its own
+// target_ids. As the safe approximation this returns the minimum of the live
+// targets' cursors (or the global head when there are no targets): a position at
+// or below every target's delivered seq means resuming all targets can replay a
+// duplicate delta but never skip one. Note the Go SDK watches a single target per
+// stream, so there this is exactly that target's cursor.
+func (ls *listenSession) allTargetsSeq() uint64 {
+	if len(ls.targets) == 0 {
+		return ls.srv.svc.CurrentSeq()
+	}
+	var min uint64
+	first := true
+	for _, t := range ls.targets {
+		if first || t.seq < min {
+			min = t.seq
+			first = false
+		}
+	}
+	return min
 }
 
 func (ls *listenSession) handleRemoveTarget(id int32) error {
@@ -230,8 +286,11 @@ func (ls *listenSession) handleRemoveTarget(id int32) error {
 func (ls *listenSession) handleChange(ev firestoreprovider.ChangeEvent) {
 	sent := false
 	for id, t := range ls.targets {
-		if ls.targetMatches(t, ev) {
+		if ls.targetMatches(*t, ev) {
 			_ = ls.sendChange(id, ev)
+			if ev.Seq > t.seq {
+				t.seq = ev.Seq
+			}
 			sent = true
 		}
 	}

--- a/internal/gcp/grpc/firestore/listen_test.go
+++ b/internal/gcp/grpc/firestore/listen_test.go
@@ -70,6 +70,13 @@ func addTargetReq(t *firestorepb.Target) *firestorepb.ListenRequest {
 	}
 }
 
+func removeTargetReq(tid int32) *firestorepb.ListenRequest {
+	return &firestorepb.ListenRequest{
+		Database:     "projects/test/databases/(default)",
+		TargetChange: &firestorepb.ListenRequest_RemoveTarget{RemoveTarget: tid},
+	}
+}
+
 func recvN(t *testing.T, stream firestorepb.Firestore_ListenClient, n int, timeout time.Duration) []*firestorepb.ListenResponse {
 	t.Helper()
 	var responses []*firestorepb.ListenResponse
@@ -650,5 +657,190 @@ func TestPublishChangeNonBlocking(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("publishChange blocked on a full subscriber channel")
+	}
+}
+
+// TestListenMultiTargetPerTargetResumeTokens asserts that each target tracks its
+// own delivered sequence and is resumed from its own resume token. Because a
+// single empty-target_ids NO_CHANGE token cannot carry one cursor per target,
+// the stream-wide token is the minimum of the live cursors (documented
+// approximation); this test pins that behavior and shows each target replaying
+// only its own deltas when resumed from its own token.
+func TestListenMultiTargetPerTargetResumeTokens(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Seed one doc in "a" so target 1 snapshots at head 1.
+	svc.CreateDocument(ctx, "test", "(default)", "a", "a1", map[string]*firestorestore.Value{
+		"v": firestorestore.StringVal("1"),
+	})
+
+	lctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	// Target 1 on "a": ADD, a1, CURRENT, NO_CHANGE. Its own token is seq 1.
+	if err := stream.Send(addTargetReq(queryTarget(1, "a"))); err != nil {
+		t.Fatalf("send target 1: %v", err)
+	}
+	rs := recvN(t, stream, 4, 3*time.Second)
+	t1Token := rs[2].GetTargetChange().GetResumeToken()
+	if seq, ok := DecodeResumeToken(t1Token); !ok || seq != 1 {
+		t.Fatalf("target 1 CURRENT token seq = %d ok = %v, want 1", seq, ok)
+	}
+
+	// Seed a doc in "b" (head 2) and add target 2: its cursor is 2, distinct
+	// from target 1's 1.
+	svc.CreateDocument(ctx, "test", "(default)", "b", "b1", map[string]*firestorestore.Value{
+		"v": firestorestore.StringVal("1"),
+	})
+	if err := stream.Send(addTargetReq(queryTarget(2, "b"))); err != nil {
+		t.Fatalf("send target 2: %v", err)
+	}
+	rs = recvN(t, stream, 4, 3*time.Second)
+	t2Token := rs[2].GetTargetChange().GetResumeToken()
+	if seq, ok := DecodeResumeToken(t2Token); !ok || seq != 2 {
+		t.Fatalf("target 2 CURRENT token seq = %d ok = %v, want 2", seq, ok)
+	}
+
+	// A new "a" doc (seq 3) matches only target 1, leaving target 2 at 2: the
+	// NO_CHANGE token is min(3, 2) = 2, not the global head 3.
+	svc.CreateDocument(ctx, "test", "(default)", "a", "a2", map[string]*firestorestore.Value{
+		"v": firestorestore.StringVal("2"),
+	})
+	rs = recvN(t, stream, 2, 3*time.Second)
+	if dc := rs[0].GetDocumentChange(); dc == nil || !containsTargetID(dc.TargetIds, 1) {
+		t.Fatalf("expected DocumentChange for target 1, got %v", rs[0])
+	}
+	if seq, ok := DecodeResumeToken(rs[1].GetTargetChange().GetResumeToken()); !ok || seq != 2 {
+		t.Fatalf("stream NO_CHANGE token after a2 = seq %d ok = %v, want 2 (min cursor)", seq, ok)
+	}
+
+	// A new "b" doc (seq 4) matches only target 2: min cursor becomes 3.
+	svc.CreateDocument(ctx, "test", "(default)", "b", "b2", map[string]*firestorestore.Value{
+		"v": firestorestore.StringVal("2"),
+	})
+	rs = recvN(t, stream, 2, 3*time.Second)
+	if dc := rs[0].GetDocumentChange(); dc == nil || !containsTargetID(dc.TargetIds, 2) {
+		t.Fatalf("expected DocumentChange for target 2, got %v", rs[0])
+	}
+	if seq, ok := DecodeResumeToken(rs[1].GetTargetChange().GetResumeToken()); !ok || seq != 3 {
+		t.Fatalf("stream NO_CHANGE token after b2 = seq %d ok = %v, want 3 (min cursor)", seq, ok)
+	}
+
+	// Resume target 1 from its own token (seq 1): it must replay only a2 (seq 3),
+	// not target 2's b2.
+	if err := stream.Send(removeTargetReq(1)); err != nil {
+		t.Fatalf("remove target 1: %v", err)
+	}
+	recvN(t, stream, 1, 3*time.Second)
+	t1Resume := queryTarget(3, "a")
+	t1Resume.ResumeType = &firestorepb.Target_ResumeToken{ResumeToken: t1Token}
+	if err := stream.Send(addTargetReq(t1Resume)); err != nil {
+		t.Fatalf("resume target 1: %v", err)
+	}
+	rs = recvN(t, stream, 4, 3*time.Second) // ADD, a2, CURRENT, NO_CHANGE
+	dc := rs[1].GetDocumentChange()
+	if dc == nil || dc.Document.Name != listenParent+"/a/a2" {
+		t.Fatalf("target 1 resume replayed %v, want only a2", rs[1])
+	}
+	if !containsTargetID(dc.TargetIds, 3) {
+		t.Fatalf("target 1 resume change target_ids = %v, want [3]", dc.TargetIds)
+	}
+
+	// Resume target 2 from its own token (seq 2): it must replay only b2 (seq 4).
+	if err := stream.Send(removeTargetReq(2)); err != nil {
+		t.Fatalf("remove target 2: %v", err)
+	}
+	recvN(t, stream, 1, 3*time.Second)
+	t2Resume := queryTarget(4, "b")
+	t2Resume.ResumeType = &firestorepb.Target_ResumeToken{ResumeToken: t2Token}
+	if err := stream.Send(addTargetReq(t2Resume)); err != nil {
+		t.Fatalf("resume target 2: %v", err)
+	}
+	rs = recvN(t, stream, 4, 3*time.Second) // ADD, b2, CURRENT, NO_CHANGE
+	dc = rs[1].GetDocumentChange()
+	if dc == nil || dc.Document.Name != listenParent+"/b/b2" {
+		t.Fatalf("target 2 resume replayed %v, want only b2", rs[1])
+	}
+}
+
+// TestListenResumeTokenBelowFloorFallsBackToSnapshot asserts that a resume token
+// whose deltas have been evicted (below the retention floor) is treated as
+// expired: the target gets a fresh snapshot instead of replaying from a partial
+// history. Deltas that would have matched are gone, so a stale replay would be
+// silently lossy.
+func TestListenResumeTokenBelowFloorFallsBackToSnapshot(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Two docs in the watched collection establish a resumable position at seq 2.
+	for _, id := range []string{"a1", "a2"} {
+		if _, err := svc.CreateDocument(ctx, "test", "(default)", "a", id, map[string]*firestorestore.Value{
+			"v": firestorestore.StringVal(id),
+		}); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+
+	lctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	if err := stream.Send(addTargetReq(queryTarget(1, "a"))); err != nil {
+		t.Fatalf("send target: %v", err)
+	}
+	rs := recvN(t, stream, 5, 5*time.Second) // ADD, a1, a2, CURRENT, NO_CHANGE
+	resumeToken := rs[3].GetTargetChange().GetResumeToken()
+	if seq, ok := DecodeResumeToken(resumeToken); !ok || seq != 2 {
+		t.Fatalf("CURRENT resume token seq = %d ok = %v, want 2", seq, ok)
+	}
+
+	// Evict the resume position by writing past the change-feed retention window.
+	// The unrelated "z" writes still advance the floor.
+	const maxWrites = 50_000
+	for i := 0; svc.ChangeFloor() <= 2 && i < maxWrites; i++ {
+		if _, err := svc.CreateDocument(ctx, "test", "(default)", "z", fmt.Sprintf("z%05d", i), nil); err != nil {
+			t.Fatalf("bulk write %d: %v", i, err)
+		}
+	}
+	if floor := svc.ChangeFloor(); floor <= 2 {
+		t.Fatalf("change floor = %d, want > 2 after eviction", floor)
+	}
+
+	// Resume from the now-expired token. A correct server falls back to a full
+	// snapshot (a1 + a2); a stale incremental replay would send no deltas at all
+	// because no "a" write happened after seq 2.
+	if err := stream.Send(removeTargetReq(1)); err != nil {
+		t.Fatalf("remove target: %v", err)
+	}
+	recvN(t, stream, 1, 5*time.Second)
+
+	rt := queryTarget(2, "a")
+	rt.ResumeType = &firestorepb.Target_ResumeToken{ResumeToken: resumeToken}
+	if err := stream.Send(addTargetReq(rt)); err != nil {
+		t.Fatalf("resume target: %v", err)
+	}
+	rs = recvN(t, stream, 5, 10*time.Second) // ADD, a1, a2, CURRENT, NO_CHANGE
+	if rs[0].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_ADD {
+		t.Fatalf("frame 0: expected ADD, got %v", rs[0])
+	}
+	got := map[string]bool{}
+	for _, r := range rs[1:3] {
+		dc := r.GetDocumentChange()
+		if dc == nil {
+			t.Fatalf("expected snapshot DocumentChange, got %v", r)
+		}
+		got[dc.Document.Name] = true
+	}
+	if !got[listenParent+"/a/a1"] || !got[listenParent+"/a/a2"] {
+		t.Fatalf("snapshot documents = %v, want a1 and a2", got)
 	}
 }

--- a/internal/gcp/grpc/firestore/transcode.go
+++ b/internal/gcp/grpc/firestore/transcode.go
@@ -1,5 +1,31 @@
 // Package firestore implements the Firestore gRPC service over the shared
 // transport-agnostic provider Service.
+//
+// # Listen fidelity
+//
+// Listen delta replay uses the shared change-feed's monotonic sequence as the
+// resume token (an opaque 8-byte encoding of the sequence; see
+// EncodeResumeToken). Three deliberate approximations of real Firestore are
+// documented here:
+//
+//   - Bounded history. The change-feed retains the most recent
+//     changeLogRetention events and drops older ones, advancing a floor. A resume
+//     token below the floor (or from before a Reset) is treated as expired: the
+//     target is not incrementally replayed and receives a fresh snapshot instead,
+//     which matches real Firestore's behavior for an expired resume token. A
+//     token of 0 is likewise not a resumable position, because the log records
+//     writes rather than a full document history.
+//   - Per-target cursors. Each target tracks the last sequence delivered to it.
+//     Its TargetChange_CURRENT frame carries that target's own sequence. The
+//     empty-target_ids NO_CHANGE frame's token must cover all targets at once; it
+//     carries the minimum of the live cursors — resuming from there can replay a
+//     duplicate delta but never skip one. Real Firestore pairs each resume token
+//     with its own target_ids, which a single "all targets" token cannot express.
+//   - Read position. A resume token is a position in the write feed, not a
+//     query-range read position: an incremental resume replays matching deltas
+//     only and does not re-stream the pre-existing result set, so a client must
+//     already hold the snapshot it is resuming from. Snapshots are computed from
+//     current document state rather than a consistent read-time index.
 package firestore
 
 import (

--- a/internal/gcp/provider/firestore/change.go
+++ b/internal/gcp/provider/firestore/change.go
@@ -4,6 +4,14 @@ import (
 	firestorestore "jaiscloud/internal/gcp/store/firestore"
 )
 
+// changeLogRetention is the maximum number of recent change events retained for
+// resume-token replay. Real Firestore keeps change history only for a bounded
+// window (resume tokens expire); this bounds the emulator's memory under a
+// steady write load. History beyond the window is dropped oldest-first and
+// ChangeFloor advances past it, so a resume token below the floor is treated as
+// expired rather than silently replayed from a partial history.
+const changeLogRetention = 10_000
+
 // ChangeEvent describes a single document mutation published by the shared
 // change-feed. Every write through the Service (REST or gRPC) publishes exactly
 // one ChangeEvent, so Listen observes writes regardless of the transport that
@@ -12,6 +20,55 @@ type ChangeEvent struct {
 	Seq  uint64
 	Name string
 	Doc  *firestorestore.Document
+}
+
+// changeRing is a fixed-capacity FIFO of ChangeEvents. Once full it overwrites
+// the oldest entry, so its memory use is exactly capacity entries no matter how
+// many writes the Service has observed.
+type changeRing struct {
+	buf   []ChangeEvent
+	head  int // index of the oldest retained event
+	count int
+}
+
+// newChangeRing returns a ring that retains at most capacity events. A
+// non-positive capacity yields a ring that retains nothing (add is a no-op).
+func newChangeRing(capacity int) changeRing {
+	if capacity < 0 {
+		capacity = 0
+	}
+	return changeRing{buf: make([]ChangeEvent, capacity)}
+}
+
+// add appends ev. When the ring is full it overwrites the oldest entry and
+// returns that evicted event with ok=true; otherwise it returns the zero event
+// and ok=false.
+func (r *changeRing) add(ev ChangeEvent) (ChangeEvent, bool) {
+	if len(r.buf) == 0 {
+		return ChangeEvent{}, false
+	}
+	if r.count < len(r.buf) {
+		r.buf[(r.head+r.count)%len(r.buf)] = ev
+		r.count++
+		return ChangeEvent{}, false
+	}
+	evicted := r.buf[r.head]
+	r.buf[r.head] = ev
+	r.head = (r.head + 1) % len(r.buf)
+	return evicted, true
+}
+
+// reset empties the ring without releasing its backing array.
+func (r *changeRing) reset() {
+	r.head = 0
+	r.count = 0
+}
+
+// each invokes fn for every retained event, oldest first.
+func (r *changeRing) each(fn func(ChangeEvent)) {
+	for i := 0; i < r.count; i++ {
+		fn(r.buf[(r.head+i)%len(r.buf)])
+	}
 }
 
 // changeSub is one subscriber to the shared change-feed.
@@ -51,17 +108,39 @@ func (s *Service) CurrentSeq() uint64 {
 	return s.changeSeq
 }
 
-// ChangesSince returns the change-feed history for every event published after
-// seq, in order. Listen uses it to replay deltas from a resume token.
+// ChangeFloor returns the sequence number of the most recently evicted change
+// event (0 when no history has been evicted yet). The feed can replay faithfully
+// only from a sequence at or above the floor; a resume token below it must fall
+// back to a snapshot because the deltas it depends on are gone.
+func (s *Service) ChangeFloor() uint64 {
+	s.changeMu.Lock()
+	defer s.changeMu.Unlock()
+	return s.changeFloor
+}
+
+// ReplayableFrom reports whether ChangesSince(seq) can reconstruct the feed
+// faithfully. It is false when seq is below the retention floor (its deltas were
+// evicted) or when seq is ahead of the current sequence (a token from before a
+// Reset). Callers treat a non-replayable token as invalid and resnapshot.
+func (s *Service) ReplayableFrom(seq uint64) bool {
+	s.changeMu.Lock()
+	defer s.changeMu.Unlock()
+	return seq >= s.changeFloor && seq <= s.changeSeq
+}
+
+// ChangesSince returns the retained change-feed history for every event
+// published after seq, in order. Listen uses it to replay deltas from a resume
+// token. A seq below ChangeFloor() cannot be replayed completely; callers should
+// check ReplayableFrom first.
 func (s *Service) ChangesSince(seq uint64) []ChangeEvent {
 	s.changeMu.Lock()
 	defer s.changeMu.Unlock()
 	out := make([]ChangeEvent, 0)
-	for _, e := range s.changeLog {
+	s.changeLog.each(func(e ChangeEvent) {
 		if e.Seq > seq {
 			out = append(out, e)
 		}
-	}
+	})
 	return out
 }
 
@@ -85,13 +164,29 @@ func (s *Service) unsubscribeChange(sub *changeSub) {
 	}
 }
 
+// retention returns the effective change-log capacity: the test override when
+// set, otherwise the package default.
+func (s *Service) retention() int {
+	if s.changeRetentionOverride > 0 {
+		return s.changeRetentionOverride
+	}
+	return changeLogRetention
+}
+
 // publishChange appends the event to the change-feed history (assigning the next
-// monotonic sequence) and fans it out to every subscriber.
+// monotonic sequence) and fans it out to every subscriber. The history keeps
+// only the most recent retention() events; once full, the oldest entry is evicted
+// and the floor advances to its sequence.
 func (s *Service) publishChange(ev ChangeEvent) {
 	s.changeMu.Lock()
+	if len(s.changeLog.buf) == 0 {
+		s.changeLog = newChangeRing(s.retention())
+	}
 	s.changeSeq++
 	ev.Seq = s.changeSeq
-	s.changeLog = append(s.changeLog, ev)
+	if evicted, ok := s.changeLog.add(ev); ok {
+		s.changeFloor = evicted.Seq
+	}
 	subs := make([]*changeSub, 0, len(s.changeSubs))
 	for sub := range s.changeSubs {
 		subs = append(subs, sub)

--- a/internal/gcp/provider/firestore/change_test.go
+++ b/internal/gcp/provider/firestore/change_test.go
@@ -2,6 +2,7 @@ package firestore
 
 import (
 	"context"
+	"fmt"
 	"testing"
 )
 
@@ -37,5 +38,73 @@ func TestReset_ClearsChangeFeed(t *testing.T) {
 	// anything either, now that history has been wiped.
 	if changes := p.ChangesSince(1); len(changes) != 0 {
 		t.Fatalf("expected no changes replaying a pre-reset seq, got %d: %+v", len(changes), changes)
+	}
+}
+
+// TestChangeFeedCapsAndAdvancesFloor verifies the change-feed retains only the
+// most recent retention() events, drops the oldest, and advances the floor past
+// the evicted history.
+func TestChangeFeedCapsAndAdvancesFloor(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	p.changeRetentionOverride = 3
+
+	for i := 0; i < 5; i++ {
+		if _, err := p.Service.CreateDocument(ctx, "proj", "(default)", "documents/cities",
+			fmt.Sprintf("d%d", i), nil); err != nil {
+			t.Fatalf("create %d: %v", i, err)
+		}
+	}
+
+	if got := p.CurrentSeq(); got != 5 {
+		t.Fatalf("CurrentSeq = %d, want 5", got)
+	}
+	// Five events written, only the last three (seq 3, 4, 5) retained, so the
+	// evicted floor is seq 2.
+	if got := p.ChangeFloor(); got != 2 {
+		t.Fatalf("ChangeFloor = %d, want 2", got)
+	}
+
+	got := p.ChangesSince(2)
+	if len(got) != 3 || got[0].Seq != 3 || got[2].Seq != 5 {
+		t.Fatalf("ChangesSince(2) = %+v, want seqs [3 4 5]", got)
+	}
+	// A token below the floor is not replayable; one at the floor is.
+	if !p.ReplayableFrom(2) {
+		t.Fatal("ReplayableFrom(2) = false, want true (token at the floor)")
+	}
+	if p.ReplayableFrom(1) {
+		t.Fatal("ReplayableFrom(1) = true, want false (token below the floor)")
+	}
+	// ChangesSince cannot reconstruct the evicted prefix.
+	if got := p.ChangesSince(0); len(got) != 3 || got[0].Seq != 3 {
+		t.Fatalf("ChangesSince(0) = %+v, want retained seqs starting at 3", got)
+	}
+}
+
+// TestResetClearsChangeFloor verifies Reset resets the floor alongside the log
+// and sequence, so a pre-reset token is not treated as replayable.
+func TestResetClearsChangeFloor(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	p.changeRetentionOverride = 2
+
+	for i := 0; i < 5; i++ {
+		if _, err := p.Service.CreateDocument(ctx, "proj", "(default)", "documents/cities",
+			fmt.Sprintf("d%d", i), nil); err != nil {
+			t.Fatalf("create %d: %v", i, err)
+		}
+	}
+	if p.ChangeFloor() == 0 {
+		t.Fatal("expected a non-zero floor before Reset")
+	}
+
+	p.Reset(ctx)
+
+	if got := p.ChangeFloor(); got != 0 {
+		t.Fatalf("ChangeFloor after Reset = %d, want 0", got)
+	}
+	if p.ReplayableFrom(1) {
+		t.Fatal("a pre-reset token must not be replayable after Reset")
 	}
 }

--- a/internal/gcp/provider/firestore/service.go
+++ b/internal/gcp/provider/firestore/service.go
@@ -33,11 +33,18 @@ type Service struct {
 	readSets map[string]*readSet
 
 	// changeMu guards the change-feed: changeSeq (monotonic), changeLog (the
-	// full ordered history used for resume-token replay), and changeSubs.
-	changeMu   sync.Mutex
-	changeSeq  uint64
-	changeLog  []ChangeEvent
-	changeSubs map[*changeSub]struct{}
+	// bounded ordered history used for resume-token replay), changeFloor (the
+	// highest evicted sequence), and changeSubs.
+	changeMu    sync.Mutex
+	changeSeq   uint64
+	changeLog   changeRing
+	changeFloor uint64
+	changeSubs  map[*changeSub]struct{}
+
+	// changeRetentionOverride, when > 0, replaces changeLogRetention. Tests set
+	// it to exercise eviction without writing a full retention window; the
+	// zero value selects the package default.
+	changeRetentionOverride int
 }
 
 // newService returns a Firestore service backed by the given document store and
@@ -54,9 +61,11 @@ func newService(s firestorestore.FirestoreStore, resources store.ResourceStore) 
 // (document state is reset via the store's own Resetter; index state via the
 // resource store's). Live subscribers (changeSubs) are left attached: they
 // only ever receive events published after Reset, from the fresh sequence, so
-// leaving them subscribed is safe — clearing changeLog/changeSeq is what
-// matters, since ChangesSince(seq) would otherwise keep replaying pre-reset
-// history that references documents the reset store no longer has.
+// leaving them subscribed is safe — clearing changeLog/changeSeq/changeFloor is
+// what matters, since ChangesSince(seq) would otherwise keep replaying pre-reset
+// history that references documents the reset store no longer has. A pre-reset
+// resume token is rejected by ReplayableFrom (it is ahead of the fresh
+// sequence), so it resnapshots rather than replaying stale deltas.
 func (s *Service) Reset(_ context.Context) {
 	s.txnMu.Lock()
 	s.readSets = make(map[string]*readSet)
@@ -64,7 +73,8 @@ func (s *Service) Reset(_ context.Context) {
 
 	s.changeMu.Lock()
 	s.changeSeq = 0
-	s.changeLog = nil
+	s.changeLog.reset()
+	s.changeFloor = 0
 	s.changeMu.Unlock()
 }
 


### PR DESCRIPTION
Closes two Firestore `Listen` debts in `gcp-deferred-debt-plan.md` §3.1. (1) **Bounded change feed**: `changeLog` was an unbounded `append`; now a fixed-capacity ring (`changeLogRetention = 10_000`) with a `changeFloor`; evicted/too-old resume tokens fall back to a full snapshot instead of replaying from a partial history. (2) **Per-target resume tokens**: each target tracks its own delivered seq and emits it (was the global `CurrentSeq()`), so a multi-target stream resumes each target from its own token; the aggregate `NO_CHANGE` token uses the minimum cursor (documented approximation). Package doc records the approximations (write-feed position, not query-range read position). Verified: build/vet/race/full-suite/gofmt clean; tests cover cap+floor advance, below-floor snapshot fallback, and multi-target per-target resume.