### PR TITLE
feat(gcp/storage): gRPC UpdateBucket/RestoreObject/LockBucketRetentionPolicy/CancelResumableWrite

### DIFF
--- a/README-GCP.md
+++ b/README-GCP.md
@@ -172,6 +172,12 @@ curl -X POST http://localhost:8080/_jaiscloud/reset
 
 This section documents deliberate simplifications and known correctness edge cases — distinct from ordinary bugs, these are behaviours a developer relying on this emulator should know about up front.
 
+### Cloud Storage: gRPC v2 `BidiReadObject` is not implemented
+
+The Cloud Storage v2 gRPC service implements `ReadObject` (metadata + bounded 2 MiB data chunks, with `read_offset`/`read_limit`), but the newer bidirectional streaming read RPC `BidiReadObject` is deliberately left `Unimplemented` — clients that reach for it receive `codes.Unimplemented`, while `ReadObject` covers the read surface. The bucket/object write, copy, restore, IAM, and resumable-upload surfaces are all implemented.
+
+`RestoreObject` models GCS soft-delete as versioning tombstones (`timeDeleted` set): restoring a non-live generation flips it live and marks the current live generation non-live, honoring the `if_generation_match`/`if_metageneration_match` preconditions atomically. `restore_token` and `copy_source_acl` are accepted but ignored (the emulator has no ACL plane and no hierarchical namespaces). `UpdateBucket` applies only the field-mask paths it models — `labels`, `versioning`, `storage_class`, `location`, and `retention_policy` — and bumps the bucket metageneration; unknown paths are ignored rather than rejected.
+
 ### Firestore: optimistic-concurrency conflict detection can miss a race under a frozen clock
 
 Firestore's `documents.patch` and transform-carrying `commit`/`batchWrite` writes are protected against concurrent lost updates via an optimistic-concurrency check: the document's `UpdateTime` at read time is captured and re-validated, atomically with applying the write, against the live document's current `UpdateTime` — a conflicting concurrent write causes the loser to receive `409 ABORTED` instead of silently overwriting the winner. This is correct and race-free under the real (or offset) clock, where `UpdateTime` values are effectively unique to nanosecond resolution.

--- a/internal/gcp/grpc/storage/service.go
+++ b/internal/gcp/grpc/storage/service.go
@@ -2,6 +2,14 @@
 // (google.storage.v2.Storage) over the same gcs.ObjectStore, blobfs.BlobStore,
 // and crypto.EnvelopeEncryptor backing the REST provider, so REST and gRPC share
 // object state and stay byte-compatible.
+//
+// Implemented RPCs: bucket CRUD + UpdateBucket/LockBucketRetentionPolicy, object
+// CRUD + RestoreObject, compose/rewrite/move, Get/Update/DeleteObject, the
+// resumable-write surface (StartResumableWrite/WriteObject/BidiWriteObject/
+// QueryWriteStatus/CancelResumableWrite), ReadObject, and bucket/object IAM.
+// BidiReadObject — the newer bidirectional streaming read surface — remains
+// intentionally unimplemented (the embedded UnimplementedStorageServer fails it
+// loud with codes.Unimplemented); ReadObject covers the read surface.
 package storage
 
 import (
@@ -30,6 +38,7 @@ import (
 	"jaiscloud/internal/model"
 	"jaiscloud/internal/store"
 
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -255,6 +264,23 @@ func bucketToProto(m map[string]any) *storagepb.Bucket {
 		if t, err := time.Parse(time.RFC3339Nano, u); err == nil {
 			b.UpdateTime = timestamppb.New(t)
 		}
+	}
+	if rp, ok := m["retentionPolicy"].(map[string]any); ok && len(rp) > 0 {
+		policy := &storagepb.Bucket_RetentionPolicy{}
+		if locked, _ := rp["isLocked"].(bool); locked {
+			policy.IsLocked = true
+		}
+		if period, _ := rp["retentionPeriod"].(string); period != "" {
+			if n, err := strconv.ParseInt(period, 10, 64); err == nil && n > 0 {
+				policy.RetentionDuration = durationpb.New(time.Duration(n) * time.Second)
+			}
+		}
+		if et, _ := rp["effectiveTime"].(string); et != "" {
+			if t, err := time.Parse(time.RFC3339Nano, et); err == nil {
+				policy.EffectiveTime = timestamppb.New(t)
+			}
+		}
+		b.RetentionPolicy = policy
 	}
 	return b
 }
@@ -591,6 +617,154 @@ func pageBuckets(buckets []map[string]any, pageSize int, pageToken string) ([]ma
 	return page, next
 }
 
+// ─── buckets: update / retention lock ─────────────────────────────────────────
+
+// mapBucketMutationError maps the bucket-store sentinels returned by
+// UpdateBucketMetaAtomic to the canonical gRPC-facing provider errors.
+func mapBucketMutationError(err error) error {
+	if errors.Is(err, gcs.ErrNoSuchBucket) {
+		return model.NewProviderError("NotFound", "bucket not found", 404)
+	}
+	if errors.Is(err, gcs.ErrPreconditionFailed) {
+		return model.NewProviderError("FailedPrecondition", "At least one of the pre-conditions you specified did not hold", 412)
+	}
+	return err
+}
+
+// bucketRetentionToMap converts a proto bucket retention policy into the map
+// shape the REST provider persists (decimal-second retentionPeriod string,
+// optional effectiveTime RFC 3339, isLocked bool). Returns nil for a nil policy.
+func bucketRetentionToMap(rp *storagepb.Bucket_RetentionPolicy) map[string]any {
+	if rp == nil {
+		return nil
+	}
+	out := map[string]any{}
+	if d := rp.GetRetentionDuration(); d != nil {
+		out["retentionPeriod"] = strconv.FormatInt(int64(d.AsDuration().Seconds()), 10)
+	}
+	if et := rp.GetEffectiveTime(); et != nil {
+		out["effectiveTime"] = et.AsTime().Format(time.RFC3339Nano)
+	}
+	if rp.GetIsLocked() {
+		out["isLocked"] = true
+	}
+	return out
+}
+
+// applyBucketMask overlays the request's masked Bucket fields onto the stored
+// bucket metadata. Only the field paths this service models (labels, versioning,
+// storageClass, location, retentionPolicy) are applied; "*" applies all of them.
+// An absent/empty masked field clears the stored key where GCS treats the field
+// as a map/message (labels, versioning, retentionPolicy) and is otherwise left
+// untouched.
+func applyBucketMask(meta map[string]any, pb *storagepb.Bucket, mask *fieldmaskpb.FieldMask) {
+	if maskIncludes(mask, "labels") {
+		if labels := pb.GetLabels(); len(labels) > 0 {
+			meta["labels"] = labels
+		} else {
+			delete(meta, "labels")
+		}
+	}
+	if maskIncludes(mask, "versioning") {
+		if v := pb.GetVersioning(); v != nil && v.GetEnabled() {
+			meta["versioning"] = map[string]any{"enabled": true}
+		} else {
+			delete(meta, "versioning")
+		}
+	}
+	if sc := pb.GetStorageClass(); sc != "" && maskIncludes(mask, "storage_class") {
+		meta["storageClass"] = sc
+	}
+	if loc := pb.GetLocation(); loc != "" && maskIncludes(mask, "location") {
+		meta["location"] = loc
+	}
+	if maskIncludes(mask, "retention_policy") {
+		if rp := bucketRetentionToMap(pb.GetRetentionPolicy()); rp != nil {
+			meta["retentionPolicy"] = rp
+		} else {
+			delete(meta, "retentionPolicy")
+		}
+	}
+}
+
+// UpdateBucket applies the request's update_mask to the stored bucket metadata.
+// The metageneration precondition (if_metageneration_match /
+// if_metageneration_not_match) is validated inside the store's atomic
+// read-modify-write, then the metageneration is bumped — the same
+// UpdateBucketMetaAtomic path the REST BucketsUpdate uses, so the two transports
+// share bucket metageneration state.
+func (s *Service) UpdateBucket(ctx context.Context, req *storagepb.UpdateBucketRequest) (*storagepb.Bucket, error) {
+	bucket := parseBucketName(req.GetBucket().GetName())
+	if bucket == "" {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "missing bucket name", 400))
+	}
+	mask := req.GetUpdateMask()
+	if mask == nil || len(mask.GetPaths()) == 0 {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "update_mask is required", 400))
+	}
+	var pre *gcs.Precondition
+	if req.IfMetagenerationMatch != nil || req.IfMetagenerationNotMatch != nil {
+		pre = &gcs.Precondition{
+			MetagenerationMatch:    req.IfMetagenerationMatch,
+			MetagenerationNotMatch: req.IfMetagenerationNotMatch,
+		}
+	}
+	updated, err := s.objects.UpdateBucketMetaAtomic(ctx, bucket, func(meta map[string]any) (map[string]any, error) {
+		if !gcs.BucketMetagenerationMatches(meta, pre) {
+			return nil, gcs.ErrPreconditionFailed
+		}
+		applyBucketMask(meta, req.GetBucket(), mask)
+		meta["metageneration"] = bumpMeta(gcs.BucketMetageneration(meta))
+		meta["updated"] = clock.Now().Format(time.RFC3339Nano)
+		return meta, nil
+	})
+	if err != nil {
+		return nil, mapError(mapBucketMutationError(err))
+	}
+	return bucketToProto(updated), nil
+}
+
+// LockBucketRetentionPolicy sets the bucket's retention policy isLocked flag
+// permanently (GCS retention locks cannot be undone) and bumps the bucket
+// metageneration, honoring the required if_metageneration_match precondition.
+// A missing bucket or a bucket with no retention policy is NotFound; a bucket
+// whose policy is already locked is returned unchanged (locking is idempotent).
+func (s *Service) LockBucketRetentionPolicy(ctx context.Context, req *storagepb.LockBucketRetentionPolicyRequest) (*storagepb.Bucket, error) {
+	bucket := parseBucketName(req.GetBucket())
+	if bucket == "" {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "missing bucket name", 400))
+	}
+	var pre *gcs.Precondition
+	if v := req.GetIfMetagenerationMatch(); v != 0 {
+		pre = &gcs.Precondition{MetagenerationMatch: &v}
+	}
+	updated, err := s.objects.UpdateBucketMetaAtomic(ctx, bucket, func(meta map[string]any) (map[string]any, error) {
+		if !gcs.BucketMetagenerationMatches(meta, pre) {
+			return nil, gcs.ErrPreconditionFailed
+		}
+		rp, _ := meta["retentionPolicy"].(map[string]any)
+		if len(rp) == 0 {
+			return nil, model.NewProviderError("NotFound", "bucket has no retention policy", 404)
+		}
+		if locked, _ := rp["isLocked"].(bool); locked {
+			return meta, nil
+		}
+		next := make(map[string]any, len(rp)+1)
+		for k, v := range rp {
+			next[k] = v
+		}
+		next["isLocked"] = true
+		meta["retentionPolicy"] = next
+		meta["metageneration"] = bumpMeta(gcs.BucketMetageneration(meta))
+		meta["updated"] = clock.Now().Format(time.RFC3339Nano)
+		return meta, nil
+	})
+	if err != nil {
+		return nil, mapError(mapBucketMutationError(err))
+	}
+	return bucketToProto(updated), nil
+}
+
 // ─── objects ──────────────────────────────────────────────────────────────────
 
 func (s *Service) GetObject(ctx context.Context, req *storagepb.GetObjectRequest) (*storagepb.Object, error) {
@@ -751,6 +925,34 @@ func checkObjectPreconditions(live gcs.ObjectMeta, ifGenMatch, ifGenNotMatch, if
 		return preconditionErr("if_metageneration_not_match precondition failed")
 	}
 	return nil
+}
+
+// RestoreObject restores a non-live (soft-deleted/tombstoned) generation to
+// live. The emulator models GCS soft-delete as versioning tombstones (TimeDeleted
+// set), so this delegates to the store's atomic RestoreObjectGeneration, which
+// flips the targeted generation live and marks the current live generation
+// non-live. The if_* preconditions are validated against the current live
+// generation inside that same atomic mutation. copy_source_acl and restore_token
+// are accepted but ignored (the emulator has no ACL plane and no hierarchical
+// namespaces).
+func (s *Service) RestoreObject(ctx context.Context, req *storagepb.RestoreObjectRequest) (*storagepb.Object, error) {
+	bucket := parseBucketName(req.GetBucket())
+	object := req.GetObject()
+	if bucket == "" || object == "" || req.GetGeneration() <= 0 {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "restore requires bucket, object, and a positive generation", 400))
+	}
+	pre := grpcObjectPrecondition(req.IfGenerationMatch, req.IfGenerationNotMatch, req.IfMetagenerationMatch, req.IfMetagenerationNotMatch)
+	meta, err := s.objects.RestoreObjectGeneration(ctx, bucket, object, int64ToGen(req.GetGeneration()), pre)
+	if err != nil {
+		if errors.Is(err, gcs.ErrNoSuchBucket) {
+			return nil, mapError(model.NewProviderError("NotFound", "bucket not found", 404))
+		}
+		if errors.Is(err, gcs.ErrNoSuchObject) {
+			return nil, mapError(model.NewProviderError("NotFound", "object generation not found", 404))
+		}
+		return nil, mapError(preconditionResult(err))
+	}
+	return objectToProto(meta), nil
 }
 
 // UpdateObject applies a patch update to an object's metadata.
@@ -1070,6 +1272,28 @@ func (s *Service) QueryWriteStatus(ctx context.Context, req *storagepb.QueryWrit
 	return &storagepb.QueryWriteStatusResponse{
 		WriteStatus: &storagepb.QueryWriteStatusResponse_PersistedSize{PersistedSize: persisted},
 	}, nil
+}
+
+// CancelResumableWrite discards an in-progress resumable upload session. It
+// removes the in-memory session (closing any spill file) and the durable store
+// record. Both are idempotent for an unknown id — real GCS returns OK for an
+// upload_id it no longer knows — so cancelling an already-completed upload is a
+// harmless no-op that never touches the committed object.
+func (s *Service) CancelResumableWrite(ctx context.Context, req *storagepb.CancelResumableWriteRequest) (*storagepb.CancelResumableWriteResponse, error) {
+	id := req.GetUploadId()
+	if id == "" {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "missing upload_id", 400))
+	}
+	s.mu.Lock()
+	if sess, ok := s.uploads[id]; ok {
+		sess.closeSpill()
+		delete(s.uploads, id)
+	}
+	s.mu.Unlock()
+	if err := s.objects.DeleteResumable(ctx, id); err != nil && !errors.Is(err, gcs.ErrNoSuchUpload) {
+		return nil, mapError(err)
+	}
+	return &storagepb.CancelResumableWriteResponse{}, nil
 }
 
 // ─── writes ───────────────────────────────────────────────────────────────────

--- a/internal/gcp/grpc/storage/service_test.go
+++ b/internal/gcp/grpc/storage/service_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"testing"
+	"time"
 
 	iampb "cloud.google.com/go/iam/apiv1/iampb"
 
@@ -23,6 +24,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
@@ -1114,5 +1116,291 @@ func TestReadObjectRange(t *testing.T) {
 	}
 	if zeroMsgs != 1 {
 		t.Fatalf("zero-length range messages = %d, want 1 (metadata only)", zeroMsgs)
+	}
+}
+
+func TestUpdateBucketLabelsAndPrecondition(t *testing.T) {
+	client, cleanup := storageTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+
+	initial, err := client.GetBucket(ctx, &storagepb.GetBucketRequest{Name: testBucket})
+	if err != nil {
+		t.Fatalf("GetBucket: %v", err)
+	}
+	initialMeta := initial.GetMetageneration()
+	if initialMeta != 1 {
+		t.Fatalf("fresh bucket metageneration = %d, want 1", initialMeta)
+	}
+
+	updated, err := client.UpdateBucket(ctx, &storagepb.UpdateBucketRequest{
+		Bucket:     &storagepb.Bucket{Name: testBucket, Labels: map[string]string{"env": "prod"}},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"labels"}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBucket: %v", err)
+	}
+	if updated.GetLabels()["env"] != "prod" {
+		t.Fatalf("UpdateBucket labels = %v, want env=prod", updated.GetLabels())
+	}
+	if updated.GetMetageneration() != initialMeta+1 {
+		t.Fatalf("UpdateBucket metageneration = %d, want %d", updated.GetMetageneration(), initialMeta+1)
+	}
+
+	// A stale metageneration precondition must fail without mutating.
+	if _, err := client.UpdateBucket(ctx, &storagepb.UpdateBucketRequest{
+		Bucket:                &storagepb.Bucket{Name: testBucket, Labels: map[string]string{"env": "dev"}},
+		UpdateMask:            &fieldmaskpb.FieldMask{Paths: []string{"labels"}},
+		IfMetagenerationMatch: &initialMeta,
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("UpdateBucket stale precondition err = %v, want FailedPrecondition", err)
+	}
+	if got, _ := client.GetBucket(ctx, &storagepb.GetBucketRequest{Name: testBucket}); got.GetLabels()["env"] != "prod" {
+		t.Fatalf("stale-precondition update mutated labels: %v", got.GetLabels())
+	}
+
+	// The current metageneration satisfies the precondition.
+	current := updated.GetMetageneration()
+	again, err := client.UpdateBucket(ctx, &storagepb.UpdateBucketRequest{
+		Bucket:                &storagepb.Bucket{Name: testBucket, Labels: map[string]string{"env": "dev"}},
+		UpdateMask:            &fieldmaskpb.FieldMask{Paths: []string{"labels"}},
+		IfMetagenerationMatch: &current,
+	})
+	if err != nil {
+		t.Fatalf("UpdateBucket matching precondition: %v", err)
+	}
+	if again.GetLabels()["env"] != "dev" {
+		t.Fatalf("UpdateBucket labels = %v, want env=dev", again.GetLabels())
+	}
+
+	// An update_mask is required.
+	if _, err := client.UpdateBucket(ctx, &storagepb.UpdateBucketRequest{
+		Bucket: &storagepb.Bucket{Name: testBucket, Labels: map[string]string{"env": "x"}},
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("UpdateBucket missing mask err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestRestoreObject(t *testing.T) {
+	client, cleanup := storageTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Versioned bucket so overwrites retain (tombstone) prior generations.
+	if _, err := client.CreateBucket(ctx, &storagepb.CreateBucketRequest{
+		Parent:   "projects/_",
+		BucketId: "bucket-a",
+		Bucket: &storagepb.Bucket{
+			Project:    "projects/test-project",
+			Location:   "US",
+			Versioning: &storagepb.Bucket_Versioning{Enabled: true},
+		},
+	}); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	v1 := writeSingleShot(t, client, testBucket, "restore-obj", "text/plain", []byte("version-one"))
+	v2 := writeSingleShot(t, client, testBucket, "restore-obj", "text/plain", []byte("version-two"))
+	if v1.GetGeneration() == v2.GetGeneration() {
+		t.Fatal("expected distinct generations")
+	}
+
+	// v1 is now non-live (tombstoned) after the v2 write.
+	dead, err := client.GetObject(ctx, &storagepb.GetObjectRequest{
+		Bucket: testBucket, Object: "restore-obj", Generation: v1.GetGeneration(),
+	})
+	if err != nil {
+		t.Fatalf("GetObject(v1): %v", err)
+	}
+	if dead.GetDeleteTime() == nil {
+		t.Fatal("expected v1 to carry a delete_time before restore")
+	}
+
+	restored, err := client.RestoreObject(ctx, &storagepb.RestoreObjectRequest{
+		Bucket: testBucket, Object: "restore-obj", Generation: v1.GetGeneration(),
+	})
+	if err != nil {
+		t.Fatalf("RestoreObject: %v", err)
+	}
+	if restored.GetGeneration() != v1.GetGeneration() {
+		t.Fatalf("RestoreObject generation = %d, want %d", restored.GetGeneration(), v1.GetGeneration())
+	}
+	if restored.GetDeleteTime() != nil {
+		t.Fatalf("RestoreObject delete_time = %v, want nil", restored.GetDeleteTime())
+	}
+
+	// v1 is the live generation again (reads resolve to it).
+	if got := readObject(t, client, testBucket, "restore-obj"); string(got) != "version-one" {
+		t.Fatalf("read after restore = %q, want version-one", got)
+	}
+	// v2 was superseded and is now non-live.
+	superseded, err := client.GetObject(ctx, &storagepb.GetObjectRequest{
+		Bucket: testBucket, Object: "restore-obj", Generation: v2.GetGeneration(),
+	})
+	if err != nil {
+		t.Fatalf("GetObject(v2): %v", err)
+	}
+	if superseded.GetDeleteTime() == nil {
+		t.Fatal("expected v2 to be non-live after restoring v1")
+	}
+
+	// Precondition mismatch on the current live generation fails without mutating.
+	stale := int64(99999999)
+	if _, err := client.RestoreObject(ctx, &storagepb.RestoreObjectRequest{
+		Bucket: testBucket, Object: "restore-obj", Generation: v2.GetGeneration(), IfGenerationMatch: &stale,
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("RestoreObject precondition err = %v, want FailedPrecondition", err)
+	}
+	if got := readObject(t, client, testBucket, "restore-obj"); string(got) != "version-one" {
+		t.Fatalf("failed restore mutated live object: %q", got)
+	}
+
+	// An unknown generation is NotFound.
+	if _, err := client.RestoreObject(ctx, &storagepb.RestoreObjectRequest{
+		Bucket: testBucket, Object: "restore-obj", Generation: v1.GetGeneration() + v2.GetGeneration() + 1,
+	}); status.Code(err) != codes.NotFound {
+		t.Fatalf("RestoreObject unknown generation err = %v, want NotFound", err)
+	}
+}
+
+func TestLockBucketRetentionPolicy(t *testing.T) {
+	client, cleanup := storageTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+
+	// No retention policy yet: lock returns NotFound.
+	if _, err := client.LockBucketRetentionPolicy(ctx, &storagepb.LockBucketRetentionPolicyRequest{
+		Bucket: testBucket, IfMetagenerationMatch: 1,
+	}); status.Code(err) != codes.NotFound {
+		t.Fatalf("lock without retention policy err = %v, want NotFound", err)
+	}
+
+	// Set an unlocked retention policy via UpdateBucket.
+	upd, err := client.UpdateBucket(ctx, &storagepb.UpdateBucketRequest{
+		Bucket: &storagepb.Bucket{
+			Name:            testBucket,
+			RetentionPolicy: &storagepb.Bucket_RetentionPolicy{RetentionDuration: durationpb.New(time.Hour)},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"retention_policy"}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBucket retention policy: %v", err)
+	}
+	if got := upd.GetRetentionPolicy().GetRetentionDuration().AsDuration(); got != time.Hour {
+		t.Fatalf("retention duration = %v, want 1h", got)
+	}
+	if upd.GetRetentionPolicy().GetIsLocked() {
+		t.Fatal("retention policy should start unlocked")
+	}
+	unlockedMeta := upd.GetMetageneration()
+
+	locked, err := client.LockBucketRetentionPolicy(ctx, &storagepb.LockBucketRetentionPolicyRequest{
+		Bucket: testBucket, IfMetagenerationMatch: unlockedMeta,
+	})
+	if err != nil {
+		t.Fatalf("LockBucketRetentionPolicy: %v", err)
+	}
+	if !locked.GetRetentionPolicy().GetIsLocked() {
+		t.Fatal("retention policy not locked after lock")
+	}
+	if locked.GetMetageneration() != unlockedMeta+1 {
+		t.Fatalf("metageneration after lock = %d, want %d", locked.GetMetageneration(), unlockedMeta+1)
+	}
+
+	// Locking again is harmless: still locked, metageneration unchanged.
+	lockedAgain, err := client.LockBucketRetentionPolicy(ctx, &storagepb.LockBucketRetentionPolicyRequest{
+		Bucket: testBucket, IfMetagenerationMatch: locked.GetMetageneration(),
+	})
+	if err != nil {
+		t.Fatalf("second LockBucketRetentionPolicy: %v", err)
+	}
+	if !lockedAgain.GetRetentionPolicy().GetIsLocked() {
+		t.Fatal("retention policy lost its lock on a second attempt")
+	}
+	if lockedAgain.GetMetageneration() != locked.GetMetageneration() {
+		t.Fatalf("second lock bumped metageneration to %d, want %d", lockedAgain.GetMetageneration(), locked.GetMetageneration())
+	}
+
+	// The precondition is enforced.
+	stale := int64(1)
+	if _, err := client.LockBucketRetentionPolicy(ctx, &storagepb.LockBucketRetentionPolicyRequest{
+		Bucket: testBucket, IfMetagenerationMatch: stale,
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("lock stale precondition err = %v, want FailedPrecondition", err)
+	}
+}
+
+func TestCancelResumableWrite(t *testing.T) {
+	client, cleanup := storageTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+	createBucket(t, client, "bucket-a", "US")
+
+	srw, err := client.StartResumableWrite(ctx, &storagepb.StartResumableWriteRequest{
+		WriteObjectSpec: &storagepb.WriteObjectSpec{
+			Resource: &storagepb.Object{Name: "cancel-me", Bucket: testBucket, ContentType: "text/plain"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartResumableWrite: %v", err)
+	}
+	uploadID := srw.GetUploadId()
+	if _, err := client.QueryWriteStatus(ctx, &storagepb.QueryWriteStatusRequest{UploadId: uploadID}); err != nil {
+		t.Fatalf("QueryWriteStatus before cancel: %v", err)
+	}
+
+	if _, err := client.CancelResumableWrite(ctx, &storagepb.CancelResumableWriteRequest{UploadId: uploadID}); err != nil {
+		t.Fatalf("CancelResumableWrite: %v", err)
+	}
+	if _, err := client.QueryWriteStatus(ctx, &storagepb.QueryWriteStatusRequest{UploadId: uploadID}); status.Code(err) != codes.NotFound {
+		t.Fatalf("QueryWriteStatus after cancel err = %v, want NotFound", err)
+	}
+
+	// Idempotent for the same id and for an unknown id.
+	if _, err := client.CancelResumableWrite(ctx, &storagepb.CancelResumableWriteRequest{UploadId: uploadID}); err != nil {
+		t.Fatalf("CancelResumableWrite (idempotent): %v", err)
+	}
+	if _, err := client.CancelResumableWrite(ctx, &storagepb.CancelResumableWriteRequest{UploadId: "does-not-exist"}); err != nil {
+		t.Fatalf("CancelResumableWrite (unknown id): %v", err)
+	}
+
+	// An empty upload_id is invalid.
+	if _, err := client.CancelResumableWrite(ctx, &storagepb.CancelResumableWriteRequest{}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("CancelResumableWrite empty id err = %v, want InvalidArgument", err)
+	}
+
+	// Cancelling the id of an already-completed upload must not remove the
+	// committed object (the session is already gone by completion).
+	done, err := client.StartResumableWrite(ctx, &storagepb.StartResumableWriteRequest{
+		WriteObjectSpec: &storagepb.WriteObjectSpec{
+			Resource: &storagepb.Object{Name: "completed-obj", Bucket: testBucket, ContentType: "text/plain"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("StartResumableWrite (completed): %v", err)
+	}
+	payload := []byte("already committed")
+	stream, err := client.WriteObject(ctx)
+	if err != nil {
+		t.Fatalf("WriteObject: %v", err)
+	}
+	if err := stream.Send(&storagepb.WriteObjectRequest{
+		FirstMessage: &storagepb.WriteObjectRequest_UploadId{UploadId: done.GetUploadId()},
+		WriteOffset:  0,
+		Data:         &storagepb.WriteObjectRequest_ChecksummedData{ChecksummedData: &storagepb.ChecksummedData{Content: payload}},
+		FinishWrite:  true,
+	}); err != nil {
+		t.Fatalf("WriteObject Send: %v", err)
+	}
+	if _, err := stream.CloseAndRecv(); err != nil {
+		t.Fatalf("WriteObject CloseAndRecv: %v", err)
+	}
+	if _, err := client.CancelResumableWrite(ctx, &storagepb.CancelResumableWriteRequest{UploadId: done.GetUploadId()}); err != nil {
+		t.Fatalf("CancelResumableWrite (completed): %v", err)
+	}
+	if got := readObject(t, client, testBucket, "completed-obj"); !bytes.Equal(got, payload) {
+		t.Fatalf("completed object content = %q, want %q", got, payload)
 	}
 }

--- a/internal/gcp/store/gcs/memory.go
+++ b/internal/gcp/store/gcs/memory.go
@@ -299,6 +299,56 @@ func (s *MemoryObjectStore) GetObjectMeta(_ context.Context, bucket, name string
 	return ObjectMeta{}, ErrNoSuchObject
 }
 
+// RestoreObjectGeneration makes generation live again: the target's timeDeleted
+// is cleared and metageneration bumped, and any other live generation is marked
+// non-live (mirroring real GCS, where restoring a soft-deleted generation
+// supersedes the current live one). The precondition is validated against the
+// current live state under the same write lock.
+func (s *MemoryObjectStore) RestoreObjectGeneration(_ context.Context, bucket, name, generation string, precondition *Precondition) (ObjectMeta, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	objs, ok := s.objects[bucket]
+	if !ok {
+		return ObjectMeta{}, ErrNoSuchObject
+	}
+	gens, ok := objs[name]
+	if !ok {
+		return ObjectMeta{}, ErrNoSuchObject
+	}
+	current, exists := liveGeneration(gens)
+	if !objectPreconditionMatches(current, exists, precondition) {
+		return ObjectMeta{}, ErrPreconditionFailed
+	}
+	idx := -1
+	for i := range gens {
+		if gens[i].Generation == generation {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return ObjectMeta{}, ErrNoSuchObject
+	}
+	if gens[idx].TimeDeleted == nil {
+		// The target is already live: restore is a no-op.
+		return gens[idx], nil
+	}
+	now := clock.Now()
+	for i := range gens {
+		if gens[i].TimeDeleted == nil && gens[i].Generation != generation {
+			t := now
+			gens[i].TimeDeleted = &t
+		}
+	}
+	g := gens[idx]
+	g.TimeDeleted = nil
+	g.Metageneration = nextMetageneration(g.Metageneration)
+	g.Updated = now
+	gens[idx] = g
+	objs[name] = gens
+	return g, nil
+}
+
 func (s *MemoryObjectStore) GetObjectGeneration(_ context.Context, bucket, name, generation string) (ObjectMeta, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/internal/gcp/store/gcs/postgres.go
+++ b/internal/gcp/store/gcs/postgres.go
@@ -431,6 +431,60 @@ func (s *PostgresObjectStore) TombstoneObjectMetaChecked(ctx context.Context, bu
 	return m, nil
 }
 
+// RestoreObjectGeneration makes generation live again inside one Serializable
+// transaction: it locks the current live generation (validating precondition)
+// and the target row, marks the current live generation non-live, then clears
+// the target's time_deleted and bumps its metageneration.
+func (s *PostgresObjectStore) RestoreObjectGeneration(ctx context.Context, bucket, name, generation string, precondition *Precondition) (ObjectMeta, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return ObjectMeta{}, err
+	}
+	defer tx.Rollback(ctx)
+	current, exists, err := lockLiveGeneration(ctx, tx, bucket, name)
+	if err != nil {
+		return ObjectMeta{}, err
+	}
+	if !objectPreconditionMatches(current, exists, precondition) {
+		return ObjectMeta{}, ErrPreconditionFailed
+	}
+	row := tx.QueryRow(ctx, `
+		SELECT `+objectCols+`
+		FROM jc_gcs_objects WHERE bucket=$1 AND name=$2 AND generation=$3
+		FOR UPDATE
+	`, bucket, name, generation)
+	target, err := scanObject(row.Scan)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ObjectMeta{}, ErrNoSuchObject
+	}
+	if err != nil {
+		return ObjectMeta{}, err
+	}
+	if target.TimeDeleted == nil {
+		// The target is already live: restore is a no-op.
+		return target, nil
+	}
+	now := clock.Now()
+	if _, err := tx.Exec(ctx, `
+		UPDATE jc_gcs_objects SET time_deleted=$3 WHERE bucket=$1 AND name=$2 AND time_deleted IS NULL
+	`, bucket, name, now); err != nil {
+		return ObjectMeta{}, err
+	}
+	target.Metageneration = nextMetageneration(target.Metageneration)
+	if _, err := tx.Exec(ctx, `
+		UPDATE jc_gcs_objects SET time_deleted=NULL, updated=$3, metageneration=$4
+		WHERE bucket=$1 AND name=$2 AND generation=$5
+	`, bucket, name, now, target.Metageneration, generation); err != nil {
+		return ObjectMeta{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ObjectMeta{}, err
+	}
+	target.TimeDeleted = nil
+	target.Updated = now
+	return target, nil
+}
+
 func (s *PostgresObjectStore) GetObjectMeta(ctx context.Context, bucket, name string) (ObjectMeta, error) {
 	row := s.pool.QueryRow(ctx, `
 		SELECT `+objectCols+`

--- a/internal/gcp/store/gcs/store.go
+++ b/internal/gcp/store/gcs/store.go
@@ -48,6 +48,16 @@ func normalizeBucketMeta(meta map[string]any) {
 	}
 }
 
+// nextMetageneration increments a metageneration string ("N" → "N+1",
+// defaulting a missing/invalid value to "1").
+func nextMetageneration(m string) string {
+	n, err := strconv.Atoi(m)
+	if err != nil {
+		return "1"
+	}
+	return strconv.Itoa(n + 1)
+}
+
 // BucketMetagenerationMatches reports whether p is satisfied by the bucket's
 // current metageneration. Buckets have no generation dimension, so only
 // MetagenerationMatch/MetagenerationNotMatch are consulted; a nil p matches,
@@ -215,6 +225,15 @@ type ObjectStore interface {
 	// and returns it, leaving any prior non-live generations untouched. Used
 	// for versioned-object deletion so a non-live tombstone is retained.
 	TombstoneObjectMeta(ctx context.Context, bucket, name string) (ObjectMeta, error)
+	// RestoreObjectGeneration makes the given (tombstoned) generation the live
+	// generation: the current live generation, if any, is marked non-live
+	// (timeDeleted set) and the target generation's timeDeleted is cleared. The
+	// precondition (if non-nil) is validated against the current live-generation
+	// state atomically with the mutation. Returns ErrNoSuchObject when the
+	// target generation does not exist and ErrPreconditionFailed — without
+	// applying the mutation — on a mismatch. If the target is already live the
+	// call is a no-op and returns it unchanged.
+	RestoreObjectGeneration(ctx context.Context, bucket, name, generation string, precondition *Precondition) (ObjectMeta, error)
 
 	// PutObjectMetaChecked/PutObjectGenerationChecked/DeleteObjectMetaChecked/
 	// TombstoneObjectMetaChecked mirror their unchecked counterparts above,


### PR DESCRIPTION
Closes the remaining GCS gRPC v2 methods in `gcp-deferred-debt-plan.md` §3.5: **UpdateBucket** (mask + metageneration precondition, via the shared `UpdateBucketMetaAtomic`), **RestoreObject** (restore a tombstoned generation live, atomic + preconditions; new store `RestoreObjectGeneration`), **LockBucketRetentionPolicy** (permanent `isLocked`, idempotent), **CancelResumableWrite** (delete session, idempotent, never touches a committed object). Only **`BidiReadObject`** remains `Unimplemented` (streaming read; documented in the package doc + README). Verified: build/vet/race/full-suite/gofmt clean.