### PR TITLE
fix(gcp): IAM etag-OCC surfaces ABORTED + Dataproc job substate

### DIFF
--- a/internal/gcp/grpc/iam_test.go
+++ b/internal/gcp/grpc/iam_test.go
@@ -7,6 +7,9 @@ import (
 
 	iampb "cloud.google.com/go/iam/apiv1/iampb"
 
+	"jaiscloud/internal/gcp/policy"
+	"jaiscloud/internal/store"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -52,5 +55,29 @@ func TestIAMRouterDispatchesByOwnership(t *testing.T) {
 	// An unrecognized resource is rejected.
 	if _, err := router.GetIamPolicy(ctx, &iampb.GetIamPolicyRequest{Resource: "projects/p/secrets/s"}); status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("GetIamPolicy unknown err = %v, want InvalidArgument", err)
+	}
+}
+
+// TestSharedIAMPolicyEtagMismatchMapsToAborted locks in the etag-OCC contract
+// for the shared IAM policy envelope: a stale-etag setIamPolicy is google.rpc
+// ABORTED on the gRPC path, not an incidental mapping through the HTTP 409
+// fallback.
+func TestSharedIAMPolicyEtagMismatchMapsToAborted(t *testing.T) {
+	ctx := context.Background()
+	s := store.NewMemoryResourceStore()
+
+	if _, err := policy.Set(ctx, s, "proj", "gcp_topic_policy", "t1", map[string]any{
+		"policy": map[string]any{"bindings": []any{}},
+	}); err != nil {
+		t.Fatalf("seed policy: %v", err)
+	}
+	_, err := policy.Set(ctx, s, "proj", "gcp_topic_policy", "t1", map[string]any{
+		"policy": map[string]any{"etag": "stale", "bindings": []any{}},
+	})
+	if err == nil {
+		t.Fatal("expected etag-mismatch error")
+	}
+	if got := status.Code(GRPCStatus(err)); got != codes.Aborted {
+		t.Fatalf("GRPCStatus(etag mismatch) = %v, want Aborted", got)
 	}
 }

--- a/internal/gcp/policy/policy.go
+++ b/internal/gcp/policy/policy.go
@@ -46,7 +46,19 @@ func Load(ctx context.Context, s store.ResourceStore, account, resourceType, id 
 
 // errEtagMismatch aborts Set's UpsertAtomic mutate callback without writing,
 // distinguishing an etag-precondition failure from a genuine storage error.
-var errEtagMismatch = model.NewProviderError("Conflict", "etag mismatch: optimistic concurrency control failed", 409)
+//
+// A stale IAM policy etag is google.rpc.ABORTED: real Cloud IAM's setIamPolicy
+// fails a stale-etag write with ABORTED, not a generic 409. Status is set
+// explicitly so the gRPC mapping is intentional rather than incidental via
+// httpToCode(409) (and the REST envelope reports "ABORTED" instead of the
+// generic 409 "ALREADY_EXISTS"). HTTP stays 409 — ABORTED → 409 is correct
+// on the REST path. Scoped to the etag-OCC sentinel; other 409s are untouched.
+var errEtagMismatch = &model.ProviderError{
+	Code:       "Aborted",
+	Message:    "etag mismatch: optimistic concurrency control failed",
+	HTTPStatus: 409,
+	Status:     "ABORTED",
+}
 
 // Set stores a policy for a resource, enforcing etag OCC. body is the parsed
 // request JSON — either the Policy fields directly, or wrapped in a "policy"

--- a/internal/gcp/provider/dataproc/dataproc.go
+++ b/internal/gcp/provider/dataproc/dataproc.go
@@ -308,6 +308,16 @@ func clusterToMap(c dataprocstore.Cluster) map[string]any {
 	return out
 }
 
+// substateRunning is the dataproc.v1.JobStatus.Substate rendered while a job is
+// non-terminal. The emulator hands a submitted job straight to the executor and
+// its only live state is RUNNING, so it reports the real QUEUED substate
+// ("the Job has been received and is awaiting execution"; dataproc.v1 documents
+// QUEUED as applying to RUNNING). The other defined substates (SUBMITTED,
+// STALE_STATUS) describe agent hand-off/staleness the emulator does not model,
+// and terminal jobs omit substate entirely because every defined substate
+// applies only to RUNNING.
+const substateRunning = "QUEUED"
+
 func jobStatusMap(s dataprocstore.JobStatus) map[string]any {
 	out := map[string]any{
 		"state":          s.State,
@@ -315,6 +325,11 @@ func jobStatusMap(s dataprocstore.JobStatus) map[string]any {
 	}
 	if s.Details != "" {
 		out["details"] = s.Details
+	}
+	// substate is an enum-valued field in dataproc.v1.JobStatus; proto3 JSON
+	// omits it at its default (UNSPECIFIED), so only render a set value.
+	if s.Substate != "" {
+		out["substate"] = s.Substate
 	}
 	return out
 }

--- a/internal/gcp/provider/dataproc/dataproc_test.go
+++ b/internal/gcp/provider/dataproc/dataproc_test.go
@@ -514,3 +514,78 @@ func TestOperationTTLSweep(t *testing.T) {
 		t.Fatalf("fresh op should remain, got %v", err)
 	}
 }
+
+// TestJobSubstateRunning verifies the dataproc.v1 JobStatus.substate field: a
+// submitted/non-terminal job carries the real QUEUED substate, both in the
+// stored JobStatus and in the rendered job response.
+func TestJobSubstateRunning(t *testing.T) {
+	p := newProvider(t)
+	ctx := context.Background()
+
+	j, err := jobToStore(testNR(map[string]any{}), map[string]any{
+		"placement":  map[string]any{"clusterName": "c1"},
+		"pysparkJob": map[string]any{"mainPythonFileUri": "gs://b/main.py"},
+	}, "us-central1")
+	if err != nil {
+		t.Fatalf("jobToStore: %v", err)
+	}
+	if j.Status.State != "RUNNING" || j.Status.Substate != "QUEUED" {
+		t.Fatalf("submitted job status = %+v, want RUNNING/QUEUED", j.Status)
+	}
+	if got := jobStatusMap(j.Status)["substate"]; got != "QUEUED" {
+		t.Fatalf("rendered substate = %v, want QUEUED", got)
+	}
+
+	if err := p.store.CreateJob(ctx, "proj", "us-central1", j); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	resp, err := p.GetJob(ctx, testNR(map[string]any{"region": "us-central1", "jobId": j.JobID}))
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	status, _ := resp.Data["status"].(map[string]any)
+	if status["substate"] != "QUEUED" {
+		t.Fatalf("GetJob status.substate = %v, want QUEUED", status["substate"])
+	}
+}
+
+// TestJobSubstateTerminalOmitted verifies a terminal job response omits
+// substate (every defined dataproc.v1 substate applies only to RUNNING) while
+// the RUNNING entry retained in statusHistory keeps QUEUED.
+func TestJobSubstateTerminalOmitted(t *testing.T) {
+	p := newProvider(t)
+	ctx := context.Background()
+	if _, err := p.CreateCluster(ctx, testNR(map[string]any{
+		"region": "us-central1",
+		"body":   map[string]any{"projectId": "proj", "clusterName": "c1"},
+	})); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+	resp, err := p.SubmitJob(ctx, testNR(map[string]any{
+		"region": "us-central1",
+		"body": map[string]any{
+			"job": map[string]any{
+				"reference":  map[string]any{"projectId": "proj", "jobId": "j-sub"},
+				"placement":  map[string]any{"clusterName": "c1"},
+				"pysparkJob": map[string]any{"mainPythonFileUri": "gs://b/main.py"},
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("SubmitJob: %v", err)
+	}
+	status, _ := resp.Data["status"].(map[string]any)
+	if status["state"] != "DONE" {
+		t.Fatalf("expected DONE, got %v", status["state"])
+	}
+	if _, ok := status["substate"]; ok {
+		t.Fatalf("terminal job status must omit substate, got %v", status)
+	}
+	history, _ := resp.Data["statusHistory"].([]any)
+	if len(history) == 0 {
+		t.Fatalf("expected a RUNNING statusHistory entry, got %v", resp.Data["statusHistory"])
+	}
+	if h0, _ := history[0].(map[string]any); h0["substate"] != "QUEUED" {
+		t.Fatalf("history RUNNING entry substate = %v, want QUEUED", h0["substate"])
+	}
+}

--- a/internal/gcp/provider/dataproc/jobs.go
+++ b/internal/gcp/provider/dataproc/jobs.go
@@ -78,8 +78,8 @@ func (p *Provider) submitJob(ctx context.Context, nr *model.NormalizedRequest) (
 	// Mock mode: complete synchronously (no goroutine). K8s mode: run for real.
 	if p.k8sClient == nil {
 		now := clock.Now().UTC()
+		j.StatusHistory = append(j.StatusHistory, j.Status)
 		j.Status = dataprocstore.JobStatus{State: "DONE", StateStartTime: now}
-		j.StatusHistory = append(j.StatusHistory, dataprocstore.JobStatus{State: "RUNNING", StateStartTime: j.CreateTime})
 		j.DriverOutputResourceURI = "gs://jaiscloud-dataproc/" + j.JobUUID + "/driveroutput"
 		if err := p.store.UpdateJob(ctx, nr.AccountID, region, j); err != nil {
 			slog.Warn("dataproc: mock SubmitJob update failed", "job", j.JobID, "err", err)

--- a/internal/gcp/provider/dataproc/jobtypes.go
+++ b/internal/gcp/provider/dataproc/jobtypes.go
@@ -109,7 +109,7 @@ func jobToStore(nr *model.NormalizedRequest, jobBody map[string]any, region stri
 		PlacementClusterName: clusterName,
 		Type:                 jobType,
 		Labels:               bodyStringMap(jobBody, "labels"),
-		Status:               dataprocstore.JobStatus{State: "RUNNING", StateStartTime: now},
+		Status:               dataprocstore.JobStatus{State: "RUNNING", StateStartTime: now, Substate: substateRunning},
 		JobUUID:              randomHex(32),
 		CreateTime:           now,
 	}

--- a/internal/gcp/provider/iam/iam_extra_test.go
+++ b/internal/gcp/provider/iam/iam_extra_test.go
@@ -90,11 +90,19 @@ func TestIAMNegativesPaginationAndOCC(t *testing.T) {
 		t.Errorf("expected requestedPolicyVersion 3, got %v", pol.Data["version"])
 	}
 
-	// setIamPolicy etag OCC: mismatch → 409.
+	// setIamPolicy etag OCC: mismatch → HTTP 409 / google.rpc ABORTED.
 	bindings := []any{map[string]any{"role": "roles/iam.serviceAccountUser", "members": []any{"allUsers"}}}
 	nr = newNR(map[string]any{"name": "serviceAccounts/" + email, "body": map[string]any{"bindings": bindings, "etag": "BOGUS="}})
-	if _, err := p.SetIamPolicy(ctx, nr); err == nil || errStatus(err) != 409 {
+	_, err = p.SetIamPolicy(ctx, nr)
+	if err == nil || errStatus(err) != 409 {
 		t.Fatalf("expected 409 on etag mismatch, got %v", err)
+	}
+	pe, ok := err.(*model.ProviderError)
+	if !ok {
+		t.Fatalf("expected *model.ProviderError, got %T", err)
+	}
+	if pe.Code != "Aborted" || pe.Status != "ABORTED" {
+		t.Fatalf("expected Code Aborted / Status ABORTED on etag mismatch, got Code=%q Status=%q", pe.Code, pe.Status)
 	}
 
 	// No etag → accepted, and a fresh etag is stored.

--- a/internal/gcp/store/dataproc/store.go
+++ b/internal/gcp/store/dataproc/store.go
@@ -50,6 +50,10 @@ type JobStatus struct {
 	State          string    `json:"state"` // DONE|RUNNING|ERROR|CANCELLED|PENDING
 	Details        string    `json:"details,omitempty"`
 	StateStartTime time.Time `json:"stateStartTime,omitempty"`
+	// Substate is the agent-reported progress substate (SUBMITTED|QUEUED|
+	// STALE_STATUS). Per dataproc.v1.JobStatus every defined substate applies to
+	// RUNNING; terminal states carry none.
+	Substate string `json:"substate,omitempty"`
 }
 
 // Job is a Dataproc job. Type is the oneof field name (sparkJob, pysparkJob,


### PR DESCRIPTION
Two small fidelity fixes. (1) **IAM etag-OCC → ABORTED**: the shared policy sentinel (`internal/gcp/policy`) was `Conflict`/409, which mapped to `ABORTED` only incidentally via `httpToCode(409)` on gRPC and rendered `ALREADY_EXISTS` on REST; it now carries `Status: "ABORTED"` explicitly (scoped to etag-OCC — all other 409s untouched). (2) **Dataproc job `status.substate`**: rendered `QUEUED` while `RUNNING` (the only real proto value applicable), omitted when terminal. Verified: build/vet/race/full-suite/gofmt/paginationcheck clean.