### PR TITLE
fix(gcp): decode gzip request bodies in the REST adapter

### DIFF
--- a/internal/gcp/adapter/gcp.go
+++ b/internal/gcp/adapter/gcp.go
@@ -7,8 +7,12 @@
 package gcp
 
 import (
+	"bytes"
+	"compress/gzip"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 
 	"jaiscloud/internal/adapter"
 	"jaiscloud/internal/gcp/identity"
@@ -70,6 +74,10 @@ func (a *GCPAdapter) ServiceToProvider(service string) string {
 // DetectAndDecode implements adapter.CloudAdapter.
 // Identifies the service from the URL path, selects the codec, and decodes.
 func (a *GCPAdapter) DetectAndDecode(r *http.Request, body []byte) (*model.NormalizedRequest, adapter.Codec, error) {
+	body, err := decodeGzippedBody(r, body)
+	if err != nil {
+		return nil, nil, err
+	}
 	service, source := DetectService(r)
 	if service == "" {
 		return nil, nil, model.NewProviderError("UnknownService", "cannot detect target GCP service", 404)
@@ -85,6 +93,73 @@ func (a *GCPAdapter) DetectAndDecode(r *http.Request, body []byte) (*model.Norma
 		return nil, codec, err
 	}
 	return nr, codec, nil
+}
+
+// decodeGzippedBody transparently decompresses a request whose
+// Content-Encoding is gzip. Google's JSON APIs accept gzip request bodies, and
+// the official SDKs rely on it: the Java google-http-client enables gzip by
+// default for every request body, so GCS bucket/object metadata writes,
+// multipart uploads and BigQuery jobs all arrive gzip-encoded. Without this a
+// JSON body fails to parse ("malformed JSON body", 400).
+//
+// GCS media uploads (uploadType=media) are deliberately excluded: there
+// Content-Encoding describes the stored object's own encoding (transcoding),
+// not the transport, so the bytes must reach the provider untouched.
+//
+// For non-streaming requests the decoded bytes are returned; for streaming
+// requests (e.g. multipart/related uploads) the request body is wrapped so the
+// codec reads decompressed bytes while Close still closes the original body.
+func decodeGzippedBody(r *http.Request, body []byte) ([]byte, error) {
+	if !strings.Contains(strings.ToLower(r.Header.Get("Content-Encoding")), "gzip") {
+		return body, nil
+	}
+	if r.URL.Query().Get("uploadType") == "media" {
+		return body, nil
+	}
+	r.Header.Del("Content-Encoding")
+
+	// Non-streaming: the gateway already buffered the body.
+	if body != nil {
+		if len(body) == 0 {
+			return body, nil
+		}
+		zr, err := gzip.NewReader(bytes.NewReader(body))
+		if err != nil {
+			return nil, model.NewProviderError("InvalidRequest", "malformed gzip request body", 400)
+		}
+		defer zr.Close()
+		out, err := io.ReadAll(zr)
+		if err != nil {
+			return nil, model.NewProviderError("InvalidRequest", "malformed gzip request body", 400)
+		}
+		return out, nil
+	}
+
+	// Streaming: leave r.Body readable by the codec, decompressed.
+	if r.Body != nil {
+		zr, err := gzip.NewReader(r.Body)
+		if err != nil {
+			return nil, model.NewProviderError("InvalidRequest", "malformed gzip request body", 400)
+		}
+		r.Body = &gzipBody{Reader: zr, underlying: r.Body}
+		r.ContentLength = -1
+	}
+	return body, nil
+}
+
+// gzipBody adapts a gzip.Reader over an underlying request body so closing it
+// releases both (gzip.Reader.Close does not close its source).
+type gzipBody struct {
+	*gzip.Reader
+	underlying io.ReadCloser
+}
+
+func (g *gzipBody) Close() error {
+	err := g.Reader.Close()
+	if cerr := g.underlying.Close(); err == nil {
+		err = cerr
+	}
+	return err
 }
 
 // EnrichRequest implements adapter.CloudAdapter.

--- a/internal/gcp/adapter/gcp_test.go
+++ b/internal/gcp/adapter/gcp_test.go
@@ -1,6 +1,8 @@
 package gcp_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -8,6 +10,88 @@ import (
 	"jaiscloud/internal/gcp/adapter"
 	"jaiscloud/internal/model"
 )
+
+func gzipBytes(t *testing.T, b []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := zw.Write(b); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestGCPAdapter_GzipJSONBody(t *testing.T) {
+	a := gcp.New()
+	payload := []byte(`{"name":"gzip-bucket"}`)
+	r := httptest.NewRequest("POST", "/storage/v1/b?project=test-project", bytes.NewReader(payload))
+	r.Header.Set("Content-Encoding", "gzip")
+
+	nr, _, err := a.DetectAndDecode(r, gzipBytes(t, payload))
+	if err != nil {
+		t.Fatalf("DetectAndDecode: %v", err)
+	}
+	body, ok := nr.Params["body"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected decoded JSON body, got %#v", nr.Params["body"])
+	}
+	if body["name"] != "gzip-bucket" {
+		t.Errorf("expected name gzip-bucket, got %v", body["name"])
+	}
+	if got := r.Header.Get("Content-Encoding"); got != "" {
+		t.Errorf("expected transport Content-Encoding cleared, got %q", got)
+	}
+}
+
+func TestGCPAdapter_GzipMediaUploadNotDecoded(t *testing.T) {
+	a := gcp.New()
+	r := httptest.NewRequest("POST", "/upload/storage/v1/b/bkt/o?uploadType=media", nil)
+	r.Header.Set("Content-Encoding", "gzip")
+
+	// uploadType=media treats Content-Encoding as the object's own encoding, so
+	// the body must be left untouched and the header preserved.
+	_, _, _ = a.DetectAndDecode(r, gzipBytes(t, []byte("object bytes")))
+	if got := r.Header.Get("Content-Encoding"); got != "gzip" {
+		t.Errorf("expected media Content-Encoding preserved, got %q", got)
+	}
+}
+
+func TestGCPAdapter_GzipMalformedBody(t *testing.T) {
+	a := gcp.New()
+	r := httptest.NewRequest("POST", "/storage/v1/b?project=test-project", nil)
+	r.Header.Set("Content-Encoding", "gzip")
+
+	_, _, err := a.DetectAndDecode(r, []byte("not actually gzip"))
+	if err == nil {
+		t.Fatal("expected malformed gzip error")
+	}
+	pe, ok := err.(*model.ProviderError)
+	if !ok {
+		t.Fatalf("expected *model.ProviderError, got %T (%v)", err, err)
+	}
+	if pe.HTTPStatus != 400 {
+		t.Errorf("expected 400, got %d", pe.HTTPStatus)
+	}
+}
+
+func TestGCPAdapter_GzipStreamingMultipartWrapped(t *testing.T) {
+	a := gcp.New()
+	r := httptest.NewRequest("POST", "/upload/storage/v1/b/bkt/o?uploadType=multipart", bytes.NewReader(gzipBytes(t, []byte("x"))))
+	r.Header.Set("Content-Encoding", "gzip")
+
+	// The codec may reject the tiny body, but the transport must already be
+	// unwrapped: header cleared and length unknown.
+	_, _, _ = a.DetectAndDecode(r, nil)
+	if got := r.Header.Get("Content-Encoding"); got != "" {
+		t.Errorf("expected multipart Content-Encoding cleared, got %q", got)
+	}
+	if r.ContentLength != -1 {
+		t.Errorf("expected ContentLength -1 for streamed body, got %d", r.ContentLength)
+	}
+}
 
 func TestGCPAdapter_Cloud(t *testing.T) {
 	a := gcp.New()


### PR DESCRIPTION
## Description

Blocker parity gap from the GCP compatibility audit (`plan_docs/gcp-floci-compat-results.md`):
jaiscloud rejected gzip-encoded request bodies with `400 malformed JSON body`.

Google's JSON APIs accept `Content-Encoding: gzip` request bodies, and the official SDKs rely
on it — the Java `google-http-client` enables gzip by default for every request body
(`AbstractGoogleClientRequest` / `HttpRequest`). That single gap cascaded through most Java GCS
and BigQuery tests, and gzip-wrapped multipart uploads failed with
`multipart body missing media part`.

## What's in this PR

- `internal/gcp/adapter/gcp.go`
  - New `decodeGzippedBody`, called at the top of `DetectAndDecode` (GCP-only path, so the AWS
    binary is unaffected).
  - Non-streaming request bodies are decompressed in place before codec dispatch.
  - Streaming bodies (`uploadType=multipart`) are wrapped so the codec reads decompressed bytes,
    while `Close` still closes the original request body.
  - `uploadType=media` is deliberately excluded: there `Content-Encoding` describes the stored
    object's own encoding (transcoding), not the transport.
  - A malformed gzip body returns `400 InvalidRequest`, and the transport
    `Content-Encoding` header is cleared so it is not mistaken for object metadata.
- `internal/gcp/adapter/gcp_test.go` — tests for gzip JSON decode, media exclusion, malformed
  gzip, and the streaming wrap.

## Out of scope

- The other blocker, Pub/Sub fan-out (separate workstream).
- GCS multipart boundary leniency for unquoted `=` boundaries (minor, tracked in
  `plan_docs/gcp-parity-gaps-plan.md` as G9).
- Other verified gaps (secret-manager version state, KMS destroyed-version, subscription
  filters, GCS `copyTo`, ...).

## How to test

```bash
go build ./... && go vet ./internal/gcp/... ./cmd/jaiscloud-gcp/ && gofmt -l internal/gcp/
go test ./internal/gcp/...
```

End-to-end (gzipped bucket insert through the real HTTP stack):

```bash
./jaiscloud-gcp start --port 18080 --grpc-port 18081 --ephemeral &
printf '{"name":"gzip-bkt"}' | gzip | curl -s -X POST \
  'http://localhost:18080/storage/v1/b?project=test-project' \
  -H 'Content-Type: application/json; charset=UTF-8' \
  -H 'Content-Encoding: gzip' --data-binary @-
# -> 200 {"name":"gzip-bkt",...}
```

Against the floci Java suite this unblocks the GCS classes (every `setUp` bucket create was
400ing). The audit's `portmux` single-endpoint workaround is still needed for the Java suite's
gRPC services (tracked separately).

## Test report

- `go test ./internal/gcp/...` — all packages pass.
- `go vet` clean; `gofmt -l` empty.
- New adapter tests: `TestGCPAdapter_GzipJSONBody`, `TestGCPAdapter_GzipMediaUploadNotDecoded`,
  `TestGCPAdapter_GzipMalformedBody`, `TestGCPAdapter_GzipStreamingMultipartWrapped`.
- Manual gzip bucket insert: HTTP 200, bucket listed (see "How to test").

## Conformance audit

- Real GCS/BigQuery JSON APIs accept gzip request bodies; the Java `google-http-client` sends
  them by default. Source: `google-api-java-client` `AbstractGoogleClientRequest` and
  `google-http-client` `HttpRequest` (gzip enabled unless disabled), and the service Discovery
  Documents (`https://storage.googleapis.com/$discovery/rest?version=v1`).
- `uploadType=media` exclusion matches GCS transcoding semantics: `Content-Encoding` on a media
  upload is the object's encoding, not transport compression
  (https://cloud.google.com/storage/docs/transcoding).
