### PR TITLE
fix(gcp/pubsub): fan out published messages to every subscription

### DIFF
--- a/internal/gcp/grpc/pubsub/service.go
+++ b/internal/gcp/grpc/pubsub/service.go
@@ -243,12 +243,22 @@ func (s *Service) Publish(ctx context.Context, req *pubsubpb.PublishRequest) (*p
 		if ok := m.GetOrderingKey(); ok != "" {
 			msg.OrderingKey = ok
 		}
-		if err := s.messages.Put(ctx, msg); err != nil {
-			return nil, mapError(err)
-		}
 		stored = append(stored, msg)
 		plainData = append(plainData, base64.StdEncoding.EncodeToString(m.GetData()))
 		ids = append(ids, id)
+	}
+
+	// Fan out: a copy per pull subscription so every subscription receives
+	// every message with independent delivery/ack state.
+	subIDs := s.pullSubscriptionIDs(ctx, project, t)
+	for _, msg := range stored {
+		for _, sid := range subIDs {
+			copy := msg
+			copy.Subscription = sid
+			if err := s.messages.Put(ctx, copy); err != nil {
+				return nil, mapError(err)
+			}
+		}
 	}
 
 	topicFull := topicName(project, t)
@@ -435,15 +445,15 @@ func (s *Service) Pull(ctx context.Context, req *pubsubpb.PullRequest) (*pubsubp
 
 	var msgs []pubsubstore.Message
 	if req.GetReturnImmediately() {
-		msgs, err = s.messages.Pull(ctx, topicID, maxMsgs, ackDeadline, retention, clock.Now())
+		msgs, err = s.messages.Pull(ctx, sub, maxMsgs, ackDeadline, retention, clock.Now())
 	} else {
-		msgs, err = s.longPoll(ctx, topicID, maxMsgs, ackDeadline, retention)
+		msgs, err = s.longPoll(ctx, sub, maxMsgs, ackDeadline, retention)
 	}
 	if err != nil {
 		return nil, mapError(err)
 	}
 
-	received, err := s.buildReceivedMessages(ctx, project, topicID, dlqTopic, maxDeliveryAttempts, msgs)
+	received, err := s.buildReceivedMessages(ctx, project, sub, dlqTopic, maxDeliveryAttempts, msgs)
 	if err != nil {
 		return nil, err
 	}
@@ -453,18 +463,20 @@ func (s *Service) Pull(ctx context.Context, req *pubsubpb.PullRequest) (*pubsubp
 // buildReceivedMessages transcodes claimed messages into wire ReceivedMessages,
 // applying DLQ republish + envelope decryption. Shared by Pull and StreamingPull
 // so both transports emit the same ack-id scheme and payload shape.
-func (s *Service) buildReceivedMessages(ctx context.Context, project, topicID, dlqTopic string, maxDeliveryAttempts int, msgs []pubsubstore.Message) ([]*pubsubpb.ReceivedMessage, error) {
+func (s *Service) buildReceivedMessages(ctx context.Context, project, queue, dlqTopic string, maxDeliveryAttempts int, msgs []pubsubstore.Message) ([]*pubsubpb.ReceivedMessage, error) {
 	received := make([]*pubsubpb.ReceivedMessage, 0, len(msgs))
 	for _, m := range msgs {
 		// DLQ: once delivery attempts exceed maxDeliveryAttempts, republish to
 		// the dead-letter topic and drop the original.
 		if dlqTopic != "" && maxDeliveryAttempts > 0 && m.DeliveryAttempt > maxDeliveryAttempts {
-			_ = s.messages.Delete(ctx, topicID, m.MessageID)
-			_ = s.messages.Put(ctx, pubsubstore.Message{
-				Topic: dlqTopic, MessageID: m.MessageID, Data: m.Data, Attributes: m.Attributes,
-				PublishTime: m.PublishTime, DeliveryAttempt: 0,
-				KmsKeyName: m.KmsKeyName, WrappedDEK: m.WrappedDEK,
-			})
+			_ = s.messages.Delete(ctx, queue, m.MessageID)
+			for _, sid := range s.pullSubscriptionIDs(ctx, project, dlqTopic) {
+				_ = s.messages.Put(ctx, pubsubstore.Message{
+					Topic: dlqTopic, Subscription: sid, MessageID: m.MessageID, Data: m.Data, Attributes: m.Attributes,
+					PublishTime: m.PublishTime, DeliveryAttempt: 0,
+					KmsKeyName: m.KmsKeyName, WrappedDEK: m.WrappedDEK,
+				})
+			}
 			continue
 		}
 
@@ -494,7 +506,7 @@ func (s *Service) buildReceivedMessages(ctx context.Context, project, topicID, d
 			pm.OrderingKey = m.OrderingKey
 		}
 		received = append(received, &pubsubpb.ReceivedMessage{
-			AckId:           encodeAckID(topicID, m.MessageID),
+			AckId:           encodeAckID(queue, m.MessageID),
 			Message:         pm,
 			DeliveryAttempt: int32(m.DeliveryAttempt),
 		})
@@ -504,10 +516,10 @@ func (s *Service) buildReceivedMessages(ctx context.Context, project, topicID, d
 
 // longPoll repeatedly claims messages until at least one is deliverable or the
 // bounded window elapses.
-func (s *Service) longPoll(ctx context.Context, topicID string, maxMsgs, ackDeadline, retention int) ([]pubsubstore.Message, error) {
+func (s *Service) longPoll(ctx context.Context, queue string, maxMsgs, ackDeadline, retention int) ([]pubsubstore.Message, error) {
 	deadline := clock.Now().Add(longPollTimeout)
 	for {
-		msgs, err := s.messages.Pull(ctx, topicID, maxMsgs, ackDeadline, retention, clock.Now())
+		msgs, err := s.messages.Pull(ctx, queue, maxMsgs, ackDeadline, retention, clock.Now())
 		if err != nil {
 			return nil, err
 		}
@@ -587,10 +599,10 @@ func (s *Service) StreamingPull(stream pubsubpb.Subscriber_StreamingPullServer) 
 	flow := newStreamFlowControl(first.GetMaxOutstandingMessages(), first.GetMaxOutstandingBytes())
 
 	// Handle the initial request's control fields.
-	for _, id := range s.applyStreamAcks(ctx, topicID, first) {
+	for _, id := range s.applyStreamAcks(ctx, sub, first) {
 		flow.release(id)
 	}
-	for _, id := range s.applyStreamModifyDeadlines(ctx, topicID, first) {
+	for _, id := range s.applyStreamModifyDeadlines(ctx, sub, first) {
 		flow.release(id)
 	}
 
@@ -604,10 +616,10 @@ func (s *Service) StreamingPull(stream pubsubpb.Subscriber_StreamingPullServer) 
 				recvErr <- err
 				return
 			}
-			for _, id := range s.applyStreamAcks(ctx, topicID, r) {
+			for _, id := range s.applyStreamAcks(ctx, sub, r) {
 				flow.release(id)
 			}
-			for _, id := range s.applyStreamModifyDeadlines(ctx, topicID, r) {
+			for _, id := range s.applyStreamModifyDeadlines(ctx, sub, r) {
 				flow.release(id)
 			}
 		}
@@ -620,7 +632,7 @@ func (s *Service) StreamingPull(stream pubsubpb.Subscriber_StreamingPullServer) 
 		if budget <= 0 || flow.bytesExhausted() {
 			// At the client's limit: release any messages acked out of band
 			// (another stream / unary Acknowledge) and wait for a slot.
-			if stored, err := s.messages.List(ctx, topicID); err == nil {
+			if stored, err := s.messages.List(ctx, sub); err == nil {
 				flow.reconcile(stored)
 			}
 			if flow.claimBudget(1) <= 0 || flow.bytesExhausted() {
@@ -640,12 +652,12 @@ func (s *Service) StreamingPull(stream pubsubpb.Subscriber_StreamingPullServer) 
 			budget = flow.claimBudget(streamPullBatch)
 		}
 
-		msgs, err := s.messages.Pull(ctx, topicID, budget, ackDeadline, retention, clock.Now())
+		msgs, err := s.messages.Pull(ctx, sub, budget, ackDeadline, retention, clock.Now())
 		if err != nil {
 			return mapError(err)
 		}
 		if len(msgs) > 0 {
-			received, err := s.buildReceivedMessages(ctx, project, topicID, dlqTopic, maxDeliveryAttempts, msgs)
+			received, err := s.buildReceivedMessages(ctx, project, sub, dlqTopic, maxDeliveryAttempts, msgs)
 			if err != nil {
 				return err
 			}
@@ -663,7 +675,7 @@ func (s *Service) StreamingPull(stream pubsubpb.Subscriber_StreamingPullServer) 
 				// immediately instead of stranding it until the ack deadline.
 				if decoded, ok := decodeAckID(rm.GetAckId()); ok {
 					if parts := strings.SplitN(decoded, "/", 2); len(parts) == 2 {
-						_ = s.messages.ModifyAckDeadline(ctx, topicID, []string{decoded}, 0, clock.Now())
+						_ = s.messages.ModifyAckDeadline(ctx, sub, []string{decoded}, 0, clock.Now())
 					}
 				}
 			}
@@ -700,7 +712,7 @@ func (s *Service) StreamingPull(stream pubsubpb.Subscriber_StreamingPullServer) 
 // applyStreamAcks acknowledges the ackIds in a StreamingPull request. It returns
 // the decoded message IDs so the caller can release them from the stream's
 // outstanding flow-control set.
-func (s *Service) applyStreamAcks(ctx context.Context, topicID string, req *pubsubpb.StreamingPullRequest) []string {
+func (s *Service) applyStreamAcks(ctx context.Context, _ string, req *pubsubpb.StreamingPullRequest) []string {
 	var acked []string
 	for _, a := range req.GetAckIds() {
 		decoded, ok := decodeAckID(a)
@@ -721,7 +733,7 @@ func (s *Service) applyStreamAcks(ctx context.Context, topicID string, req *pubs
 // A deadline of 0 is a nack (immediately redeliverable), so those IDs are
 // returned for flow-control release; a positive extension keeps the message
 // outstanding.
-func (s *Service) applyStreamModifyDeadlines(ctx context.Context, topicID string, req *pubsubpb.StreamingPullRequest) []string {
+func (s *Service) applyStreamModifyDeadlines(ctx context.Context, queue string, req *pubsubpb.StreamingPullRequest) []string {
 	ackIDs := req.GetModifyDeadlineAckIds()
 	seconds := req.GetModifyDeadlineSeconds()
 	n := len(seconds)
@@ -734,7 +746,7 @@ func (s *Service) applyStreamModifyDeadlines(ctx context.Context, topicID string
 		if !ok {
 			continue
 		}
-		_ = s.messages.ModifyAckDeadline(ctx, topicID, []string{decoded}, int(seconds[i]), clock.Now())
+		_ = s.messages.ModifyAckDeadline(ctx, queue, []string{decoded}, int(seconds[i]), clock.Now())
 		if seconds[i] <= 0 {
 			if parts := strings.SplitN(decoded, "/", 2); len(parts) == 2 {
 				nacked = append(nacked, parts[1])
@@ -772,18 +784,13 @@ func (s *Service) ModifyAckDeadline(ctx context.Context, req *pubsubpb.ModifyAck
 	}
 	var meta map[string]any
 	json.Unmarshal(e.Data, &meta)
-	topic, _ := meta["topic"].(string)
-	topicID := topic
-	if i := strings.LastIndex(topicID, "/"); i >= 0 {
-		topicID = topicID[i+1:]
-	}
 	decoded := make([]string, 0, len(req.GetAckIds()))
 	for _, id := range req.GetAckIds() {
 		if d, ok := decodeAckID(id); ok {
 			decoded = append(decoded, d)
 		}
 	}
-	if err := s.messages.ModifyAckDeadline(ctx, topicID, decoded, int(req.GetAckDeadlineSeconds()), clock.Now()); err != nil {
+	if err := s.messages.ModifyAckDeadline(ctx, sub, decoded, int(req.GetAckDeadlineSeconds()), clock.Now()); err != nil {
 		return nil, mapError(err)
 	}
 	return &emptypb.Empty{}, nil
@@ -1029,6 +1036,40 @@ func decodeAckID(s string) (string, bool) {
 
 // topicRetention resolves a topic's messageRetentionDuration in seconds,
 // defaulting to GCP's 7-day default.
+// pullSubscriptionIDs returns the IDs of a topic's pull subscriptions. Push
+// subscriptions are delivered over HTTP at publish time and are not queued.
+func (s *Service) pullSubscriptionIDs(ctx context.Context, accountID, topicID string) []string {
+	entries, err := s.resources.List(ctx, accountID, store.GlobalRegion, rtSubscription, "")
+	if err != nil {
+		return nil
+	}
+	var ids []string
+	for _, e := range entries {
+		var sub map[string]any
+		if json.Unmarshal(e.Data, &sub) != nil {
+			continue
+		}
+		st, _ := sub["topic"].(string)
+		if lastSegment(st) != topicID {
+			continue
+		}
+		if pc, _ := sub["pushConfig"].(map[string]any); pc != nil {
+			if ep, _ := pc["pushEndpoint"].(string); ep != "" {
+				continue
+			}
+		}
+		ids = append(ids, e.ID)
+	}
+	return ids
+}
+
+func lastSegment(s string) string {
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}
+
 func (s *Service) topicRetention(ctx context.Context, account, topicID string) int {
 	const defaultRetentionSecs = 604800
 	e, err := s.resources.Get(ctx, account, store.GlobalRegion, rtTopic, topicID)

--- a/internal/gcp/grpc/pubsub/service_test.go
+++ b/internal/gcp/grpc/pubsub/service_test.go
@@ -92,6 +92,18 @@ func TestPubSubEndToEnd(t *testing.T) {
 		t.Fatalf("ListTopics = %v, want exactly [%s]", listed.GetTopics(), topic)
 	}
 
+	// Create the subscription before publishing (a subscription only receives
+	// messages published after it exists).
+	sub, err := subc.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name: subscription, Topic: topic, AckDeadlineSeconds: 30,
+	})
+	if err != nil {
+		t.Fatalf("CreateSubscription: %v", err)
+	}
+	if sub.GetTopic() != topic || sub.GetAckDeadlineSeconds() != 30 {
+		t.Fatalf("CreateSubscription = %+v, want topic=%s ackDeadline=30", sub, topic)
+	}
+
 	// Publish.
 	pubRes, err := pub.Publish(ctx, &pubsubpb.PublishRequest{
 		Topic: topic,
@@ -104,17 +116,6 @@ func TestPubSubEndToEnd(t *testing.T) {
 	}
 	if len(pubRes.GetMessageIds()) != 1 {
 		t.Fatalf("Publish messageIds = %v, want 1 id", pubRes.GetMessageIds())
-	}
-
-	// Create subscription.
-	sub, err := subc.CreateSubscription(ctx, &pubsubpb.Subscription{
-		Name: subscription, Topic: topic, AckDeadlineSeconds: 30,
-	})
-	if err != nil {
-		t.Fatalf("CreateSubscription: %v", err)
-	}
-	if sub.GetTopic() != topic || sub.GetAckDeadlineSeconds() != 30 {
-		t.Fatalf("CreateSubscription = %+v, want topic=%s ackDeadline=30", sub, topic)
 	}
 
 	// Pull (returnImmediately) → the published message.
@@ -431,5 +432,46 @@ func TestTestIamPermissionsFailsOpenOnMissingTopic(t *testing.T) {
 	}
 	if len(got.GetPermissions()) != 0 {
 		t.Fatalf("TestIamPermissions on missing topic = %v, want empty", got.GetPermissions())
+	}
+}
+
+// TestPubSubFanOutGRPC verifies per-subscription fan-out over gRPC: two pull
+// subscriptions of one topic both receive a copy of a published message.
+func TestPubSubFanOutGRPC(t *testing.T) {
+	pub, subc, _, _, cleanup := pubsubTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const topic = "projects/test/topics/fan-grpc"
+	if _, err := pub.CreateTopic(ctx, &pubsubpb.Topic{Name: topic}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	subs := []string{
+		"projects/test/subscriptions/fan-grpc-a",
+		"projects/test/subscriptions/fan-grpc-b",
+	}
+	for _, s := range subs {
+		if _, err := subc.CreateSubscription(ctx, &pubsubpb.Subscription{Name: s, Topic: topic, AckDeadlineSeconds: 30}); err != nil {
+			t.Fatalf("CreateSubscription %s: %v", s, err)
+		}
+	}
+	if _, err := pub.Publish(ctx, &pubsubpb.PublishRequest{
+		Topic:    topic,
+		Messages: []*pubsubpb.PubsubMessage{{Data: []byte("broadcast")}},
+	}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	for _, s := range subs {
+		pull, err := subc.Pull(ctx, &pubsubpb.PullRequest{Subscription: s, MaxMessages: 10, ReturnImmediately: true})
+		if err != nil {
+			t.Fatalf("Pull %s: %v", s, err)
+		}
+		if len(pull.GetReceivedMessages()) != 1 {
+			t.Fatalf("subscription %s: got %d messages, want 1", s, len(pull.GetReceivedMessages()))
+		}
+		if got := string(pull.GetReceivedMessages()[0].GetMessage().GetData()); got != "broadcast" {
+			t.Fatalf("subscription %s: data = %q, want broadcast", s, got)
+		}
 	}
 }

--- a/internal/gcp/provider/pubsub/pubsub.go
+++ b/internal/gcp/provider/pubsub/pubsub.go
@@ -245,12 +245,22 @@ func (p *Provider) TopicPublish(ctx context.Context, nr *model.NormalizedRequest
 		if ok, _ := mm["orderingKey"].(string); ok != "" {
 			msg.OrderingKey = ok
 		}
-		if err := p.messages.Put(ctx, msg); err != nil {
-			return nil, err
-		}
 		stored = append(stored, msg)
 		plainData = append(plainData, data)
 		ids = append(ids, id)
+	}
+
+	// Fan out: Pub/Sub delivers a copy to every pull subscription of the topic,
+	// so each subscription has an independent delivery/ack state.
+	subIDs := p.pullSubscriptionIDs(ctx, nr.AccountID, t)
+	for _, msg := range stored {
+		for _, sid := range subIDs {
+			copy := msg
+			copy.Subscription = sid
+			if err := p.messages.Put(ctx, copy); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// Push subscriptions: deliver each message to the push endpoint with the
@@ -453,9 +463,9 @@ func (p *Provider) SubscriptionPull(ctx context.Context, nr *model.NormalizedReq
 
 	var msgs []pubsubstore.Message
 	if ri {
-		msgs, err = p.messages.Pull(ctx, topicID, maxMsgs, ackDeadline, retention, clock.Now())
+		msgs, err = p.messages.Pull(ctx, s, maxMsgs, ackDeadline, retention, clock.Now())
 	} else {
-		msgs, err = p.longPoll(ctx, topicID, maxMsgs, ackDeadline, retention)
+		msgs, err = p.longPoll(ctx, s, maxMsgs, ackDeadline, retention)
 	}
 	if err != nil {
 		return nil, err
@@ -466,12 +476,14 @@ func (p *Provider) SubscriptionPull(ctx context.Context, nr *model.NormalizedReq
 		// dead-letter topic and drop the original (mirrors SQS checkDLQ, strictly
 		// greater threshold).
 		if dlqTopic != "" && maxDeliveryAttempts > 0 && m.DeliveryAttempt > maxDeliveryAttempts {
-			_ = p.messages.Delete(ctx, topicID, m.MessageID)
-			_ = p.messages.Put(ctx, pubsubstore.Message{
-				Topic: dlqTopic, MessageID: m.MessageID, Data: m.Data, Attributes: m.Attributes,
-				PublishTime: m.PublishTime, DeliveryAttempt: 0,
-				KmsKeyName: m.KmsKeyName, WrappedDEK: m.WrappedDEK,
-			})
+			_ = p.messages.Delete(ctx, s, m.MessageID)
+			for _, sid := range p.pullSubscriptionIDs(ctx, nr.AccountID, dlqTopic) {
+				_ = p.messages.Put(ctx, pubsubstore.Message{
+					Topic: dlqTopic, Subscription: sid, MessageID: m.MessageID, Data: m.Data, Attributes: m.Attributes,
+					PublishTime: m.PublishTime, DeliveryAttempt: 0,
+					KmsKeyName: m.KmsKeyName, WrappedDEK: m.WrappedDEK,
+				})
+			}
 			continue
 		}
 
@@ -502,7 +514,7 @@ func (p *Provider) SubscriptionPull(ctx context.Context, nr *model.NormalizedReq
 			msg["orderingKey"] = m.OrderingKey
 		}
 		received = append(received, map[string]any{
-			"ackId":           encodeAckID(topicID, m.MessageID),
+			"ackId":           encodeAckID(s, m.MessageID),
 			"message":         msg,
 			"deliveryAttempt": m.DeliveryAttempt,
 		})
@@ -514,10 +526,10 @@ func (p *Provider) SubscriptionPull(ctx context.Context, nr *model.NormalizedReq
 // bounded window elapses. The deadline is derived from clock.Now() (so a frozen
 // test clock yields a consistent remaining duration) while time.Sleep drives the
 // real poll cadence — the emulator's analogue of SQS WaitForMessages.
-func (p *Provider) longPoll(ctx context.Context, topicID string, maxMsgs, ackDeadline, retention int) ([]pubsubstore.Message, error) {
+func (p *Provider) longPoll(ctx context.Context, queue string, maxMsgs, ackDeadline, retention int) ([]pubsubstore.Message, error) {
 	deadline := clock.Now().Add(longPollTimeout)
 	for {
-		msgs, err := p.messages.Pull(ctx, topicID, maxMsgs, ackDeadline, retention, clock.Now())
+		msgs, err := p.messages.Pull(ctx, queue, maxMsgs, ackDeadline, retention, clock.Now())
 		if err != nil {
 			return nil, err
 		}
@@ -553,19 +565,11 @@ func (p *Provider) SubscriptionModifyAckDeadline(ctx context.Context, nr *model.
 		return nil, err
 	}
 	s := strings.TrimPrefix(name, "subscriptions/")
-	e, err := p.resources.Get(ctx, nr.AccountID, store.GlobalRegion, rtSubscription, s)
-	if err != nil {
+	if _, err = p.resources.Get(ctx, nr.AccountID, store.GlobalRegion, rtSubscription, s); err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return nil, model.NewProviderError("NotFound", "subscription not found", 404)
 		}
 		return nil, err
-	}
-	var sub map[string]any
-	json.Unmarshal(e.Data, &sub)
-	topic, _ := sub["topic"].(string)
-	topicID := topic
-	if i := strings.LastIndex(topicID, "/"); i >= 0 {
-		topicID = topicID[i+1:]
 	}
 	body, _ := nr.Params["body"].(map[string]any)
 	ackIDs := toStrings(body["ackIds"])
@@ -579,7 +583,7 @@ func (p *Provider) SubscriptionModifyAckDeadline(ctx context.Context, nr *model.
 	if ad, ok := body["ackDeadlineSeconds"].(float64); ok {
 		seconds = int(ad)
 	}
-	if err := p.messages.ModifyAckDeadline(ctx, topicID, decoded, seconds, clock.Now()); err != nil {
+	if err := p.messages.ModifyAckDeadline(ctx, s, decoded, seconds, clock.Now()); err != nil {
 		return nil, err
 	}
 	return &model.ProviderResponse{HTTPStatus: 200, Data: map[string]any{}}, nil
@@ -597,6 +601,40 @@ func decodeAckID(s string) (string, bool) {
 		return "", false
 	}
 	return string(raw), true
+}
+
+// pullSubscriptionIDs returns the IDs of a topic's pull subscriptions. Push
+// subscriptions are delivered over HTTP at publish time and are not queued.
+func (p *Provider) pullSubscriptionIDs(ctx context.Context, accountID, topicID string) []string {
+	entries, err := p.resources.List(ctx, accountID, store.GlobalRegion, rtSubscription, "")
+	if err != nil {
+		return nil
+	}
+	var ids []string
+	for _, e := range entries {
+		var sub map[string]any
+		if json.Unmarshal(e.Data, &sub) != nil {
+			continue
+		}
+		st, _ := sub["topic"].(string)
+		if lastSegment(st) != topicID {
+			continue
+		}
+		if pc, _ := sub["pushConfig"].(map[string]any); pc != nil {
+			if ep, _ := pc["pushEndpoint"].(string); ep != "" {
+				continue
+			}
+		}
+		ids = append(ids, e.ID)
+	}
+	return ids
+}
+
+func lastSegment(s string) string {
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		return s[i+1:]
+	}
+	return s
 }
 
 // topicRetention resolves a topic's messageRetentionDuration in seconds,

--- a/internal/gcp/provider/pubsub/pubsub_extra_test.go
+++ b/internal/gcp/provider/pubsub/pubsub_extra_test.go
@@ -110,6 +110,14 @@ func TestPubSubDLQ(t *testing.T) {
 	if _, err := p.SubscriptionCreate(ctx, nr); err != nil {
 		t.Fatalf("create subscription: %v", err)
 	}
+	// A subscription on the dead-letter topic so republished messages land in a
+	// queue (fan-out stores per subscription).
+	if _, err := p.SubscriptionCreate(ctx, newNR(map[string]any{
+		"name": "subscriptions/dlq-sub",
+		"body": map[string]any{"topic": "projects/proj/topics/dlq"},
+	})); err != nil {
+		t.Fatalf("create dlq subscription: %v", err)
+	}
 
 	// Publish one message.
 	if _, err := p.TopicPublish(ctx, newNR(map[string]any{
@@ -130,12 +138,12 @@ func TestPubSubDLQ(t *testing.T) {
 	// redeliver makes every message in the source topic immediately visible
 	// again, simulating the ack deadline expiring.
 	redeliver := func() {
-		msgs, _ := p.messages.List(ctx, "src")
+		msgs, _ := p.messages.List(ctx, "sub")
 		ids := make([]string, 0, len(msgs))
 		for _, m := range msgs {
-			ids = append(ids, "src/"+m.MessageID)
+			ids = append(ids, "sub/"+m.MessageID)
 		}
-		_ = p.messages.ModifyAckDeadline(ctx, "src", ids, 0, time.Now())
+		_ = p.messages.ModifyAckDeadline(ctx, "sub", ids, 0, time.Now())
 	}
 
 	if got := pull(); got != 1 {
@@ -150,10 +158,10 @@ func TestPubSubDLQ(t *testing.T) {
 		t.Fatalf("pull 3 expected 0 messages (moved to DLQ), got %d", got)
 	}
 
-	// The message now lives on the DLQ topic.
-	msgs, err := p.messages.List(ctx, "dlq")
+	// The message now lives on the DLQ topic's subscription queue.
+	msgs, err := p.messages.List(ctx, "dlq-sub")
 	if err != nil || len(msgs) != 1 {
-		t.Fatalf("expected 1 message in DLQ topic, got %d / %v", len(msgs), err)
+		t.Fatalf("expected 1 message in DLQ queue, got %d / %v", len(msgs), err)
 	}
 	// DLQ republish preserves the envelope-encrypted payload + key material;
 	// decrypt it to verify the payload round-trips.
@@ -298,5 +306,84 @@ func TestPubSubIamPolicy(t *testing.T) {
 	// 404 on missing topic.
 	if _, err := p.TopicGetIamPolicy(ctx, newNR(map[string]any{"name": "topics/missing"})); err == nil || errStatus(err) != 404 {
 		t.Fatalf("expected 404 on missing topic, got %v", err)
+	}
+}
+
+// TestPubSubFanOut verifies that every pull subscription of a topic receives a
+// copy of each published message, and that acking one subscription does not
+// affect another's copy.
+func TestPubSubFanOut(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+
+	if _, err := p.TopicCreate(ctx, newNR(map[string]any{"name": "topics/fan"})); err != nil {
+		t.Fatalf("topic create: %v", err)
+	}
+	for _, s := range []string{"fan-a", "fan-b"} {
+		if _, err := p.SubscriptionCreate(ctx, newNR(map[string]any{
+			"name": "subscriptions/" + s,
+			"body": map[string]any{"topic": "projects/proj/topics/fan"},
+		})); err != nil {
+			t.Fatalf("subscription %s: %v", s, err)
+		}
+	}
+	// Push subscriptions must not get a queued copy.
+	if _, err := p.SubscriptionCreate(ctx, newNR(map[string]any{
+		"name": "subscriptions/fan-push",
+		"body": map[string]any{
+			"topic":      "projects/proj/topics/fan",
+			"pushConfig": map[string]any{"pushEndpoint": "http://127.0.0.1:1/push"},
+		},
+	})); err != nil {
+		t.Fatalf("push subscription: %v", err)
+	}
+
+	// "broadcast"
+	if _, err := p.TopicPublish(ctx, newNR(map[string]any{
+		"name": "topics/fan",
+		"body": map[string]any{"messages": []any{map[string]any{"data": "YnJvYWRjYXN0"}}},
+	})); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	pull := func(s string) map[string]any {
+		resp, err := p.SubscriptionPull(ctx, newNR(map[string]any{
+			"name": "subscriptions/" + s,
+			"body": map[string]any{"returnImmediately": true},
+		}))
+		if err != nil {
+			t.Fatalf("pull %s: %v", s, err)
+		}
+		received, _ := resp.Data["receivedMessages"].([]any)
+		if len(received) != 1 {
+			t.Fatalf("subscription %s: expected 1 message, got %d", s, len(received))
+		}
+		return received[0].(map[string]any)
+	}
+
+	rmA := pull("fan-a")
+	rmB := pull("fan-b")
+	for _, rm := range []map[string]any{rmA, rmB} {
+		if got := rm["message"].(map[string]any)["data"]; got != "YnJvYWRjYXN0" {
+			t.Fatalf("fan-out payload = %v, want broadcast", got)
+		}
+	}
+
+	// Acking fan-a must not consume fan-b's copy.
+	if _, err := p.SubscriptionAcknowledge(ctx, newNR(map[string]any{
+		"name": "subscriptions/fan-a",
+		"body": map[string]any{"ackIds": []any{rmA["ackId"].(string)}},
+	})); err != nil {
+		t.Fatalf("ack: %v", err)
+	}
+	resp, err := p.SubscriptionPull(ctx, newNR(map[string]any{
+		"name": "subscriptions/fan-a",
+		"body": map[string]any{"returnImmediately": true},
+	}))
+	if err != nil {
+		t.Fatalf("pull acked: %v", err)
+	}
+	if received, _ := resp.Data["receivedMessages"].([]any); len(received) != 0 {
+		t.Fatalf("acked subscription still has %d messages", len(received))
 	}
 }

--- a/internal/gcp/provider/pubsub/pubsub_test.go
+++ b/internal/gcp/provider/pubsub/pubsub_test.go
@@ -34,6 +34,13 @@ func TestPubSubRoundTrip(t *testing.T) {
 		t.Fatalf("topic create: %v", err)
 	}
 
+	// Create the subscription before publishing: Pub/Sub only delivers
+	// messages published after the subscription exists.
+	nr = newNR(map[string]any{"name": "subscriptions/my-sub", "body": map[string]any{"topic": "projects/proj/topics/my-topic"}})
+	if _, err := p.SubscriptionCreate(ctx, nr); err != nil {
+		t.Fatalf("subscription create: %v", err)
+	}
+
 	// Publish.
 	nr = newNR(map[string]any{"name": "topics/my-topic", "body": map[string]any{"messages": []any{map[string]any{"data": "aGVsbG8="}}}})
 	resp, err := p.TopicPublish(ctx, nr)
@@ -43,12 +50,6 @@ func TestPubSubRoundTrip(t *testing.T) {
 	ids, _ := resp.Data["messageIds"].([]string)
 	if len(ids) != 1 {
 		t.Fatalf("expected 1 message id, got %d", len(ids))
-	}
-
-	// Create subscription.
-	nr = newNR(map[string]any{"name": "subscriptions/my-sub", "body": map[string]any{"topic": "projects/proj/topics/my-topic"}})
-	if _, err := p.SubscriptionCreate(ctx, nr); err != nil {
-		t.Fatalf("subscription create: %v", err)
 	}
 
 	// Pull.
@@ -85,12 +86,12 @@ func TestPubSubOpaqueAckID(t *testing.T) {
 	if _, err := p.TopicCreate(ctx, newNR(map[string]any{"name": "topics/t"})); err != nil {
 		t.Fatalf("topic create: %v", err)
 	}
+	if _, err := p.SubscriptionCreate(ctx, newNR(map[string]any{"name": "subscriptions/s", "body": map[string]any{"topic": "projects/proj/topics/t"}})); err != nil {
+		t.Fatalf("subscription create: %v", err)
+	}
 	nr := newNR(map[string]any{"name": "topics/t", "body": map[string]any{"messages": []any{map[string]any{"data": "aGk="}}}})
 	if _, err := p.TopicPublish(ctx, nr); err != nil {
 		t.Fatalf("publish: %v", err)
-	}
-	if _, err := p.SubscriptionCreate(ctx, newNR(map[string]any{"name": "subscriptions/s", "body": map[string]any{"topic": "projects/proj/topics/t"}})); err != nil {
-		t.Fatalf("subscription create: %v", err)
 	}
 
 	resp, err := p.SubscriptionPull(ctx, newNR(map[string]any{"name": "subscriptions/s"}))
@@ -105,16 +106,16 @@ func TestPubSubOpaqueAckID(t *testing.T) {
 	ackID, _ := rm["ackId"].(string)
 	msgID, _ := rm["message"].(map[string]any)["messageId"].(string)
 
-	// Opaque: not the raw "topicID/messageID" string.
-	if ackID == "t/"+msgID {
-		t.Errorf("ackId %q is not opaque (raw topic/messageID leaked)", ackID)
+	// Opaque: not the raw "queue/messageID" string.
+	if ackID == "s/"+msgID {
+		t.Errorf("ackId %q is not opaque (raw queue/messageID leaked)", ackID)
 	}
 	decoded, err := base64.RawURLEncoding.DecodeString(ackID)
 	if err != nil {
 		t.Fatalf("ackId is not base64url: %v", err)
 	}
-	if string(decoded) != "t/"+msgID {
-		t.Errorf("decoded ackId = %q, want t/%s", decoded, msgID)
+	if string(decoded) != "s/"+msgID {
+		t.Errorf("decoded ackId = %q, want s/%s", decoded, msgID)
 	}
 
 	// modifyAckDeadline round-trips through the opaque ackId.
@@ -224,6 +225,13 @@ func TestPubSubCMEKRoundTrip(t *testing.T) {
 		t.Fatalf("topic create: %v", err)
 	}
 
+	// Subscribe before publishing (a subscription only receives later messages).
+	nr = newNR(map[string]any{"name": "subscriptions/cmek-sub", "body": map[string]any{"topic": "projects/" + projectID + "/topics/cmek-topic"}})
+	nr.AccountID = projectID
+	if _, err := p.SubscriptionCreate(ctx, nr); err != nil {
+		t.Fatalf("subscription create: %v", err)
+	}
+
 	// Publish a message.
 	payload := "aGVsbG8sIHdvcmxk" // base64 "hello, world"
 	nr = newNR(map[string]any{"name": "topics/cmek-topic", "body": map[string]any{"messages": []any{map[string]any{"data": payload}}}})
@@ -232,12 +240,6 @@ func TestPubSubCMEKRoundTrip(t *testing.T) {
 		t.Fatalf("publish: %v", err)
 	}
 
-	// Subscribe and pull; the payload must decrypt back to the original.
-	nr = newNR(map[string]any{"name": "subscriptions/cmek-sub", "body": map[string]any{"topic": "projects/" + projectID + "/topics/cmek-topic"}})
-	nr.AccountID = projectID
-	if _, err := p.SubscriptionCreate(ctx, nr); err != nil {
-		t.Fatalf("subscription create: %v", err)
-	}
 	nr = newNR(map[string]any{"name": "subscriptions/cmek-sub"})
 	nr.AccountID = projectID
 	resp, err := p.SubscriptionPull(ctx, nr)

--- a/internal/gcp/store/migrations/038_pubsub_fanout.sql
+++ b/internal/gcp/store/migrations/038_pubsub_fanout.sql
@@ -1,0 +1,14 @@
+-- Pub/Sub fan-out: messages are stored per subscription (a copy per pull
+-- subscription) rather than once per topic, so every subscription receives
+-- every message. Key rows by subscription; keep the logical topic for
+-- display/snapshot fidelity.
+ALTER TABLE jc_pubsub_messages ADD COLUMN IF NOT EXISTS subscription TEXT NOT NULL DEFAULT '';
+
+-- Backfill legacy topic-keyed rows so they keep a stable key.
+UPDATE jc_pubsub_messages SET subscription = topic WHERE subscription = '';
+
+ALTER TABLE jc_pubsub_messages DROP CONSTRAINT IF EXISTS jc_pubsub_messages_pkey;
+ALTER TABLE jc_pubsub_messages ADD PRIMARY KEY (subscription, message_id);
+
+CREATE INDEX IF NOT EXISTS idx_pubsub_messages_subscription
+    ON jc_pubsub_messages (subscription, publish_time);

--- a/internal/gcp/store/pubsub/memory.go
+++ b/internal/gcp/store/pubsub/memory.go
@@ -13,13 +13,13 @@ import (
 // MemoryMessages is an in-memory Messages store.
 type MemoryMessages struct {
 	mu       sync.RWMutex
-	messages map[string]map[string]Message // topic → messageID → message
-	// sortedIDs caches, per topic, message IDs in ascending PublishTime order.
-	// Put/Delete invalidate a topic's entry (they change membership/order);
+	messages map[string]map[string]Message // queue (subscription ID) → messageID → message
+	// sortedIDs caches, per queue, message IDs in ascending PublishTime order.
+	// Put/Delete invalidate a queue's entry (they change membership/order);
 	// claim-state mutations (Pull/UpdateDeliveryAttempt/ModifyAckDeadline only
 	// touch VisibleAt/DeliveryAttempt, never PublishTime) do not, so repeated
-	// polling against an unchanged topic — the common Pub/Sub access pattern —
-	// avoids re-sorting the topic on every call.
+	// polling against an unchanged queue — the common Pub/Sub access pattern —
+	// avoids re-sorting the queue on every call.
 	sortedIDs map[string][]string
 	seq       atomic.Int64 // monotonic message-ID counter
 }
@@ -32,20 +32,20 @@ func NewMemoryMessages() *MemoryMessages {
 	}
 }
 
-// orderedIDsLocked returns messageIDs for topic in ascending PublishTime
+// orderedIDsLocked returns messageIDs for a queue in ascending PublishTime
 // order, building and caching them if the cache was invalidated. Callers must
 // hold s.mu for writing.
-func (s *MemoryMessages) orderedIDsLocked(topic string) []string {
-	if ids, ok := s.sortedIDs[topic]; ok {
+func (s *MemoryMessages) orderedIDsLocked(queue string) []string {
+	if ids, ok := s.sortedIDs[queue]; ok {
 		return ids
 	}
-	msgs := s.messages[topic]
+	msgs := s.messages[queue]
 	ids := make([]string, 0, len(msgs))
 	for id := range msgs {
 		ids = append(ids, id)
 	}
 	sort.Slice(ids, func(i, j int) bool { return msgs[ids[i]].PublishTime.Before(msgs[ids[j]].PublishTime) })
-	s.sortedIDs[topic] = ids
+	s.sortedIDs[queue] = ids
 	return ids
 }
 
@@ -57,19 +57,20 @@ func (s *MemoryMessages) NextID(_ context.Context) (string, error) {
 func (s *MemoryMessages) Put(_ context.Context, m Message) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.messages[m.Topic] == nil {
-		s.messages[m.Topic] = make(map[string]Message)
+	q := m.queueKey()
+	if s.messages[q] == nil {
+		s.messages[q] = make(map[string]Message)
 	}
-	s.messages[m.Topic][m.MessageID] = m
-	delete(s.sortedIDs, m.Topic)
+	s.messages[q][m.MessageID] = m
+	delete(s.sortedIDs, q)
 	return nil
 }
 
-func (s *MemoryMessages) List(_ context.Context, topic string) ([]Message, error) {
+func (s *MemoryMessages) List(_ context.Context, queue string) ([]Message, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	msgs := s.messages[topic]
-	ids := s.orderedIDsLocked(topic)
+	msgs := s.messages[queue]
+	ids := s.orderedIDsLocked(queue)
 	result := make([]Message, 0, len(ids))
 	for _, id := range ids {
 		result = append(result, msgs[id])
@@ -79,12 +80,12 @@ func (s *MemoryMessages) List(_ context.Context, topic string) ([]Message, error
 
 // Pull atomically claims eligible messages (mirrors SQS Receive: skip delayed/
 // in-flight, gate ordering-key groups, then claim under the mutex).
-func (s *MemoryMessages) Pull(_ context.Context, topic string, maxMessages, ackDeadlineSec, retentionSec int, now time.Time) ([]Message, error) {
+func (s *MemoryMessages) Pull(_ context.Context, queue string, maxMessages, ackDeadlineSec, retentionSec int, now time.Time) ([]Message, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	msgs := s.messages[topic]
-	ids := s.orderedIDsLocked(topic)
+	msgs := s.messages[queue]
+	ids := s.orderedIDsLocked(queue)
 
 	// FIFO: build the set of ordering keys that have an earlier in-flight message.
 	inFlightGroups := map[string]bool{}
@@ -115,7 +116,7 @@ func (s *MemoryMessages) Pull(_ context.Context, topic string, maxMessages, ackD
 		// Claim.
 		m.VisibleAt = now.Add(duration(ackDeadlineSec))
 		m.DeliveryAttempt++
-		s.messages[topic][m.MessageID] = m
+		s.messages[queue][m.MessageID] = m
 		if m.OrderingKey != "" {
 			inFlightGroups[m.OrderingKey] = true
 		}
@@ -124,22 +125,22 @@ func (s *MemoryMessages) Pull(_ context.Context, topic string, maxMessages, ackD
 	return out, nil
 }
 
-func (s *MemoryMessages) Delete(_ context.Context, topic, messageID string) error {
+func (s *MemoryMessages) Delete(_ context.Context, queue, messageID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if msgs, ok := s.messages[topic]; ok {
+	if msgs, ok := s.messages[queue]; ok {
 		if _, existed := msgs[messageID]; existed {
 			delete(msgs, messageID)
-			delete(s.sortedIDs, topic)
+			delete(s.sortedIDs, queue)
 		}
 	}
 	return nil
 }
 
-func (s *MemoryMessages) UpdateDeliveryAttempt(_ context.Context, topic, messageID string, attempt int) error {
+func (s *MemoryMessages) UpdateDeliveryAttempt(_ context.Context, queue, messageID string, attempt int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	msgs, ok := s.messages[topic]
+	msgs, ok := s.messages[queue]
 	if !ok {
 		return nil
 	}
@@ -152,8 +153,8 @@ func (s *MemoryMessages) UpdateDeliveryAttempt(_ context.Context, topic, message
 	return nil
 }
 
-// ModifyAckDeadline resets the visibility deadline for each ack ID ("topic/messageID").
-func (s *MemoryMessages) ModifyAckDeadline(_ context.Context, topic string, ackIDs []string, seconds int, now time.Time) error {
+// ModifyAckDeadline resets the visibility deadline for each ack ID ("queue/messageID").
+func (s *MemoryMessages) ModifyAckDeadline(_ context.Context, queue string, ackIDs []string, seconds int, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, ackID := range ackIDs {
@@ -161,7 +162,7 @@ func (s *MemoryMessages) ModifyAckDeadline(_ context.Context, topic string, ackI
 		if i := lastSlash(ackID); i >= 0 {
 			msgID = ackID[i+1:]
 		}
-		m, ok := s.messages[topic][msgID]
+		m, ok := s.messages[queue][msgID]
 		if !ok {
 			continue
 		}
@@ -170,7 +171,7 @@ func (s *MemoryMessages) ModifyAckDeadline(_ context.Context, topic string, ackI
 		} else {
 			m.VisibleAt = now.Add(duration(seconds))
 		}
-		s.messages[topic][msgID] = m
+		s.messages[queue][msgID] = m
 	}
 	return nil
 }

--- a/internal/gcp/store/pubsub/postgres.go
+++ b/internal/gcp/store/pubsub/postgres.go
@@ -13,7 +13,9 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// PostgresMessages implements Messages against jc_pubsub_messages.
+// PostgresMessages implements Messages against jc_pubsub_messages. Rows are
+// keyed by delivery queue: the subscription ID for fanned-out messages (see
+// Message.Subscription).
 type PostgresMessages struct {
 	pool *pgxpool.Pool
 }
@@ -39,19 +41,19 @@ func (s *PostgresMessages) Put(ctx context.Context, m Message) error {
 	}
 	attrs, _ := json.Marshal(m.Attributes)
 	_, err := s.pool.Exec(ctx, `
-		INSERT INTO jc_pubsub_messages (topic, message_id, data, attributes, publish_time, delivery_attempt, ordering_key, visible_at, kms_key_name, wrapped_dek)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
-		ON CONFLICT (topic, message_id) DO UPDATE
-			SET data=$3, attributes=$4, publish_time=$5, delivery_attempt=$6, ordering_key=$7, visible_at=$8, kms_key_name=$9, wrapped_dek=$10
-	`, m.Topic, m.MessageID, m.Data, json.RawMessage(attrs), m.PublishTime, m.DeliveryAttempt, m.OrderingKey, nullableTime(m.VisibleAt), m.KmsKeyName, m.WrappedDEK)
+		INSERT INTO jc_pubsub_messages (topic, subscription, message_id, data, attributes, publish_time, delivery_attempt, ordering_key, visible_at, kms_key_name, wrapped_dek)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+		ON CONFLICT (subscription, message_id) DO UPDATE
+			SET topic=$1, data=$4, attributes=$5, publish_time=$6, delivery_attempt=$7, ordering_key=$8, visible_at=$9, kms_key_name=$10, wrapped_dek=$11
+	`, m.Topic, m.queueKey(), m.MessageID, m.Data, json.RawMessage(attrs), m.PublishTime, m.DeliveryAttempt, m.OrderingKey, nullableTime(m.VisibleAt), m.KmsKeyName, m.WrappedDEK)
 	return err
 }
 
-func (s *PostgresMessages) List(ctx context.Context, topic string) ([]Message, error) {
+func (s *PostgresMessages) List(ctx context.Context, queue string) ([]Message, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT message_id, data, attributes, publish_time, delivery_attempt, ordering_key, visible_at, kms_key_name, wrapped_dek
-		FROM jc_pubsub_messages WHERE topic=$1 ORDER BY publish_time
-	`, topic)
+		SELECT topic, message_id, data, attributes, publish_time, delivery_attempt, ordering_key, visible_at, kms_key_name, wrapped_dek
+		FROM jc_pubsub_messages WHERE subscription=$1 ORDER BY publish_time
+	`, queue)
 	if err != nil {
 		return nil, err
 	}
@@ -61,11 +63,11 @@ func (s *PostgresMessages) List(ctx context.Context, topic string) ([]Message, e
 		var m Message
 		var attrs []byte
 		var visibleAt *time.Time
-		if err := rows.Scan(&m.MessageID, &m.Data, &attrs, &m.PublishTime, &m.DeliveryAttempt, &m.OrderingKey, &visibleAt, &m.KmsKeyName, &m.WrappedDEK); err != nil {
+		if err := rows.Scan(&m.Topic, &m.MessageID, &m.Data, &attrs, &m.PublishTime, &m.DeliveryAttempt, &m.OrderingKey, &visibleAt, &m.KmsKeyName, &m.WrappedDEK); err != nil {
 			return nil, err
 		}
 		json.Unmarshal(attrs, &m.Attributes)
-		m.Topic = topic
+		m.Subscription = queue
 		if visibleAt != nil {
 			m.VisibleAt = *visibleAt
 		}
@@ -79,7 +81,7 @@ func (s *PostgresMessages) List(ctx context.Context, topic string) ([]Message, e
 // (mirrors SQS Receive), applying the same orderingKey FIFO gating as the
 // memory store: only the earliest eligible message in each ordering-key group
 // is claimed in a single pull.
-func (s *PostgresMessages) Pull(ctx context.Context, topic string, maxMessages, ackDeadlineSec, retentionSec int, now time.Time) ([]Message, error) {
+func (s *PostgresMessages) Pull(ctx context.Context, queue string, maxMessages, ackDeadlineSec, retentionSec int, now time.Time) ([]Message, error) {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return nil, err
@@ -91,8 +93,8 @@ func (s *PostgresMessages) Pull(ctx context.Context, topic string, maxMessages, 
 	inFlightGroups := map[string]bool{}
 	krows, err := tx.Query(ctx, `
 		SELECT DISTINCT ordering_key FROM jc_pubsub_messages
-		WHERE topic = $1 AND ordering_key <> '' AND visible_at > $2
-	`, topic, now)
+		WHERE subscription = $1 AND ordering_key <> '' AND visible_at > $2
+	`, queue, now)
 	if err != nil {
 		return nil, err
 	}
@@ -110,14 +112,14 @@ func (s *PostgresMessages) Pull(ctx context.Context, topic string, maxMessages, 
 	}
 
 	rows, err := tx.Query(ctx, `
-		SELECT message_id, data, attributes, publish_time, delivery_attempt, ordering_key, kms_key_name, wrapped_dek
+		SELECT topic, message_id, data, attributes, publish_time, delivery_attempt, ordering_key, kms_key_name, wrapped_dek
 		FROM jc_pubsub_messages
-		WHERE topic = $1
+		WHERE subscription = $1
 		  AND (visible_at IS NULL OR visible_at <= $2)
 		  AND publish_time > $2 - make_interval(secs => $3)
 		ORDER BY publish_time
 		FOR UPDATE SKIP LOCKED
-	`, topic, now, retentionSec)
+	`, queue, now, retentionSec)
 	if err != nil {
 		return nil, err
 	}
@@ -125,12 +127,12 @@ func (s *PostgresMessages) Pull(ctx context.Context, topic string, maxMessages, 
 	for rows.Next() {
 		var m Message
 		var attrs []byte
-		if err := rows.Scan(&m.MessageID, &m.Data, &attrs, &m.PublishTime, &m.DeliveryAttempt, &m.OrderingKey, &m.KmsKeyName, &m.WrappedDEK); err != nil {
+		if err := rows.Scan(&m.Topic, &m.MessageID, &m.Data, &attrs, &m.PublishTime, &m.DeliveryAttempt, &m.OrderingKey, &m.KmsKeyName, &m.WrappedDEK); err != nil {
 			rows.Close()
 			return nil, err
 		}
 		json.Unmarshal(attrs, &m.Attributes)
-		m.Topic = topic
+		m.Subscription = queue
 		candidates = append(candidates, m)
 	}
 	rows.Close()
@@ -158,28 +160,28 @@ func (s *PostgresMessages) Pull(ctx context.Context, topic string, maxMessages, 
 	for _, m := range out {
 		if _, err := tx.Exec(ctx, `
 			UPDATE jc_pubsub_messages SET visible_at=$2, delivery_attempt=$3
-			WHERE topic=$1 AND message_id=$4
-		`, topic, m.VisibleAt, m.DeliveryAttempt, m.MessageID); err != nil {
+			WHERE subscription=$1 AND message_id=$4
+		`, queue, m.VisibleAt, m.DeliveryAttempt, m.MessageID); err != nil {
 			return nil, err
 		}
 	}
 	return out, tx.Commit(ctx)
 }
 
-func (s *PostgresMessages) Delete(ctx context.Context, topic, messageID string) error {
-	_, err := s.pool.Exec(ctx, `DELETE FROM jc_pubsub_messages WHERE topic=$1 AND message_id=$2`, topic, messageID)
+func (s *PostgresMessages) Delete(ctx context.Context, queue, messageID string) error {
+	_, err := s.pool.Exec(ctx, `DELETE FROM jc_pubsub_messages WHERE subscription=$1 AND message_id=$2`, queue, messageID)
 	return err
 }
 
-func (s *PostgresMessages) UpdateDeliveryAttempt(ctx context.Context, topic, messageID string, attempt int) error {
+func (s *PostgresMessages) UpdateDeliveryAttempt(ctx context.Context, queue, messageID string, attempt int) error {
 	_, err := s.pool.Exec(ctx, `
-		UPDATE jc_pubsub_messages SET delivery_attempt=$3 WHERE topic=$1 AND message_id=$2
-	`, topic, messageID, attempt)
+		UPDATE jc_pubsub_messages SET delivery_attempt=$3 WHERE subscription=$1 AND message_id=$2
+	`, queue, messageID, attempt)
 	return err
 }
 
-// ModifyAckDeadline resets the visibility deadline for each ack ID ("topic/messageID").
-func (s *PostgresMessages) ModifyAckDeadline(ctx context.Context, topic string, ackIDs []string, seconds int, now time.Time) error {
+// ModifyAckDeadline resets the visibility deadline for each ack ID ("queue/messageID").
+func (s *PostgresMessages) ModifyAckDeadline(ctx context.Context, queue string, ackIDs []string, seconds int, now time.Time) error {
 	for _, ackID := range ackIDs {
 		msgID := ackID
 		if i := strings.LastIndex(ackID, "/"); i >= 0 {
@@ -190,7 +192,7 @@ func (s *PostgresMessages) ModifyAckDeadline(ctx context.Context, topic string, 
 			t := now.Add(time.Duration(seconds) * time.Second)
 			visibleAt = &t
 		}
-		if _, err := s.pool.Exec(ctx, `UPDATE jc_pubsub_messages SET visible_at=$2 WHERE topic=$1 AND message_id=$3`, topic, visibleAt, msgID); err != nil {
+		if _, err := s.pool.Exec(ctx, `UPDATE jc_pubsub_messages SET visible_at=$2 WHERE subscription=$1 AND message_id=$3`, queue, visibleAt, msgID); err != nil {
 			return err
 		}
 	}

--- a/internal/gcp/store/pubsub/snapshot.go
+++ b/internal/gcp/store/pubsub/snapshot.go
@@ -37,10 +37,11 @@ func (s *MemoryMessages) Restore(_ context.Context, r io.Reader) error {
 	}
 	messages := make(map[string]map[string]Message)
 	for _, m := range snap.Messages {
-		if messages[m.Topic] == nil {
-			messages[m.Topic] = make(map[string]Message)
+		q := m.queueKey()
+		if messages[q] == nil {
+			messages[q] = make(map[string]Message)
 		}
-		messages[m.Topic][m.MessageID] = m
+		messages[q][m.MessageID] = m
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -58,7 +59,7 @@ func (s *PostgresMessages) IsEmpty(ctx context.Context) (bool, error) {
 }
 
 func (s *PostgresMessages) Snapshot(ctx context.Context, w io.Writer) error {
-	rows, err := s.pool.Query(ctx, `SELECT topic, message_id, data, attributes, publish_time, delivery_attempt, ordering_key, visible_at, kms_key_name, wrapped_dek FROM jc_pubsub_messages ORDER BY topic, message_id`)
+	rows, err := s.pool.Query(ctx, `SELECT topic, subscription, message_id, data, attributes, publish_time, delivery_attempt, ordering_key, visible_at, kms_key_name, wrapped_dek FROM jc_pubsub_messages ORDER BY subscription, message_id`)
 	if err != nil {
 		return err
 	}
@@ -68,7 +69,7 @@ func (s *PostgresMessages) Snapshot(ctx context.Context, w io.Writer) error {
 		var m Message
 		var attrs []byte
 		var visibleAt *time.Time
-		if err := rows.Scan(&m.Topic, &m.MessageID, &m.Data, &attrs, &m.PublishTime, &m.DeliveryAttempt, &m.OrderingKey, &visibleAt, &m.KmsKeyName, &m.WrappedDEK); err != nil {
+		if err := rows.Scan(&m.Topic, &m.Subscription, &m.MessageID, &m.Data, &attrs, &m.PublishTime, &m.DeliveryAttempt, &m.OrderingKey, &visibleAt, &m.KmsKeyName, &m.WrappedDEK); err != nil {
 			return err
 		}
 		json.Unmarshal(attrs, &m.Attributes)
@@ -98,8 +99,8 @@ func (s *PostgresMessages) Restore(ctx context.Context, r io.Reader) error {
 	}
 	for _, m := range snap.Messages {
 		attrs, _ := json.Marshal(m.Attributes)
-		if _, err := tx.Exec(ctx, `INSERT INTO jc_pubsub_messages (topic, message_id, data, attributes, publish_time, delivery_attempt, ordering_key, visible_at, kms_key_name, wrapped_dek) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
-			m.Topic, m.MessageID, m.Data, json.RawMessage(attrs), m.PublishTime, m.DeliveryAttempt, m.OrderingKey, nullableTime(m.VisibleAt), m.KmsKeyName, m.WrappedDEK); err != nil {
+		if _, err := tx.Exec(ctx, `INSERT INTO jc_pubsub_messages (topic, subscription, message_id, data, attributes, publish_time, delivery_attempt, ordering_key, visible_at, kms_key_name, wrapped_dek) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+			m.Topic, m.queueKey(), m.MessageID, m.Data, json.RawMessage(attrs), m.PublishTime, m.DeliveryAttempt, m.OrderingKey, nullableTime(m.VisibleAt), m.KmsKeyName, m.WrappedDEK); err != nil {
 			return err
 		}
 	}

--- a/internal/gcp/store/pubsub/store.go
+++ b/internal/gcp/store/pubsub/store.go
@@ -11,7 +11,12 @@ import (
 
 // Message is a single published Pub/Sub message.
 type Message struct {
-	Topic           string
+	Topic string
+	// Subscription is the delivery queue this message was fanned out to. Pub/Sub
+	// delivers a copy to every subscription of a topic, so messages are stored
+	// per subscription (not once per topic); Ack/ModifyAckDeadline act on this
+	// subscription's copy. Empty for legacy/topic-keyed rows.
+	Subscription    string
 	MessageID       string
 	Data            string
 	Attributes      map[string]string
@@ -26,23 +31,34 @@ type Message struct {
 	WrappedDEK []byte
 }
 
-// Messages is the Pub/Sub message store.
+// queueKey is the delivery queue a message belongs to: the subscription ID for
+// fanned-out messages, falling back to the logical topic for legacy rows.
+func (m Message) queueKey() string {
+	if m.Subscription != "" {
+		return m.Subscription
+	}
+	return m.Topic
+}
+
+// Messages is the Pub/Sub message store. Every operation is keyed by a delivery
+// queue: a subscription ID for fanned-out messages (the normal case), or a
+// topic for legacy/topic-keyed rows.
 type Messages interface {
 	// NextID allocates the next monotonic message ID. The memory backend uses a
 	// process-local counter; the Postgres backend uses a database sequence so IDs
 	// remain monotonic across restarts (mirrors SQS jc_sqs_fifo_seq).
 	NextID(ctx context.Context) (string, error)
 	Put(ctx context.Context, m Message) error
-	// List returns all messages for a topic, sorted by publish time (no claim).
-	List(ctx context.Context, topic string) ([]Message, error)
+	// List returns all messages for a queue, sorted by publish time (no claim).
+	List(ctx context.Context, queue string) ([]Message, error)
 	// Pull atomically claims up to maxMessages eligible messages, marking each
 	// invisible until now+ackDeadlineSec and incrementing its delivery attempt.
 	// retentionSec filters out messages older than the topic's retention.
-	Pull(ctx context.Context, topic string, maxMessages, ackDeadlineSec, retentionSec int, now time.Time) ([]Message, error)
-	Delete(ctx context.Context, topic, messageID string) error
-	UpdateDeliveryAttempt(ctx context.Context, topic, messageID string, attempt int) error
+	Pull(ctx context.Context, queue string, maxMessages, ackDeadlineSec, retentionSec int, now time.Time) ([]Message, error)
+	Delete(ctx context.Context, queue, messageID string) error
+	UpdateDeliveryAttempt(ctx context.Context, queue, messageID string, attempt int) error
 	// ModifyAckDeadline resets the visibility deadline for the given ack IDs
-	// (each "topic/messageID"); seconds==0 makes them immediately visible.
-	ModifyAckDeadline(ctx context.Context, topic string, ackIDs []string, seconds int, now time.Time) error
+	// (each "queue/messageID"); seconds==0 makes them immediately visible.
+	ModifyAckDeadline(ctx context.Context, queue string, ackIDs []string, seconds int, now time.Time) error
 	Reset(ctx context.Context)
 }

--- a/tests/integration/gcp/sdk-rest/sdkrest_extra_test.go
+++ b/tests/integration/gcp/sdk-rest/sdkrest_extra_test.go
@@ -46,6 +46,11 @@ func TestSDKPubSubOrderingKeyAndAttributes(t *testing.T) {
 	_, err = svc.Projects.Topics.Create(topic, &pubsub.Topic{Name: topic}).Do()
 	require.NoError(t, err)
 
+	// Subscribe before publishing (a subscription only receives later messages).
+	sub := "projects/proj/subscriptions/" + unique("ok-sub")
+	_, err = svc.Projects.Subscriptions.Create(sub, &pubsub.Subscription{Name: sub, Topic: topic}).Do()
+	require.NoError(t, err)
+
 	const n = 3
 	// Publish one message per request so each gets a distinct publish time —
 	// the emulator orders delivery by publish time, so a single batch (which
@@ -62,10 +67,6 @@ func TestSDKPubSubOrderingKeyAndAttributes(t *testing.T) {
 		require.Len(t, pub.MessageIds, 1)
 		time.Sleep(time.Millisecond)
 	}
-
-	sub := "projects/proj/subscriptions/" + unique("ok-sub")
-	_, err = svc.Projects.Subscriptions.Create(sub, &pubsub.Subscription{Name: sub, Topic: topic}).Do()
-	require.NoError(t, err)
 
 	// Ordering-key FIFO: only one message per key is in flight at a time, so
 	// pull+ack one at a time and verify strict delivery order.

--- a/tests/integration/gcp/sdk-rest/sdkrest_test.go
+++ b/tests/integration/gcp/sdk-rest/sdkrest_test.go
@@ -54,14 +54,8 @@ func TestSDKPubSub(t *testing.T) {
 	_, err = svc.Projects.Topics.Create(topicName, &pubsub.Topic{Name: topicName}).Do()
 	require.NoError(t, err)
 
-	// Publish.
-	pub, err := svc.Projects.Topics.Publish(topicName, &pubsub.PublishRequest{
-		Messages: []*pubsub.PubsubMessage{{Data: "aGk="}},
-	}).Do()
-	require.NoError(t, err)
-	require.Len(t, pub.MessageIds, 1)
-
-	// Subscription + pull + ack.
+	// Create the subscription before publishing: Pub/Sub only delivers messages
+	// published after the subscription exists.
 	subName := "projects/proj/subscriptions/" + unique("s")
 	_, err = svc.Projects.Subscriptions.Create(subName, &pubsub.Subscription{
 		Name:  subName,
@@ -69,6 +63,14 @@ func TestSDKPubSub(t *testing.T) {
 	}).Do()
 	require.NoError(t, err)
 
+	// Publish.
+	pub, err := svc.Projects.Topics.Publish(topicName, &pubsub.PublishRequest{
+		Messages: []*pubsub.PubsubMessage{{Data: "aGk="}},
+	}).Do()
+	require.NoError(t, err)
+	require.Len(t, pub.MessageIds, 1)
+
+	// Pull + ack.
 	pull, err := svc.Projects.Subscriptions.Pull(subName, &pubsub.PullRequest{MaxMessages: 10}).Do()
 	require.NoError(t, err)
 	require.NotEmpty(t, pull.ReceivedMessages)


### PR DESCRIPTION
## Description

Blocker parity gap from the GCP compatibility audit: Pub/Sub did **not fan out**. A
published message was stored once per topic and `Pull` claimed it by mutating the shared
`visible_at`, so the first subscription to pull consumed the message and every other
subscription received nothing (the localgcp `TestFanOut` and floci Pub/Sub fan-out cases
failed).

Pub/Sub semantics (https://cloud.google.com/pubsub/docs/pubsub-basics): every subscription
of a topic receives its own copy of each message, with independent delivery/ack state.

## What's in this PR

Store messages per subscription (fan-out on publish) and key delivery by subscription:

- `store/pubsub`: `Message` gains `Subscription`; the memory and Postgres stores key rows by
  it; `queueKey()` falls back to `Topic` for legacy rows. Postgres primary key becomes
  `(subscription, message_id)`; migration `038_pubsub_fanout.sql` adds/backfills the column.
- `provider/pubsub` + `grpc/pubsub` `Publish` enqueue one copy per **pull** subscription
  (push subscriptions are delivered over HTTP and are not queued).
- `Pull` / `Acknowledge` / `ModifyAckDeadline` / `StreamingPull` and the opaque ackId scheme
  operate on the subscription queue, so acking one subscription does not affect another.
- Dead-letter republish now fans out to the dead-letter **topic's** subscriptions.

## Out of scope

- Subscription `filter` (store/validate/enforce) and `DetachSubscription` — separate gaps in
  the verified plan.
- Topic-delete orphaning (`topic` → `_deleted-topic_`).
- Subscription creation against a missing topic (should be `NotFound`).

## How to test

```bash
go build ./... && go vet ./internal/gcp/... && gofmt -l internal/gcp/
go test ./internal/gcp/store/pubsub/ ./internal/gcp/provider/pubsub/ ./internal/gcp/grpc/pubsub/ -count=1
```

End-to-end through the REST API:

```bash
./jaiscloud-gcp start --port 18095 --grpc-port 18096 --ephemeral &
B=http://localhost:18095/v1/projects/proj
curl -s -X PUT $B/topics/zt
curl -s -X PUT $B/subscriptions/zsa -d '{"topic":"projects/proj/topics/zt"}'
curl -s -X PUT $B/subscriptions/zsb -d '{"topic":"projects/proj/topics/zt"}'
curl -s -X POST $B/topics/zt:publish -d '{"messages":[{"data":"YnJvYWRjYXN0"}]}'
curl -s -X POST $B/subscriptions/zsa:pull -d '{"maxMessages":10,"returnImmediately":true}'
curl -s -X POST $B/subscriptions/zsb:pull -d '{"maxMessages":10,"returnImmediately":true}'
# both return the message (ackIds zsa/1 and zsb/1)
```

## Test report

- `go test ./internal/gcp/...` green; `go vet`/`gofmt` clean.
- New: `TestPubSubFanOut` (REST provider) and `TestPubSubFanOutGRPC` — two subscriptions both
  receive the message and acking one leaves the other's copy; a push subscription gets no
  queued copy. The test also asserts ack isolation.
- Existing round-trip tests now create the subscription **before** publishing, matching real
  Pub/Sub (a subscription only receives messages published after it exists); this was the
  assumption the old topic-keyed store had masked.
- E2E verified over the REST API (both subscriptions receive; ackIds are `zsa/1`, `zsb/1`).

## Post-fix validation (floci + localgcp)

Run against a build combining this branch with the merged `gcp` (#82 gzip), ephemeral server:

| Suite | Result |
|---|---|
| floci Go `TestPubSub` | 13/13 pass |
| floci Python `tests/test_pubsub.py` | 4 passed, 3 failed — all three are subscription-`filter` tests (out of scope, G7) |
| localgcp Pub/Sub replay | 26 pass / 2 fail — `TestFanOut` now **PASS** (was `second subscription got 0`); the 2 remaining are topic-existence + orphan (out of scope) |

Cluster replay (k3d, this branch's image) confirmed the same: localgcp Pub/Sub 26/2 with
`TestFanOut` passing.

## Conformance audit

- Fan-out to every subscription: https://cloud.google.com/pubsub/docs/pubsub-basics.
- A subscription receives messages published after it is created: same page / `Subscription`
  lifecycle.
- `Subscription.deadLetterPolicy.deadLetterTopic` forwards to the DLQ **topic**; behaviour is
  subject to a subscription on that topic (mirrors real Pub/Sub, where a DLQ topic with no
  subscription discards).
- Memory and Postgres backends implement the same queue-key semantics (migration 038).
