### PR TITLE
fix(gcp/secretmanager): enforce version state, fix REST IAM, emit destroyTime

### DIFF
--- a/internal/gcp/adapter/jsoncodec.go
+++ b/internal/gcp/adapter/jsoncodec.go
@@ -308,11 +308,11 @@ func deriveAction(resourceType string, isCollection bool, name, method, custom s
 			case "enable":
 				return "EnableVersion"
 			case "getIamPolicy":
-				return "SecretGetIamPolicy"
+				return "GetIamPolicy"
 			case "setIamPolicy":
-				return "SecretSetIamPolicy"
+				return "SetIamPolicy"
 			case "testIamPermissions":
-				return "SecretTestIamPermissions"
+				return "TestIamPermissions"
 			}
 		case "cryptoKeys":
 			switch custom {

--- a/internal/gcp/adapter/jsoncodec_test.go
+++ b/internal/gcp/adapter/jsoncodec_test.go
@@ -18,9 +18,9 @@ func TestJSONCodecDecode(t *testing.T) {
 		{"POST", "/v1/projects/p/secrets/s:addVersion", "AddVersion"},
 		{"POST", "/v1/projects/p/secrets/s/versions/1:access", "Access"},
 		{"GET", "/v1/projects/p/secrets/s/versions/1", "GetVersion"},
-		{"GET", "/v1/projects/p/secrets/s:getIamPolicy", "SecretGetIamPolicy"},
-		{"POST", "/v1/projects/p/secrets/s:setIamPolicy", "SecretSetIamPolicy"},
-		{"POST", "/v1/projects/p/secrets/s:testIamPermissions", "SecretTestIamPermissions"},
+		{"GET", "/v1/projects/p/secrets/s:getIamPolicy", "GetIamPolicy"},
+		{"POST", "/v1/projects/p/secrets/s:setIamPolicy", "SetIamPolicy"},
+		{"POST", "/v1/projects/p/secrets/s:testIamPermissions", "TestIamPermissions"},
 		// Pub/Sub
 		{"PUT", "/v1/projects/p/topics/t", "TopicCreate"},
 		{"GET", "/v1/projects/p/topics", "TopicList"},

--- a/internal/gcp/grpc/secretmanager/service.go
+++ b/internal/gcp/grpc/secretmanager/service.go
@@ -283,6 +283,12 @@ func (s *Service) AccessSecretVersion(ctx context.Context, req *secretmanagerpb.
 	if err != nil {
 		return nil, mapVersionErr(err)
 	}
+	if v.State != "ENABLED" {
+		return nil, mapError(&model.ProviderError{
+			Code: "FailedPrecondition", HTTPStatus: 400, Status: "FAILED_PRECONDITION",
+			Message: "secret version " + v.VersionID + " is " + v.State + ", not ENABLED",
+		})
+	}
 
 	encrypted, err := base64.StdEncoding.DecodeString(v.Data)
 	if err != nil {
@@ -392,7 +398,17 @@ func (s *Service) setVersionState(ctx context.Context, name, state string) (*sec
 	if err != nil {
 		return nil, mapVersionErr(err)
 	}
+	// DESTROYED is terminal: a version may not leave this state once entered.
+	if v.State == "DESTROYED" {
+		return nil, mapError(&model.ProviderError{
+			Code: "FailedPrecondition", HTTPStatus: 400, Status: "FAILED_PRECONDITION",
+			Message: "secret version " + v.VersionID + " is DESTROYED",
+		})
+	}
 	v.State = state
+	if state == "DESTROYED" {
+		v.DestroyTime = clock.Now()
+	}
 	if err := s.secrets.UpdateVersion(ctx, project, v); err != nil {
 		return nil, mapVersionErr(err)
 	}
@@ -513,6 +529,9 @@ func versionToProto(project string, v secretmanagerstore.Version) *secretmanager
 	}
 	if !v.CreateTime.IsZero() {
 		out.CreateTime = timestamppb.New(v.CreateTime)
+	}
+	if !v.DestroyTime.IsZero() {
+		out.DestroyTime = timestamppb.New(v.DestroyTime)
 	}
 	return out
 }

--- a/internal/gcp/grpc/secretmanager/service_test.go
+++ b/internal/gcp/grpc/secretmanager/service_test.go
@@ -147,6 +147,10 @@ func TestSecretManagerEndToEnd(t *testing.T) {
 	if dis.GetState() != secretmanagerpb.SecretVersion_DISABLED {
 		t.Fatalf("DisableSecretVersion state = %v, want DISABLED", dis.GetState())
 	}
+	// A disabled version cannot be accessed.
+	if _, err := client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{Name: secret + "/versions/1"}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("AccessSecretVersion disabled err = %v, want FailedPrecondition", err)
+	}
 
 	en, err := client.EnableSecretVersion(ctx, &secretmanagerpb.EnableSecretVersionRequest{Name: secret + "/versions/1"})
 	if err != nil {
@@ -162,6 +166,16 @@ func TestSecretManagerEndToEnd(t *testing.T) {
 	}
 	if des.GetState() != secretmanagerpb.SecretVersion_DESTROYED {
 		t.Fatalf("DestroySecretVersion state = %v, want DESTROYED", des.GetState())
+	}
+	if des.GetDestroyTime() == nil {
+		t.Fatal("DestroySecretVersion destroyTime is nil")
+	}
+	// DESTROYED is terminal.
+	if _, err := client.AccessSecretVersion(ctx, &secretmanagerpb.AccessSecretVersionRequest{Name: secret + "/versions/1"}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("AccessSecretVersion destroyed err = %v, want FailedPrecondition", err)
+	}
+	if _, err := client.EnableSecretVersion(ctx, &secretmanagerpb.EnableSecretVersionRequest{Name: secret + "/versions/1"}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("EnableSecretVersion destroyed err = %v, want FailedPrecondition", err)
 	}
 
 	// Get a missing version → NotFound.

--- a/internal/gcp/provider/secretmanager/secret.go
+++ b/internal/gcp/provider/secretmanager/secret.go
@@ -65,10 +65,11 @@ type secretMeta struct {
 }
 
 type versionMeta struct {
-	Name       string `json:"name"`
-	State      string `json:"state"`
-	CreateTime string `json:"createTime"`
-	Data       string `json:"data"` // base64 payload
+	Name        string `json:"name"`
+	State       string `json:"state"`
+	CreateTime  string `json:"createTime"`
+	DestroyTime string `json:"destroyTime,omitempty"` // only when DESTROYED
+	Data        string `json:"data"`                  // base64 payload
 }
 
 // resourceName returns the "name" path param, or a 400 when absent.
@@ -182,6 +183,9 @@ func fromStoreVersion(nr *model.NormalizedRequest, v secretmanagerstore.Version)
 	}
 	if !v.CreateTime.IsZero() {
 		m.CreateTime = v.CreateTime.Format(time.RFC3339Nano)
+	}
+	if !v.DestroyTime.IsZero() {
+		m.DestroyTime = v.DestroyTime.Format(time.RFC3339Nano)
 	}
 	return m
 }
@@ -447,6 +451,12 @@ func (p *Provider) Access(ctx context.Context, nr *model.NormalizedRequest) (*mo
 	if err != nil {
 		return nil, mapVersionErr(err)
 	}
+	if v.State != "ENABLED" {
+		return nil, &model.ProviderError{
+			Code: "FailedPrecondition", HTTPStatus: 400, Status: "FAILED_PRECONDITION",
+			Message: "secret version " + v.VersionID + " is " + v.State + ", not ENABLED",
+		}
+	}
 
 	encryptedPayloadBytes, err := base64.StdEncoding.DecodeString(v.Data)
 	if err != nil {
@@ -541,7 +551,17 @@ func (p *Provider) setVersionState(ctx context.Context, nr *model.NormalizedRequ
 	if err != nil {
 		return nil, mapVersionErr(err)
 	}
+	// DESTROYED is terminal: a version may not leave this state once entered.
+	if v.State == "DESTROYED" {
+		return nil, &model.ProviderError{
+			Code: "FailedPrecondition", HTTPStatus: 400, Status: "FAILED_PRECONDITION",
+			Message: "secret version " + v.VersionID + " is DESTROYED",
+		}
+	}
 	v.State = state
+	if state == "DESTROYED" {
+		v.DestroyTime = clock.Now()
+	}
 	if err := p.secrets.UpdateVersion(ctx, nr.AccountID, v); err != nil {
 		return nil, mapVersionErr(err)
 	}
@@ -653,9 +673,13 @@ func secretToMap(m secretMeta) map[string]any {
 }
 
 func versionToMap(v versionMeta) map[string]any {
-	return map[string]any{
+	out := map[string]any{
 		"name":       v.Name,
 		"state":      v.State,
 		"createTime": v.CreateTime,
 	}
+	if v.DestroyTime != "" {
+		out["destroyTime"] = v.DestroyTime
+	}
+	return out
 }

--- a/internal/gcp/provider/secretmanager/secret_extra_test.go
+++ b/internal/gcp/provider/secretmanager/secret_extra_test.go
@@ -107,19 +107,28 @@ func TestSecretVersionLifecycle(t *testing.T) {
 		t.Fatalf("addVersion: %v", err)
 	}
 
+	// Deterministic lifecycle (DESTROYED is terminal, so order matters).
 	nr = newNR(map[string]any{"name": "secrets/s/versions/1"})
-	for state, fn := range map[string]func(context.Context, *model.NormalizedRequest) (*model.ProviderResponse, error){
-		"DISABLED":  p.DisableVersion,
-		"ENABLED":   p.EnableVersion,
-		"DESTROYED": p.DestroyVersion,
-	} {
-		resp, err := fn(ctx, nr)
+	steps := []struct {
+		state string
+		fn    func(context.Context, *model.NormalizedRequest) (*model.ProviderResponse, error)
+	}{
+		{"DISABLED", p.DisableVersion},
+		{"ENABLED", p.EnableVersion},
+		{"DESTROYED", p.DestroyVersion},
+	}
+	for _, step := range steps {
+		resp, err := step.fn(ctx, nr)
 		if err != nil {
-			t.Fatalf("%s: %v", state, err)
+			t.Fatalf("%s: %v", step.state, err)
 		}
-		if resp.Data["state"] != state {
-			t.Errorf("expected state %s, got %v", state, resp.Data["state"])
+		if resp.Data["state"] != step.state {
+			t.Errorf("expected state %s, got %v", step.state, resp.Data["state"])
 		}
+	}
+	// A destroyed version cannot be re-enabled.
+	if _, err := p.EnableVersion(ctx, nr); err == nil {
+		t.Error("expected error re-enabling a destroyed version")
 	}
 
 	// 404 on a missing version.
@@ -435,5 +444,85 @@ func TestSecretManagerCMEKRoundTrip(t *testing.T) {
 	payloadResp := accessResp.Data["payload"].(map[string]any)
 	if payloadResp["data"] != payloadB64 {
 		t.Fatalf("expected payload %q, got %q", payloadB64, payloadResp["data"])
+	}
+}
+
+// TestSecretVersionStateEnforcement verifies Secret Manager lifecycle rules:
+// a DISABLED/DESTROYED version cannot be accessed, DESTROYED is terminal, and
+// destroyTime is emitted once destroyed.
+func TestSecretVersionStateEnforcement(t *testing.T) {
+	ctx := context.Background()
+	p := New(secretmanagerstore.NewMemoryStore(), store.NewMemoryResourceStore(), crypto.NewEnvelopeEncryptor(kms.NewMemoryStore()))
+
+	if _, err := p.Create(ctx, newNR(map[string]any{"secretId": "state-secret"})); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := p.AddVersion(ctx, newNR(map[string]any{
+		"name": "secrets/state-secret", "body": map[string]any{"payload": map[string]any{"data": "aGVsbG8="}},
+	})); err != nil {
+		t.Fatalf("addVersion: %v", err)
+	}
+	version := "secrets/state-secret/versions/1"
+
+	// DISABLED version is not accessible.
+	if _, err := p.DisableVersion(ctx, newNR(map[string]any{"name": version})); err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+	_, err := p.Access(ctx, newNR(map[string]any{"name": version}))
+	requireProviderCode(t, err, "FailedPrecondition")
+
+	// Re-enabling restores access.
+	if _, err := p.EnableVersion(ctx, newNR(map[string]any{"name": version})); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if _, err := p.Access(ctx, newNR(map[string]any{"name": version})); err != nil {
+		t.Fatalf("access after enable: %v", err)
+	}
+
+	// Destroy sets DESTROYED and destroyTime.
+	resp, err := p.DestroyVersion(ctx, newNR(map[string]any{"name": version}))
+	if err != nil {
+		t.Fatalf("destroy: %v", err)
+	}
+	if resp.Data["state"] != "DESTROYED" {
+		t.Fatalf("state = %v, want DESTROYED", resp.Data["state"])
+	}
+	if dt, _ := resp.Data["destroyTime"].(string); dt == "" {
+		t.Fatalf("expected destroyTime on destroyed version, got %v", resp.Data["destroyTime"])
+	}
+
+	// DESTROYED is terminal.
+	_, err = p.Access(ctx, newNR(map[string]any{"name": version}))
+	requireProviderCode(t, err, "FailedPrecondition")
+	_, err = p.EnableVersion(ctx, newNR(map[string]any{"name": version}))
+	requireProviderCode(t, err, "FailedPrecondition")
+	_, err = p.DisableVersion(ctx, newNR(map[string]any{"name": version}))
+	requireProviderCode(t, err, "FailedPrecondition")
+}
+
+// TestSecretIAMRoutesRegistered pins the provider-side keys for the REST IAM
+// surface: the codec's bare GetIamPolicy/SetIamPolicy/TestIamPermissions actions
+// combine with the "Secret" service prefix to reach these.
+func TestSecretIAMRoutesRegistered(t *testing.T) {
+	p := New(secretmanagerstore.NewMemoryStore(), store.NewMemoryResourceStore(), crypto.NewEnvelopeEncryptor(kms.NewMemoryStore()))
+	routes := p.Routes()
+	for _, k := range []string{"Secret.GetIamPolicy", "Secret.SetIamPolicy", "Secret.TestIamPermissions"} {
+		if routes[k] == nil {
+			t.Errorf("missing route %q", k)
+		}
+	}
+}
+
+func requireProviderCode(t *testing.T, err error, code string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error %s, got nil", code)
+	}
+	pe, ok := err.(*model.ProviderError)
+	if !ok {
+		t.Fatalf("expected *model.ProviderError, got %T (%v)", err, err)
+	}
+	if pe.Code != code {
+		t.Fatalf("expected code %s, got %s (%v)", code, pe.Code, err)
 	}
 }

--- a/internal/gcp/store/migrations/039_secretmanager_destroy_time.sql
+++ b/internal/gcp/store/migrations/039_secretmanager_destroy_time.sql
@@ -1,0 +1,3 @@
+-- Secret Manager version destroy timestamp: output-only, present only when the
+-- version state is DESTROYED.
+ALTER TABLE jc_sm_versions ADD COLUMN IF NOT EXISTS destroy_time TIMESTAMPTZ;

--- a/internal/gcp/store/secretmanager/postgres.go
+++ b/internal/gcp/store/secretmanager/postgres.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"sort"
+	"time"
 
 	"jaiscloud/internal/clock"
 
@@ -189,30 +190,34 @@ func (s *PostgresStore) CreateVersion(ctx context.Context, projectID string, v V
 		v.CreateTime = clock.Now()
 	}
 	_, err := s.pool.Exec(ctx, `
-		INSERT INTO jc_sm_versions (project_id, secret_id, version_id, state, create_time, data, kms_key_name, wrapped_dek)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
-	`, projectID, v.SecretID, v.VersionID, v.State, v.CreateTime, v.Data, v.KmsKeyName, v.WrappedDEK)
+		INSERT INTO jc_sm_versions (project_id, secret_id, version_id, state, create_time, destroy_time, data, kms_key_name, wrapped_dek)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+	`, projectID, v.SecretID, v.VersionID, v.State, v.CreateTime, nullableTime(v.DestroyTime), v.Data, v.KmsKeyName, v.WrappedDEK)
 	return err
 }
 
 func (s *PostgresStore) GetVersion(ctx context.Context, projectID, secretID, versionID string) (Version, error) {
 	var v Version
+	var destroyTime *time.Time
 	err := s.pool.QueryRow(ctx, `
-		SELECT secret_id, version_id, state, create_time, data, kms_key_name, wrapped_dek
+		SELECT secret_id, version_id, state, create_time, destroy_time, data, kms_key_name, wrapped_dek
 		FROM jc_sm_versions WHERE project_id=$1 AND secret_id=$2 AND version_id=$3
-	`, projectID, secretID, versionID).Scan(&v.SecretID, &v.VersionID, &v.State, &v.CreateTime, &v.Data, &v.KmsKeyName, &v.WrappedDEK)
+	`, projectID, secretID, versionID).Scan(&v.SecretID, &v.VersionID, &v.State, &v.CreateTime, &destroyTime, &v.Data, &v.KmsKeyName, &v.WrappedDEK)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Version{}, ErrNoSuchVersion
 	}
 	if err != nil {
 		return Version{}, err
 	}
+	if destroyTime != nil {
+		v.DestroyTime = *destroyTime
+	}
 	return v, nil
 }
 
 func (s *PostgresStore) ListVersions(ctx context.Context, projectID, secretID string) ([]Version, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT secret_id, version_id, state, create_time, data, kms_key_name, wrapped_dek
+		SELECT secret_id, version_id, state, create_time, destroy_time, data, kms_key_name, wrapped_dek
 		FROM jc_sm_versions WHERE project_id=$1 AND secret_id=$2 ORDER BY version_id
 	`, projectID, secretID)
 	if err != nil {
@@ -222,8 +227,12 @@ func (s *PostgresStore) ListVersions(ctx context.Context, projectID, secretID st
 	var result []Version
 	for rows.Next() {
 		var v Version
-		if err := rows.Scan(&v.SecretID, &v.VersionID, &v.State, &v.CreateTime, &v.Data, &v.KmsKeyName, &v.WrappedDEK); err != nil {
+		var destroyTime *time.Time
+		if err := rows.Scan(&v.SecretID, &v.VersionID, &v.State, &v.CreateTime, &destroyTime, &v.Data, &v.KmsKeyName, &v.WrappedDEK); err != nil {
 			return nil, err
+		}
+		if destroyTime != nil {
+			v.DestroyTime = *destroyTime
 		}
 		result = append(result, v)
 	}
@@ -233,8 +242,8 @@ func (s *PostgresStore) ListVersions(ctx context.Context, projectID, secretID st
 
 func (s *PostgresStore) UpdateVersion(ctx context.Context, projectID string, v Version) error {
 	tag, err := s.pool.Exec(ctx, `
-		UPDATE jc_sm_versions SET state=$4 WHERE project_id=$1 AND secret_id=$2 AND version_id=$3
-	`, projectID, v.SecretID, v.VersionID, v.State)
+		UPDATE jc_sm_versions SET state=$4, destroy_time=$5 WHERE project_id=$1 AND secret_id=$2 AND version_id=$3
+	`, projectID, v.SecretID, v.VersionID, v.State, nullableTime(v.DestroyTime))
 	if err != nil {
 		return err
 	}
@@ -265,4 +274,11 @@ func (s *PostgresStore) NextVersion(ctx context.Context, projectID, secretID str
 func (s *PostgresStore) Reset(ctx context.Context) {
 	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_sm_versions`)
 	_, _ = s.pool.Exec(ctx, `DELETE FROM jc_sm_secrets`)
+}
+
+func nullableTime(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
 }

--- a/internal/gcp/store/secretmanager/snapshot.go
+++ b/internal/gcp/store/secretmanager/snapshot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"time"
 )
 
 // --- Memory store ---
@@ -91,15 +92,19 @@ func (s *PostgresStore) Snapshot(ctx context.Context, w io.Writer) error {
 	}
 
 	versions := make([]versionRow, 0)
-	vrows, err := s.pool.Query(ctx, `SELECT project_id, secret_id, version_id, state, create_time, data FROM jc_sm_versions ORDER BY project_id, secret_id, version_id`)
+	vrows, err := s.pool.Query(ctx, `SELECT project_id, secret_id, version_id, state, create_time, destroy_time, data FROM jc_sm_versions ORDER BY project_id, secret_id, version_id`)
 	if err != nil {
 		return err
 	}
 	for vrows.Next() {
 		var r versionRow
-		if err := vrows.Scan(&r.ProjectID, &r.SecretID, &r.Version.VersionID, &r.Version.State, &r.Version.CreateTime, &r.Version.Data); err != nil {
+		var destroyTime *time.Time
+		if err := vrows.Scan(&r.ProjectID, &r.SecretID, &r.Version.VersionID, &r.Version.State, &r.Version.CreateTime, &destroyTime, &r.Version.Data); err != nil {
 			vrows.Close()
 			return err
+		}
+		if destroyTime != nil {
+			r.Version.DestroyTime = *destroyTime
 		}
 		r.Version.SecretID = r.SecretID
 		versions = append(versions, r)
@@ -153,8 +158,8 @@ func (s *PostgresStore) Restore(ctx context.Context, r io.Reader) error {
 		}
 	}
 	for _, r := range snap.Versions {
-		if _, err := tx.Exec(ctx, `INSERT INTO jc_sm_versions (project_id, secret_id, version_id, state, create_time, data) VALUES ($1,$2,$3,$4,$5,$6)`,
-			r.ProjectID, r.SecretID, r.Version.VersionID, r.Version.State, r.Version.CreateTime, r.Version.Data); err != nil {
+		if _, err := tx.Exec(ctx, `INSERT INTO jc_sm_versions (project_id, secret_id, version_id, state, create_time, destroy_time, data) VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+			r.ProjectID, r.SecretID, r.Version.VersionID, r.Version.State, r.Version.CreateTime, nullableTime(r.Version.DestroyTime), r.Version.Data); err != nil {
 			return err
 		}
 	}

--- a/internal/gcp/store/secretmanager/store.go
+++ b/internal/gcp/store/secretmanager/store.go
@@ -39,9 +39,11 @@ type Version struct {
 	VersionID  string
 	State      string
 	CreateTime time.Time
-	Data       string // base64 payload
-	KmsKeyName string
-	WrappedDEK []byte
+	// DestroyTime is set only when State is DESTROYED (output-only in the API).
+	DestroyTime time.Time
+	Data        string // base64 payload
+	KmsKeyName  string
+	WrappedDEK  []byte
 }
 
 // Store is the Secret Manager store.


### PR DESCRIPTION
## Description

Three verified Secret Manager parity gaps from the GCP compatibility audit
(`plan_docs/gcp-parity-gaps-plan.md`: G4, G6, G12):

- **State not enforced:** `AccessSecretVersion` returned the payload for `DISABLED`
  and `DESTROYED` versions, and `Enable`/`Disable` could move a `DESTROYED`
  version (which is terminal in real Secret Manager).
- **REST IAM broken:** `GET/POST .../secrets/{s}:getIamPolicy|:setIamPolicy|:testIamPermissions`
  returned `400 no handler for "Secret.SecretGetIamPolicy"` — the codec emitted
  `SecretGetIamPolicy` while the service prefix is also `Secret`, so the dispatch
  key was doubled. gRPC IAM already worked.
- **`destroyTime` missing:** `DestroySecretVersion` never recorded or returned it.

## What's in this PR

- `provider/secretmanager` + `grpc/secretmanager`:
  - `AccessSecretVersion` returns `FailedPrecondition` for any non-`ENABLED` version.
  - `DESTROYED` is terminal: `EnableSecretVersion`/`DisableSecretVersion` on a
    destroyed version fail with `FailedPrecondition`; `Destroy` sets `destroyTime`.
  - `destroyTime` is emitted only when the state is `DESTROYED`.
  - REST errors carry `status: FAILED_PRECONDITION`.
- `adapter/jsoncodec.go`: secret IAM custom methods now emit bare
  `GetIamPolicy`/`SetIamPolicy`/`TestIamPermissions`, resolving to the registered
  `Secret.*` routes.
- `store/secretmanager`: `Version.DestroyTime`; migration `039` adds the
  `destroy_time` column; memory, Postgres (CRUD + snapshot) updated.

## Out of scope

- Rotation/CMEK and other Secret Manager behavior.
- Cloud KMS destroyed-version enforcement (G5), GCS `copyTo` (G3), Pub/Sub filters (G7).

## How to test

```bash
go build ./... && go vet ./internal/gcp/... && gofmt -l internal/gcp/
go test ./internal/gcp/store/secretmanager/ ./internal/gcp/provider/secretmanager/ \
        ./internal/gcp/grpc/secretmanager/ ./internal/gcp/adapter/ -count=1
```

End-to-end (REST): create a secret, `:getIamPolicy` (was 400, now 200), add a
version, `:disable`, then `:access` → 400 `FAILED_PRECONDITION`; `:destroy` returns
`destroyTime`; `:enable` on the destroyed version → 400.

## Test report

- `go test ./internal/gcp/...` green; `vet`/`gofmt` clean.
- New/updated: `TestSecretVersionStateEnforcement`, `TestSecretIAMRoutesRegistered`,
  deterministic `TestSecretVersionLifecycle` (was map-order dependent), gRPC
  lifecycle test now asserts `destroyTime` + terminal state; adapter codec test
  updated to the bare IAM action names.
- localgcp Secret Manager replay vs a live server: **16/16 pass** (was 13/3 —
  `TestDisableVersion`, `TestDestroyVersion`, `TestVersionStateTransitions` now pass).
- REST envelope check: disabled access returns
  `{"code":400,"message":"secret version 1 is DISABLED, not ENABLED","status":"FAILED_PRECONDITION"}`.

## Conformance audit

- `SecretVersion.state`: `DISABLED` "may not be accessed"; `DESTROYED` "may not
  leave this state once entered" — Secret Manager Discovery / docs.
- `destroyTime`: output-only, present only when `DESTROYED`.
- Secret IAM methods exist on the secret resource (`projects.secrets.getIamPolicy`
  etc.); the fix routes the documented REST paths to the existing handlers.
