### PR TITLE
fix(gcp/kms): reject use of non-ENABLED versions, report real primary state

### DIFF
--- a/internal/gcp/grpc/kms/service.go
+++ b/internal/gcp/grpc/kms/service.go
@@ -70,6 +70,37 @@ func keyRingErr(err error) error {
 	return mapError(err)
 }
 
+// requireVersionEnabled rejects use of a crypto-key version that is not ENABLED.
+func (s *Service) requireVersionEnabled(ctx context.Context, project, loc, kr, key, version string) error {
+	v, err := s.keys.GetVersion(ctx, project, loc, kr, key, version)
+	if err != nil {
+		return versionErr(err)
+	}
+	if v.State != "ENABLED" {
+		return mapError(versionNotEnabledErr(version, v.State))
+	}
+	return nil
+}
+
+// primaryState reports the state of a crypto key's primary version.
+func (s *Service) primaryState(ctx context.Context, project string, k kmsstore.CryptoKey) string {
+	if k.PrimaryVersion == "" {
+		return "ENABLED"
+	}
+	v, err := s.keys.GetVersion(ctx, project, k.Location, k.KeyRingID, k.ID, k.PrimaryVersion)
+	if err != nil || v.State == "" {
+		return "ENABLED"
+	}
+	return v.State
+}
+
+func versionNotEnabledErr(version, state string) *model.ProviderError {
+	return &model.ProviderError{
+		Code: "FailedPrecondition", HTTPStatus: 400, Status: "FAILED_PRECONDITION",
+		Message: "CryptoKeyVersion " + version + " is " + state,
+	}
+}
+
 func keyErr(err error) error {
 	if errors.Is(err, kmsstore.ErrNoSuchCryptoKey) {
 		return mapError(model.NewProviderError("NotFound", "crypto key not found", 404))
@@ -236,7 +267,7 @@ func (s *Service) ListCryptoKeys(ctx context.Context, req *kmspb.ListCryptoKeysR
 		map[string]any{"pageSize": int(req.GetPageSize()), "pageToken": req.GetPageToken()})
 	out := make([]*kmspb.CryptoKey, 0, len(page))
 	for _, k := range page {
-		out = append(out, cryptoKeyToProto(project, k))
+		out = append(out, cryptoKeyToProto(project, k, s.primaryState(ctx, project, k)))
 	}
 	return &kmspb.ListCryptoKeysResponse{CryptoKeys: out, NextPageToken: next, TotalSize: int32(len(keys))}, nil
 }
@@ -289,7 +320,7 @@ func (s *Service) CreateCryptoKey(ctx context.Context, req *kmspb.CreateCryptoKe
 		}
 		return nil, mapError(err)
 	}
-	return cryptoKeyToProto(project, ck), nil
+	return cryptoKeyToProto(project, ck, "ENABLED"), nil
 }
 
 func (s *Service) GetCryptoKey(ctx context.Context, req *kmspb.GetCryptoKeyRequest) (*kmspb.CryptoKey, error) {
@@ -301,7 +332,7 @@ func (s *Service) GetCryptoKey(ctx context.Context, req *kmspb.GetCryptoKeyReque
 	if err != nil {
 		return nil, keyErr(err)
 	}
-	return cryptoKeyToProto(project, k), nil
+	return cryptoKeyToProto(project, k, s.primaryState(ctx, project, k)), nil
 }
 
 // UpdateCryptoKey applies the update_mask to the mutable fields. `labels` and
@@ -330,7 +361,7 @@ func (s *Service) UpdateCryptoKey(ctx context.Context, req *kmspb.UpdateCryptoKe
 	if err != nil {
 		return nil, keyErr(err)
 	}
-	return cryptoKeyToProto(project, k), nil
+	return cryptoKeyToProto(project, k, s.primaryState(ctx, project, k)), nil
 }
 
 // applyCryptoKeyMask merges an incoming crypto key into the stored key
@@ -375,7 +406,7 @@ func (s *Service) UpdateCryptoKeyPrimaryVersion(ctx context.Context, req *kmspb.
 		return nil, versionErr(err)
 	}
 	ck, _ := s.keys.GetCryptoKey(ctx, project, loc, kr, key)
-	return cryptoKeyToProto(project, ck), nil
+	return cryptoKeyToProto(project, ck, s.primaryState(ctx, project, ck)), nil
 }
 
 // ─── CryptoKeyVersions ────────────────────────────────────────────────────────
@@ -482,6 +513,9 @@ func (s *Service) Encrypt(ctx context.Context, req *kmspb.EncryptRequest) (*kmsp
 	if version == "" {
 		version = ck.PrimaryVersion
 	}
+	if err := s.requireVersionEnabled(ctx, project, loc, kr, key, version); err != nil {
+		return nil, err
+	}
 	keyMat, err := s.keys.KeyMaterial(ctx, project, loc, kr, key, version)
 	if err != nil {
 		return nil, versionErr(err)
@@ -520,6 +554,9 @@ func (s *Service) Decrypt(ctx context.Context, req *kmspb.DecryptRequest) (*kmsp
 	if err != nil {
 		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid ciphertext", 400))
 	}
+	if err := s.requireVersionEnabled(ctx, project, loc, kr, key, version); err != nil {
+		return nil, err
+	}
 	keyMat, err := s.keys.KeyMaterial(ctx, project, loc, kr, key, version)
 	if err != nil {
 		return nil, versionErr(err)
@@ -544,6 +581,9 @@ func (s *Service) AsymmetricSign(ctx context.Context, req *kmspb.AsymmetricSignR
 	v, err := s.keys.GetVersion(ctx, project, loc, kr, key, version)
 	if err != nil {
 		return nil, versionErr(err)
+	}
+	if v.State != "ENABLED" {
+		return nil, mapError(versionNotEnabledErr(version, v.State))
 	}
 	digest, err := digestBytes(req.GetDigest(), req.GetData(), v.Algorithm)
 	if err != nil {
@@ -589,6 +629,9 @@ func (s *Service) AsymmetricDecrypt(ctx context.Context, req *kmspb.AsymmetricDe
 	v, err := s.keys.GetVersion(ctx, project, loc, kr, key, version)
 	if err != nil {
 		return nil, versionErr(err)
+	}
+	if v.State != "ENABLED" {
+		return nil, mapError(versionNotEnabledErr(version, v.State))
 	}
 	priv, err := s.keys.PrivateKey(ctx, project, loc, kr, key, version)
 	if err != nil {
@@ -640,6 +683,9 @@ func (s *Service) GetPublicKey(ctx context.Context, req *kmspb.GetPublicKeyReque
 	if err != nil {
 		return nil, versionErr(err)
 	}
+	if v.State != "ENABLED" {
+		return nil, mapError(versionNotEnabledErr(version, v.State))
+	}
 	pub, err := s.keys.PublicKey(ctx, project, loc, kr, key, version)
 	if err != nil {
 		return nil, versionErr(err)
@@ -665,6 +711,9 @@ func (s *Service) MacSign(ctx context.Context, req *kmspb.MacSignRequest) (*kmsp
 	v, err := s.keys.GetVersion(ctx, project, loc, kr, key, version)
 	if err != nil {
 		return nil, versionErr(err)
+	}
+	if v.State != "ENABLED" {
+		return nil, mapError(versionNotEnabledErr(version, v.State))
 	}
 	if !strings.HasPrefix(v.Algorithm, "HMAC_") {
 		return nil, mapError(model.NewProviderError("FailedPrecondition", "key is not for MAC", 400))
@@ -697,6 +746,9 @@ func (s *Service) MacVerify(ctx context.Context, req *kmspb.MacVerifyRequest) (*
 	v, err := s.keys.GetVersion(ctx, project, loc, kr, key, version)
 	if err != nil {
 		return nil, versionErr(err)
+	}
+	if v.State != "ENABLED" {
+		return nil, mapError(versionNotEnabledErr(version, v.State))
 	}
 	if !strings.HasPrefix(v.Algorithm, "HMAC_") {
 		return nil, mapError(model.NewProviderError("FailedPrecondition", "key is not for MAC", 400))
@@ -823,13 +875,16 @@ func keyRingToProto(project, location string, kr kmsstore.KeyRing) *kmspb.KeyRin
 	return out
 }
 
-func cryptoKeyToProto(project string, k kmsstore.CryptoKey) *kmspb.CryptoKey {
+func cryptoKeyToProto(project string, k kmsstore.CryptoKey, primaryState string) *kmspb.CryptoKey {
+	if primaryState == "" {
+		primaryState = "ENABLED"
+	}
 	out := &kmspb.CryptoKey{
 		Name:    cryptoKeyName(project, k.Location, k.KeyRingID, k.ID),
 		Purpose: purposeToProto(k.Purpose),
 		Primary: &kmspb.CryptoKeyVersion{
 			Name:            versionName(project, k.Location, k.KeyRingID, k.ID, k.PrimaryVersion),
-			State:           kmspb.CryptoKeyVersion_ENABLED,
+			State:           stateToProto(primaryState),
 			Algorithm:       algorithmToProto(k.Algorithm),
 			ProtectionLevel: kmspb.ProtectionLevel_SOFTWARE,
 		},

--- a/internal/gcp/grpc/kms/service_test.go
+++ b/internal/gcp/grpc/kms/service_test.go
@@ -485,6 +485,18 @@ func TestKMSDestroyVersion(t *testing.T) {
 		t.Fatalf("DestroyCryptoKeyVersion state = %v, want DESTROYED", destroyed.GetState())
 	}
 
+	// A destroyed version cannot be used, and the primary reports its state.
+	if _, err := client.Encrypt(ctx, &kmspb.EncryptRequest{Name: symKey, Plaintext: []byte("hi")}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("Encrypt destroyed err = %v, want FailedPrecondition", err)
+	}
+	got, err := client.GetCryptoKey(ctx, &kmspb.GetCryptoKeyRequest{Name: symKey})
+	if err != nil {
+		t.Fatalf("GetCryptoKey: %v", err)
+	}
+	if got.GetPrimary().GetState() != kmspb.CryptoKeyVersion_DESTROYED {
+		t.Fatalf("primary.state = %v, want DESTROYED", got.GetPrimary().GetState())
+	}
+
 	// Restore brings it back to DISABLED (GCP semantics).
 	restored, err := client.RestoreCryptoKeyVersion(ctx, &kmspb.RestoreCryptoKeyVersionRequest{Name: verName})
 	if err != nil {

--- a/internal/gcp/provider/kms/kms.go
+++ b/internal/gcp/provider/kms/kms.go
@@ -110,14 +110,17 @@ func cryptoKeyVersionName(nr *model.NormalizedRequest, loc, kr, key, version str
 }
 
 // cryptoKeyMap renders a CryptoKey as its GCP response object.
-func cryptoKeyMap(nr *model.NormalizedRequest, k kmsstore.CryptoKey) map[string]any {
+func cryptoKeyMap(nr *model.NormalizedRequest, k kmsstore.CryptoKey, primaryState string) map[string]any {
+	if primaryState == "" {
+		primaryState = "ENABLED"
+	}
 	out := map[string]any{
 		"name":       cryptoKeyName(nr, k.Location, k.KeyRingID, k.ID),
 		"purpose":    k.Purpose,
 		"createTime": k.CreateTime.UTC().Format(time.RFC3339Nano),
 		"primary": map[string]any{
 			"name":      cryptoKeyVersionName(nr, k.Location, k.KeyRingID, k.ID, k.PrimaryVersion),
-			"state":     "ENABLED", // the emulator never disables a primary version
+			"state":     primaryState,
 			"algorithm": k.Algorithm,
 		},
 		"versionTemplate": map[string]any{
@@ -307,7 +310,7 @@ func (p *Provider) CryptoKeyCreate(ctx context.Context, nr *model.NormalizedRequ
 		}
 		return nil, err
 	}
-	return provider.OK(cryptoKeyMap(nr, ck)), nil
+	return provider.OK(cryptoKeyMap(nr, ck, "ENABLED")), nil
 }
 
 func (p *Provider) CryptoKeyList(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
@@ -323,7 +326,7 @@ func (p *Provider) CryptoKeyList(ctx context.Context, nr *model.NormalizedReques
 	page, next := paging.Page(keys, func(k kmsstore.CryptoKey) string { return k.ID }, nr.Params)
 	items := make([]any, 0, len(page))
 	for _, k := range page {
-		items = append(items, cryptoKeyMap(nr, k))
+		items = append(items, cryptoKeyMap(nr, k, p.primaryState(ctx, nr.AccountID, k)))
 	}
 	resp := map[string]any{"cryptoKeys": items, "totalSize": len(keys)}
 	if next != "" {
@@ -342,7 +345,7 @@ func (p *Provider) CryptoKeyGet(ctx context.Context, nr *model.NormalizedRequest
 	if err != nil {
 		return nil, p.keyErr(err)
 	}
-	return provider.OK(cryptoKeyMap(nr, k)), nil
+	return provider.OK(cryptoKeyMap(nr, k, p.primaryState(ctx, nr.AccountID, k))), nil
 }
 
 func (p *Provider) CryptoKeyEncrypt(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
@@ -354,6 +357,9 @@ func (p *Provider) CryptoKeyEncrypt(ctx context.Context, nr *model.NormalizedReq
 	ck, err := p.keys.GetCryptoKey(ctx, nr.AccountID, loc, kr, key)
 	if err != nil {
 		return nil, p.keyErr(err)
+	}
+	if err := p.requireVersionEnabled(ctx, nr.AccountID, loc, kr, key, ck.PrimaryVersion); err != nil {
+		return nil, err
 	}
 	body, _ := nr.Params["body"].(map[string]any)
 	pt, err := base64.StdEncoding.DecodeString(body["plaintext"].(string))
@@ -389,6 +395,9 @@ func (p *Provider) CryptoKeyDecrypt(ctx context.Context, nr *model.NormalizedReq
 	ck, err := p.keys.GetCryptoKey(ctx, nr.AccountID, loc, kr, key)
 	if err != nil {
 		return nil, p.keyErr(err)
+	}
+	if err := p.requireVersionEnabled(ctx, nr.AccountID, loc, kr, key, ck.PrimaryVersion); err != nil {
+		return nil, err
 	}
 	body, _ := nr.Params["body"].(map[string]any)
 	blob, err := base64.StdEncoding.DecodeString(body["ciphertext"].(string))
@@ -515,7 +524,7 @@ func (p *Provider) CryptoKeyUpdatePrimaryVersion(ctx context.Context, nr *model.
 		return nil, p.versionErr(err)
 	}
 	ck, _ := p.keys.GetCryptoKey(ctx, nr.AccountID, loc, kr, key)
-	return provider.OK(cryptoKeyMap(nr, ck)), nil
+	return provider.OK(cryptoKeyMap(nr, ck, p.primaryState(ctx, nr.AccountID, ck))), nil
 }
 
 // defaultAlgorithmForPurpose maps a GCP KMS purpose to its default algorithm.
@@ -541,6 +550,9 @@ func (p *Provider) CryptoKeyVersionAsymmetricSign(ctx context.Context, nr *model
 	v, err := p.keys.GetVersion(ctx, nr.AccountID, loc, kr, key, version)
 	if err != nil {
 		return nil, p.versionErr(err)
+	}
+	if v.State != "ENABLED" {
+		return nil, versionNotEnabledErr(version, v.State)
 	}
 	body, _ := nr.Params["body"].(map[string]any)
 	// GCP's AsymmetricSignRequest carries the digest as an object with one of
@@ -596,6 +608,9 @@ func (p *Provider) CryptoKeyVersionAsymmetricDecrypt(ctx context.Context, nr *mo
 	if err != nil {
 		return nil, p.versionErr(err)
 	}
+	if v.State != "ENABLED" {
+		return nil, versionNotEnabledErr(version, v.State)
+	}
 	body, _ := nr.Params["body"].(map[string]any)
 	ct, err := base64.StdEncoding.DecodeString(body["ciphertext"].(string))
 	if err != nil {
@@ -629,6 +644,9 @@ func (p *Provider) CryptoKeyVersionMacSign(ctx context.Context, nr *model.Normal
 	v, err := p.keys.GetVersion(ctx, nr.AccountID, loc, kr, key, version)
 	if err != nil {
 		return nil, p.versionErr(err)
+	}
+	if v.State != "ENABLED" {
+		return nil, versionNotEnabledErr(version, v.State)
 	}
 	if !strings.HasPrefix(v.Algorithm, "HMAC_") {
 		return nil, model.NewProviderError("FailedPrecondition", "key is not for MAC", 400)
@@ -664,6 +682,9 @@ func (p *Provider) CryptoKeyVersionMacVerify(ctx context.Context, nr *model.Norm
 	v, err := p.keys.GetVersion(ctx, nr.AccountID, loc, kr, key, version)
 	if err != nil {
 		return nil, p.versionErr(err)
+	}
+	if v.State != "ENABLED" {
+		return nil, versionNotEnabledErr(version, v.State)
 	}
 	if !strings.HasPrefix(v.Algorithm, "HMAC_") {
 		return nil, model.NewProviderError("FailedPrecondition", "key is not for MAC", 400)
@@ -701,6 +722,9 @@ func (p *Provider) CryptoKeyVersionGetPublicKey(ctx context.Context, nr *model.N
 	if err != nil {
 		return nil, p.versionErr(err)
 	}
+	if v.State != "ENABLED" {
+		return nil, versionNotEnabledErr(version, v.State)
+	}
 	pub, err := p.keys.PublicKey(ctx, nr.AccountID, loc, kr, key, version)
 	if err != nil {
 		return nil, p.versionErr(err)
@@ -729,6 +753,38 @@ func decodeAAD(v any) []byte {
 		return nil
 	}
 	return b
+}
+
+// requireVersionEnabled rejects use of a crypto-key version that is not
+// ENABLED (DISABLED/DESTROYED/PENDING) with FailedPrecondition.
+func (p *Provider) requireVersionEnabled(ctx context.Context, accountID, loc, kr, key, version string) error {
+	v, err := p.keys.GetVersion(ctx, accountID, loc, kr, key, version)
+	if err != nil {
+		return p.versionErr(err)
+	}
+	if v.State != "ENABLED" {
+		return versionNotEnabledErr(version, v.State)
+	}
+	return nil
+}
+
+// primaryState reports the current state of a crypto key's primary version.
+func (p *Provider) primaryState(ctx context.Context, accountID string, k kmsstore.CryptoKey) string {
+	if k.PrimaryVersion == "" {
+		return "ENABLED"
+	}
+	v, err := p.keys.GetVersion(ctx, accountID, k.Location, k.KeyRingID, k.ID, k.PrimaryVersion)
+	if err != nil || v.State == "" {
+		return "ENABLED"
+	}
+	return v.State
+}
+
+func versionNotEnabledErr(version, state string) error {
+	return &model.ProviderError{
+		Code: "FailedPrecondition", HTTPStatus: 400, Status: "FAILED_PRECONDITION",
+		Message: "CryptoKeyVersion " + version + " is " + state,
+	}
 }
 
 // keyErr maps crypto-key store errors to GCP provider errors.

--- a/internal/gcp/provider/kms/kms_extra_test.go
+++ b/internal/gcp/provider/kms/kms_extra_test.go
@@ -214,3 +214,47 @@ func TestKMSRotation(t *testing.T) {
 		t.Errorf("expected DESTROYED, got %v", dr.Data["state"])
 	}
 }
+
+// TestKMSDestroyedPrimaryUnusable verifies a DESTROYED primary version cannot
+// be used for encryption and that GetCryptoKey reports its real state.
+func TestKMSDestroyedPrimaryUnusable(t *testing.T) {
+	ctx := context.Background()
+	p := New(kmsstore.NewMemoryStore())
+
+	if _, err := p.KeyRingCreate(ctx, newNR(map[string]any{"location": "global", "keyRingId": "kr"})); err != nil {
+		t.Fatalf("keyring: %v", err)
+	}
+	if _, err := p.CryptoKeyCreate(ctx, newNR(map[string]any{"name": "locations/global/keyRings/kr", "cryptoKeyId": "k"})); err != nil {
+		t.Fatalf("cryptokey: %v", err)
+	}
+	keyName := "locations/global/keyRings/kr/cryptoKeys/k"
+
+	// Encrypt works while the primary is ENABLED.
+	if _, err := p.CryptoKeyEncrypt(ctx, newNR(map[string]any{"name": keyName, "body": map[string]any{"plaintext": "aGVsbG8="}})); err != nil {
+		t.Fatalf("encrypt before destroy: %v", err)
+	}
+
+	// Destroy the primary version.
+	if _, err := p.CryptoKeyVersionDestroy(ctx, newNR(map[string]any{"name": keyName + "/cryptoKeyVersions/1"})); err != nil {
+		t.Fatalf("destroy: %v", err)
+	}
+
+	// Encrypt must now fail with FailedPrecondition.
+	_, err := p.CryptoKeyEncrypt(ctx, newNR(map[string]any{"name": keyName, "body": map[string]any{"plaintext": "aGVsbG8="}}))
+	if err == nil {
+		t.Fatal("expected encrypt against destroyed primary to fail")
+	}
+	if pe, ok := err.(*model.ProviderError); !ok || pe.Code != "FailedPrecondition" {
+		t.Fatalf("expected FailedPrecondition, got %v", err)
+	}
+
+	// GetCryptoKey reports the real primary state.
+	resp, err := p.CryptoKeyGet(ctx, newNR(map[string]any{"name": keyName}))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	primary, _ := resp.Data["primary"].(map[string]any)
+	if primary["state"] != "DESTROYED" {
+		t.Fatalf("primary.state = %v, want DESTROYED", primary["state"])
+	}
+}


### PR DESCRIPTION
## Description

Verified gap G5 from the GCP compatibility audit (`plan_docs/gcp-parity-gaps-plan.md`):
KMS ignored `CryptoKeyVersion.state` on the data path. `Encrypt`/`Decrypt`,
`AsymmetricSign`/`AsymmetricDecrypt`, `MacSign`/`MacVerify` and `GetPublicKey` all
succeeded against `DISABLED` and `DESTROYED` versions, and `CryptoKey.primary.state`
was hardcoded to `ENABLED` regardless of the stored version.

Real KMS only uses `ENABLED` versions and reports the primary's actual state.

## What's in this PR

- `provider/kms` + `grpc/kms`: use of a version whose state is not `ENABLED` now
  fails with `FailedPrecondition` (REST envelope `status: FAILED_PRECONDITION`).
  `Encrypt`/`Decrypt` guard the primary (or explicitly named) version; the
  sign/decrypt/MAC/public-key paths guard the named version.
- `CryptoKey.primary.state` now reflects the stored version's state instead of a
  constant (`cryptoKeyMap` / `cryptoKeyToProto` take the resolved state).
- State transitions are untouched: `Destroy`/`Restore`/`UpdateCryptoKeyVersion`
  still work, so a destroyed version can be restored to `DISABLED` (real KMS
  behaviour) — only *use* of a non-`ENABLED` version is rejected.

## Out of scope

- Key material wiping on destroy, rotation execution, other KMS surfaces.
- Remaining verified gaps (G3 GCS copyTo, G7 Pub/Sub filters, G8 mediaLink).

## How to test

```bash
go build ./... && go vet ./internal/gcp/... && gofmt -l internal/gcp/
go test ./internal/gcp/store/kms/ ./internal/gcp/provider/kms/ ./internal/gcp/grpc/kms/ -count=1
```

## Test report

- `go test ./internal/gcp/...` green; `vet`/`gofmt` clean.
- Provider: `TestKMSDestroyedPrimaryUnusable` — encrypt before destroy succeeds,
  after destroy fails `FailedPrecondition`, and `GetCryptoKey` reports
  `primary.state = DESTROYED`.
- gRPC: `TestKMSDestroyVersion` now asserts `Encrypt` → `FailedPrecondition` and
  `primary.state = DESTROYED` on a destroyed version, while still exercising the
  destroy → restore → enable sequence.
- localgcp replay: Cloud KMS **5/5** (was 4/1 — `TestDestroyVersion` now passes).

## Conformance audit

- `CryptoKeyVersion.state`: only `ENABLED` versions may be used; `DISABLED`
  versions are not usable, `DESTROYED` versions have no usable material
  (KMS Discovery / CryptoKeyVersion docs).
- `CryptoKey.primary` is the version used by `Encrypt`; its reported state must
  match the stored version.
- `RestoreCryptoKeyVersion` moves a destroyed version back to `DISABLED` —
  unchanged by this PR.
