### PR TITLE
fix(gcp/pubsub): subscription filters, DetachSubscription, topic-delete orphaning

### DIFF
--- a/internal/gcp/adapter/jsoncodec.go
+++ b/internal/gcp/adapter/jsoncodec.go
@@ -282,6 +282,8 @@ func deriveAction(resourceType string, isCollection bool, name, method, custom s
 			}
 		case "subscriptions":
 			switch custom {
+			case "detach":
+				return "SubscriptionDetach"
 			case "pull":
 				return "SubscriptionPull"
 			case "acknowledge":

--- a/internal/gcp/adapter/jsoncodec_test.go
+++ b/internal/gcp/adapter/jsoncodec_test.go
@@ -163,3 +163,15 @@ func TestDetectV1Service(t *testing.T) {
 		}
 	}
 }
+
+func TestJSONCodecSubscriptionDetachRouting(t *testing.T) {
+	c := &JSONCodec{Service: "pubsub"}
+	r := httptest.NewRequest("POST", "/v1/projects/p/subscriptions/s:detach", nil)
+	nr, err := c.Decode(r, nil)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if nr.Action != "SubscriptionDetach" {
+		t.Fatalf("expected SubscriptionDetach, got %q", nr.Action)
+	}
+}

--- a/internal/gcp/grpc/pubsub/service.go
+++ b/internal/gcp/grpc/pubsub/service.go
@@ -24,6 +24,7 @@ import (
 	grpcutil "jaiscloud/internal/gcp/grpc"
 	"jaiscloud/internal/gcp/paging"
 	"jaiscloud/internal/gcp/policy"
+	"jaiscloud/internal/gcp/pubsubfilter"
 	kmsstore "jaiscloud/internal/gcp/store/kms"
 	pubsubstore "jaiscloud/internal/gcp/store/pubsub"
 	"jaiscloud/internal/model"
@@ -194,6 +195,23 @@ func (s *Service) DeleteTopic(ctx context.Context, req *pubsubpb.DeleteTopicRequ
 		}
 		return nil, mapError(err)
 	}
+	// Existing subscriptions are not deleted; their topic is set to the
+	// sentinel "_deleted-topic_" (real Pub/Sub behaviour).
+	topicFull := topicName(project, t)
+	if entries, err := s.resources.List(ctx, project, store.GlobalRegion, rtSubscription, ""); err == nil {
+		for _, e := range entries {
+			var meta map[string]any
+			if json.Unmarshal(e.Data, &meta) != nil {
+				continue
+			}
+			if st, _ := meta["topic"].(string); st != topicFull {
+				continue
+			}
+			meta["topic"] = "_deleted-topic_"
+			data, _ := json.Marshal(meta)
+			_ = s.resources.Update(ctx, project, store.GlobalRegion, store.ResourceEntry{Type: rtSubscription, ID: e.ID, Data: data})
+		}
+	}
 	return &emptypb.Empty{}, nil
 }
 
@@ -321,6 +339,17 @@ func (s *Service) CreateSubscription(ctx context.Context, req *pubsubpb.Subscrip
 	if project == "" {
 		project = grpcutil.ProjectFromMetadata(ctx, s.defaultProj)
 	}
+	// The topic must already exist (real Pub/Sub returns NotFound otherwise).
+	_, topicID, ok := splitTopicName(req.GetTopic())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid topic name", 400))
+	}
+	if _, err := s.resources.Get(ctx, project, store.GlobalRegion, rtTopic, topicID); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, mapError(model.NewProviderError("NotFound", "topic not found", 404))
+		}
+		return nil, mapError(err)
+	}
 	ackDeadline := 10
 	if req.GetAckDeadlineSeconds() != 0 {
 		ackDeadline = int(req.GetAckDeadlineSeconds())
@@ -329,6 +358,15 @@ func (s *Service) CreateSubscription(ctx context.Context, req *pubsubpb.Subscrip
 		"name":               subscriptionName(project, sub),
 		"topic":              req.GetTopic(),
 		"ackDeadlineSeconds": ackDeadline,
+	}
+	if f := req.GetFilter(); f != "" {
+		if _, err := pubsubfilter.Compile(f); err != nil {
+			return nil, mapError(model.NewProviderError("InvalidArgument", "invalid subscription filter: "+err.Error(), 400))
+		}
+		meta["filter"] = f
+	}
+	if len(req.GetLabels()) > 0 {
+		meta["labels"] = req.GetLabels()
 	}
 	if dlp := req.GetDeadLetterPolicy(); dlp != nil {
 		meta["deadLetterPolicy"] = map[string]any{
@@ -411,6 +449,13 @@ func (s *Service) Pull(ctx context.Context, req *pubsubpb.PullRequest) (*pubsubp
 	}
 	var meta map[string]any
 	json.Unmarshal(e.Data, &meta)
+	if detached, _ := meta["detached"].(bool); detached {
+		return nil, mapError(&model.ProviderError{
+			Code: "FailedPrecondition", HTTPStatus: 400, Status: "FAILED_PRECONDITION",
+			Message: "subscription " + sub + " is detached",
+		})
+	}
+	subFilter, _ := meta["filter"].(string)
 	topic, _ := meta["topic"].(string)
 	topicID := topic
 	if i := strings.LastIndex(topicID, "/"); i >= 0 {
@@ -453,6 +498,7 @@ func (s *Service) Pull(ctx context.Context, req *pubsubpb.PullRequest) (*pubsubp
 		return nil, mapError(err)
 	}
 
+	msgs = s.filterMessages(ctx, sub, subFilter, msgs)
 	received, err := s.buildReceivedMessages(ctx, project, sub, dlqTopic, maxDeliveryAttempts, msgs)
 	if err != nil {
 		return nil, err
@@ -560,6 +606,13 @@ func (s *Service) StreamingPull(stream pubsubpb.Subscriber_StreamingPullServer) 
 	}
 	var meta map[string]any
 	json.Unmarshal(e.Data, &meta)
+	if detached, _ := meta["detached"].(bool); detached {
+		return mapError(&model.ProviderError{
+			Code: "FailedPrecondition", HTTPStatus: 400, Status: "FAILED_PRECONDITION",
+			Message: "subscription " + sub + " is detached",
+		})
+	}
+	subFilter, _ := meta["filter"].(string)
 	topic, _ := meta["topic"].(string)
 	topicID := topic
 	if i := strings.LastIndex(topicID, "/"); i >= 0 {
@@ -657,6 +710,7 @@ func (s *Service) StreamingPull(stream pubsubpb.Subscriber_StreamingPullServer) 
 			return mapError(err)
 		}
 		if len(msgs) > 0 {
+			msgs = s.filterMessages(ctx, sub, subFilter, msgs)
 			received, err := s.buildReceivedMessages(ctx, project, sub, dlqTopic, maxDeliveryAttempts, msgs)
 			if err != nil {
 				return err
@@ -796,6 +850,105 @@ func (s *Service) ModifyAckDeadline(ctx context.Context, req *pubsubpb.ModifyAck
 	return &emptypb.Empty{}, nil
 }
 
+// filterMessages drops (and deletes) messages that do not match a
+// subscription's filter. Filters are immutable, so a non-matching message will
+// never be delivered to this subscription and is discarded for it.
+func (s *Service) filterMessages(ctx context.Context, queue, filterExpr string, msgs []pubsubstore.Message) []pubsubstore.Message {
+	filter, err := pubsubfilter.Compile(filterExpr)
+	if err != nil || filter == nil {
+		return msgs
+	}
+	kept := make([]pubsubstore.Message, 0, len(msgs))
+	for _, m := range msgs {
+		if filter.Match(m.Attributes) {
+			kept = append(kept, m)
+		} else {
+			_ = s.messages.Delete(ctx, queue, m.MessageID)
+		}
+	}
+	return kept
+}
+
+// UpdateSubscription applies an update_mask to a subscription. The filter is
+// immutable (rejected even when unchanged); labels and ack_deadline_seconds are
+// supported.
+func (s *Service) UpdateSubscription(ctx context.Context, req *pubsubpb.UpdateSubscriptionRequest) (*pubsubpb.Subscription, error) {
+	in := req.GetSubscription()
+	if in == nil {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "subscription is required", 400))
+	}
+	project, id, ok := splitSubscriptionName(in.GetName())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid subscription name", 400))
+	}
+	e, err := s.resources.Get(ctx, project, store.GlobalRegion, rtSubscription, id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, mapError(model.NewProviderError("NotFound", "subscription not found", 404))
+		}
+		return nil, mapError(err)
+	}
+	var meta map[string]any
+	json.Unmarshal(e.Data, &meta)
+
+	paths := req.GetUpdateMask().GetPaths()
+	if len(paths) == 0 {
+		paths = []string{"labels"}
+	}
+	for _, p := range paths {
+		switch p {
+		case "filter":
+			return nil, mapError(model.NewProviderError("InvalidArgument",
+				"subscription filter is immutable and cannot be updated", 400))
+		case "labels":
+			if len(in.GetLabels()) == 0 {
+				delete(meta, "labels")
+			} else {
+				meta["labels"] = in.GetLabels()
+			}
+		case "ack_deadline_seconds", "ackDeadlineSeconds":
+			meta["ackDeadlineSeconds"] = int(in.GetAckDeadlineSeconds())
+		default:
+			return nil, mapError(model.NewProviderError("InvalidArgument", "unsupported update_mask path: "+p, 400))
+		}
+	}
+	data, _ := json.Marshal(meta)
+	if err := s.resources.Update(ctx, project, store.GlobalRegion, store.ResourceEntry{Type: rtSubscription, ID: id, Data: data}); err != nil {
+		return nil, mapError(err)
+	}
+	return subToProto(meta), nil
+}
+
+// DetachSubscription detaches a subscription from its topic: it stops receiving
+// messages, its backlog is dropped, and Pull returns FailedPrecondition. The
+// subscription resource is retained (real Pub/Sub DetachSubscription).
+func (s *Service) DetachSubscription(ctx context.Context, req *pubsubpb.DetachSubscriptionRequest) (*pubsubpb.DetachSubscriptionResponse, error) {
+	project, id, ok := splitSubscriptionName(req.GetSubscription())
+	if !ok {
+		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid subscription name", 400))
+	}
+	e, err := s.resources.Get(ctx, project, store.GlobalRegion, rtSubscription, id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, mapError(model.NewProviderError("NotFound", "subscription not found", 404))
+		}
+		return nil, mapError(err)
+	}
+	var meta map[string]any
+	json.Unmarshal(e.Data, &meta)
+	meta["detached"] = true
+	data, _ := json.Marshal(meta)
+	if err := s.resources.Update(ctx, project, store.GlobalRegion, store.ResourceEntry{Type: rtSubscription, ID: id, Data: data}); err != nil {
+		return nil, mapError(err)
+	}
+	if msgs, err := s.messages.List(ctx, id); err == nil {
+		for _, m := range msgs {
+			_ = s.messages.Delete(ctx, id, m.MessageID)
+		}
+	}
+	return &pubsubpb.DetachSubscriptionResponse{}, nil
+}
+
 // ─── IAM (google.iam.v1.IAMPolicy over topics and subscriptions) ─────────────
 
 // Owns reports whether the Pub/Sub service handles IAM for this resource name.
@@ -923,6 +1076,25 @@ func subToProto(meta map[string]any) *pubsubpb.Subscription {
 	sub.Topic, _ = meta["topic"].(string)
 	if ad, ok := asInt(meta["ackDeadlineSeconds"]); ok {
 		sub.AckDeadlineSeconds = int32(ad)
+	}
+	if f, _ := meta["filter"].(string); f != "" {
+		sub.Filter = f
+	}
+	if detached, _ := meta["detached"].(bool); detached {
+		sub.Detached = true
+	}
+	if labels, ok := meta["labels"].(map[string]any); ok {
+		m := make(map[string]string, len(labels))
+		for k, v := range labels {
+			if s, ok := v.(string); ok {
+				m[k] = s
+			}
+		}
+		if len(m) > 0 {
+			sub.Labels = m
+		}
+	} else if labels, ok := meta["labels"].(map[string]string); ok {
+		sub.Labels = labels
 	}
 	if dlp, ok := meta["deadLetterPolicy"].(map[string]any); ok {
 		p := &pubsubpb.DeadLetterPolicy{}

--- a/internal/gcp/grpc/pubsub/service_test.go
+++ b/internal/gcp/grpc/pubsub/service_test.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 // pubsubTestService dials a real in-process gRPC server backed by the memory
@@ -473,5 +474,158 @@ func TestPubSubFanOutGRPC(t *testing.T) {
 		if got := string(pull.GetReceivedMessages()[0].GetMessage().GetData()); got != "broadcast" {
 			t.Fatalf("subscription %s: data = %q, want broadcast", s, got)
 		}
+	}
+}
+
+func TestPubSubFilterGRPC(t *testing.T) {
+	pub, subc, _, _, cleanup := pubsubTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const topic = "projects/test/topics/filter-topic"
+	if _, err := pub.CreateTopic(ctx, &pubsubpb.Topic{Name: topic}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	filtered := "projects/test/subscriptions/filtered"
+	unfiltered := "projects/test/subscriptions/unfiltered"
+	if _, err := subc.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name: filtered, Topic: topic, AckDeadlineSeconds: 30, Filter: `attributes.event_type = "a"`,
+	}); err != nil {
+		t.Fatalf("CreateSubscription filtered: %v", err)
+	}
+	if _, err := subc.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name: unfiltered, Topic: topic, AckDeadlineSeconds: 30,
+	}); err != nil {
+		t.Fatalf("CreateSubscription unfiltered: %v", err)
+	}
+	if _, err := pub.Publish(ctx, &pubsubpb.PublishRequest{Topic: topic, Messages: []*pubsubpb.PubsubMessage{
+		{Data: []byte("match"), Attributes: map[string]string{"event_type": "a"}},
+		{Data: []byte("nope"), Attributes: map[string]string{"event_type": "b"}},
+	}}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	fp, err := subc.Pull(ctx, &pubsubpb.PullRequest{Subscription: filtered, MaxMessages: 10, ReturnImmediately: true})
+	if err != nil {
+		t.Fatalf("Pull filtered: %v", err)
+	}
+	if len(fp.GetReceivedMessages()) != 1 || string(fp.GetReceivedMessages()[0].GetMessage().GetData()) != "match" {
+		t.Fatalf("filtered pull = %v, want exactly [match]", fp.GetReceivedMessages())
+	}
+	up, err := subc.Pull(ctx, &pubsubpb.PullRequest{Subscription: unfiltered, MaxMessages: 10, ReturnImmediately: true})
+	if err != nil {
+		t.Fatalf("Pull unfiltered: %v", err)
+	}
+	if len(up.GetReceivedMessages()) != 2 {
+		t.Fatalf("unfiltered pull got %d, want 2", len(up.GetReceivedMessages()))
+	}
+}
+
+func TestPubSubUnparseableFilterRejectedGRPC(t *testing.T) {
+	pub, subc, _, _, cleanup := pubsubTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const topic = "projects/test/topics/bad-filter-topic"
+	if _, err := pub.CreateTopic(ctx, &pubsubpb.Topic{Name: topic}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	_, err := subc.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name: "projects/test/subscriptions/bad-filter", Topic: topic, Filter: "this is not a filter (((",
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("CreateSubscription bad filter err = %v, want InvalidArgument", err)
+	}
+}
+
+func TestPubSubDetachGRPC(t *testing.T) {
+	pub, subc, _, _, cleanup := pubsubTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const topic = "projects/test/topics/detach-topic"
+	const sub = "projects/test/subscriptions/detach-sub"
+	if _, err := pub.CreateTopic(ctx, &pubsubpb.Topic{Name: topic}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	if _, err := subc.CreateSubscription(ctx, &pubsubpb.Subscription{Name: sub, Topic: topic}); err != nil {
+		t.Fatalf("CreateSubscription: %v", err)
+	}
+	if _, err := pub.DetachSubscription(ctx, &pubsubpb.DetachSubscriptionRequest{Subscription: sub}); err != nil {
+		t.Fatalf("DetachSubscription: %v", err)
+	}
+	got, err := subc.GetSubscription(ctx, &pubsubpb.GetSubscriptionRequest{Subscription: sub})
+	if err != nil {
+		t.Fatalf("GetSubscription: %v", err)
+	}
+	if !got.GetDetached() {
+		t.Fatal("expected detached=true")
+	}
+	if _, err := subc.Pull(ctx, &pubsubpb.PullRequest{Subscription: sub, MaxMessages: 1, ReturnImmediately: true}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("Pull detached err = %v, want FailedPrecondition", err)
+	}
+}
+
+func TestPubSubUpdateFilterImmutableGRPC(t *testing.T) {
+	pub, subc, _, _, cleanup := pubsubTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const topic = "projects/test/topics/immutable-topic"
+	const sub = "projects/test/subscriptions/immutable-sub"
+	if _, err := pub.CreateTopic(ctx, &pubsubpb.Topic{Name: topic}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	if _, err := subc.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name: sub, Topic: topic, Filter: `attributes.event_type = "a"`,
+	}); err != nil {
+		t.Fatalf("CreateSubscription: %v", err)
+	}
+
+	_, err := subc.UpdateSubscription(ctx, &pubsubpb.UpdateSubscriptionRequest{
+		Subscription: &pubsubpb.Subscription{Name: sub, Filter: `attributes.event_type = "b"`},
+		UpdateMask:   &fieldmaskpb.FieldMask{Paths: []string{"filter"}},
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("UpdateSubscription filter err = %v, want InvalidArgument", err)
+	}
+
+	relabelled, err := subc.UpdateSubscription(ctx, &pubsubpb.UpdateSubscriptionRequest{
+		Subscription: &pubsubpb.Subscription{Name: sub, Labels: map[string]string{"env": "local"}},
+		UpdateMask:   &fieldmaskpb.FieldMask{Paths: []string{"labels"}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateSubscription labels: %v", err)
+	}
+	if relabelled.GetLabels()["env"] != "local" {
+		t.Fatalf("labels = %v, want env=local", relabelled.GetLabels())
+	}
+	if relabelled.GetFilter() != `attributes.event_type = "a"` {
+		t.Fatalf("filter changed to %q", relabelled.GetFilter())
+	}
+}
+
+func TestPubSubTopicDeleteOrphansGRPC(t *testing.T) {
+	pub, subc, _, _, cleanup := pubsubTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const topic = "projects/test/topics/orphan-topic"
+	const sub = "projects/test/subscriptions/orphan-sub"
+	if _, err := pub.CreateTopic(ctx, &pubsubpb.Topic{Name: topic}); err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	if _, err := subc.CreateSubscription(ctx, &pubsubpb.Subscription{Name: sub, Topic: topic}); err != nil {
+		t.Fatalf("CreateSubscription: %v", err)
+	}
+	if _, err := pub.DeleteTopic(ctx, &pubsubpb.DeleteTopicRequest{Topic: topic}); err != nil {
+		t.Fatalf("DeleteTopic: %v", err)
+	}
+	got, err := subc.GetSubscription(ctx, &pubsubpb.GetSubscriptionRequest{Subscription: sub})
+	if err != nil {
+		t.Fatalf("GetSubscription: %v", err)
+	}
+	if got.GetTopic() != "_deleted-topic_" {
+		t.Fatalf("topic = %q, want _deleted-topic_", got.GetTopic())
 	}
 }

--- a/internal/gcp/provider/pubsub/pubsub.go
+++ b/internal/gcp/provider/pubsub/pubsub.go
@@ -16,6 +16,7 @@ import (
 	"jaiscloud/internal/gcp/crypto"
 	"jaiscloud/internal/gcp/paging"
 	"jaiscloud/internal/gcp/policy"
+	"jaiscloud/internal/gcp/pubsubfilter"
 	kmsstore "jaiscloud/internal/gcp/store/kms"
 	pubsubstore "jaiscloud/internal/gcp/store/pubsub"
 	"jaiscloud/internal/model"
@@ -61,6 +62,7 @@ func (p *Provider) Routes() map[string]provider.HandlerFunc {
 		"PubSub.SubscriptionCreate":             p.SubscriptionCreate,
 		"PubSub.SubscriptionGet":                p.SubscriptionGet,
 		"PubSub.SubscriptionDelete":             p.SubscriptionDelete,
+		"PubSub.SubscriptionDetach":             p.SubscriptionDetach,
 		"PubSub.SubscriptionList":               p.SubscriptionList,
 		"PubSub.SubscriptionPull":               p.SubscriptionPull,
 		"PubSub.SubscriptionAcknowledge":        p.SubscriptionAcknowledge,
@@ -155,6 +157,55 @@ func (p *Provider) TopicDelete(ctx context.Context, nr *model.NormalizedRequest)
 			return nil, model.NewProviderError("NotFound", "topic not found", 404)
 		}
 		return nil, err
+	}
+	// Existing subscriptions are not deleted; their topic is set to the
+	// sentinel "_deleted-topic_" (real Pub/Sub behaviour).
+	topicFull := nr.ResourceID("pubsub-topic", t)
+	if entries, err := p.resources.List(ctx, nr.AccountID, store.GlobalRegion, rtSubscription, ""); err == nil {
+		for _, e := range entries {
+			var meta map[string]any
+			if json.Unmarshal(e.Data, &meta) != nil {
+				continue
+			}
+			if st, _ := meta["topic"].(string); st != topicFull {
+				continue
+			}
+			meta["topic"] = "_deleted-topic_"
+			data, _ := json.Marshal(meta)
+			_ = p.resources.Update(ctx, nr.AccountID, store.GlobalRegion, store.ResourceEntry{Type: rtSubscription, ID: e.ID, Data: data})
+		}
+	}
+	return &model.ProviderResponse{HTTPStatus: 200, Data: map[string]any{}}, nil
+}
+
+// SubscriptionDetach implements subscriptions.detach: the subscription stops
+// receiving messages (its backlog is dropped) and Pull returns
+// FailedPrecondition. The subscription itself is retained.
+func (p *Provider) SubscriptionDetach(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	name, err := resourceName(nr)
+	if err != nil {
+		return nil, err
+	}
+	s := strings.TrimPrefix(name, "subscriptions/")
+	e, err := p.resources.Get(ctx, nr.AccountID, store.GlobalRegion, rtSubscription, s)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, model.NewProviderError("NotFound", "subscription not found", 404)
+		}
+		return nil, err
+	}
+	var meta map[string]any
+	json.Unmarshal(e.Data, &meta)
+	meta["detached"] = true
+	data, _ := json.Marshal(meta)
+	if err := p.resources.Update(ctx, nr.AccountID, store.GlobalRegion, store.ResourceEntry{Type: rtSubscription, ID: s, Data: data}); err != nil {
+		return nil, err
+	}
+	// Drop the backlog: a detached subscription receives no further messages.
+	if msgs, err := p.messages.List(ctx, s); err == nil {
+		for _, m := range msgs {
+			_ = p.messages.Delete(ctx, s, m.MessageID)
+		}
 	}
 	return &model.ProviderResponse{HTTPStatus: 200, Data: map[string]any{}}, nil
 }
@@ -326,6 +377,14 @@ func (p *Provider) SubscriptionCreate(ctx context.Context, nr *model.NormalizedR
 	}
 	body, _ := nr.Params["body"].(map[string]any)
 	topic, _ := body["topic"].(string)
+	if topic == "" {
+		return nil, model.NewProviderError("InvalidArgument", "missing topic", 400)
+	}
+	// The topic must already exist (real Pub/Sub rejects a subscription for a
+	// missing topic with NotFound).
+	if !p.topicExists(ctx, nr.AccountID, lastSegment(topic)) {
+		return nil, model.NewProviderError("NotFound", "topic not found", 404)
+	}
 	ackDeadline := 10
 	if ad, ok := body["ackDeadlineSeconds"].(float64); ok {
 		ackDeadline = int(ad)
@@ -334,6 +393,12 @@ func (p *Provider) SubscriptionCreate(ctx context.Context, nr *model.NormalizedR
 		"name":               nr.ResourceID("pubsub-subscription", s),
 		"topic":              topic,
 		"ackDeadlineSeconds": ackDeadline,
+	}
+	if filter, _ := body["filter"].(string); filter != "" {
+		if _, err := pubsubfilter.Compile(filter); err != nil {
+			return nil, model.NewProviderError("InvalidArgument", "invalid subscription filter: "+err.Error(), 400)
+		}
+		meta["filter"] = filter
 	}
 	if dp, ok := body["deadLetterPolicy"].(map[string]any); ok {
 		meta["deadLetterPolicy"] = dp
@@ -419,6 +484,14 @@ func (p *Provider) SubscriptionPull(ctx context.Context, nr *model.NormalizedReq
 	}
 	var sub map[string]any
 	json.Unmarshal(e.Data, &sub)
+	if detached, _ := sub["detached"].(bool); detached {
+		return nil, &model.ProviderError{
+			Code: "FailedPrecondition", HTTPStatus: 400, Status: "FAILED_PRECONDITION",
+			Message: "subscription " + s + " is detached",
+		}
+	}
+	filterExpr, _ := sub["filter"].(string)
+	filter, _ := pubsubfilter.Compile(filterExpr)
 	topic, _ := sub["topic"].(string)
 	// topic full name → topic ID (last segment).
 	topicID := topic
@@ -472,6 +545,12 @@ func (p *Provider) SubscriptionPull(ctx context.Context, nr *model.NormalizedReq
 	}
 	received := make([]any, 0, len(msgs))
 	for _, m := range msgs {
+		// Filtering: a message that does not match the subscription's filter is
+		// dropped for this subscription (filters are immutable).
+		if filter != nil && !filter.Match(m.Attributes) {
+			_ = p.messages.Delete(ctx, s, m.MessageID)
+			continue
+		}
 		// DLQ: once delivery attempts exceed maxDeliveryAttempts, republish to the
 		// dead-letter topic and drop the original (mirrors SQS checkDLQ, strictly
 		// greater threshold).

--- a/internal/gcp/provider/pubsub/pubsub_extra_test.go
+++ b/internal/gcp/provider/pubsub/pubsub_extra_test.go
@@ -387,3 +387,137 @@ func TestPubSubFanOut(t *testing.T) {
 		t.Fatalf("acked subscription still has %d messages", len(received))
 	}
 }
+
+func pubsubPull(t *testing.T, p *Provider, sub string) []any {
+	t.Helper()
+	ctx := context.Background()
+	resp, err := p.SubscriptionPull(ctx, newNR(map[string]any{
+		"name": "subscriptions/" + sub,
+		"body": map[string]any{"returnImmediately": true},
+	}))
+	if err != nil {
+		t.Fatalf("pull %s: %v", sub, err)
+	}
+	msgs, _ := resp.Data["receivedMessages"].([]any)
+	return msgs
+}
+
+func TestPubSubSubscriptionFilter(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+
+	if _, err := p.TopicCreate(ctx, newNR(map[string]any{"name": "topics/ft"})); err != nil {
+		t.Fatalf("topic: %v", err)
+	}
+	if _, err := p.SubscriptionCreate(ctx, newNR(map[string]any{
+		"name": "subscriptions/fs",
+		"body": map[string]any{"topic": "projects/proj/topics/ft", "filter": `attributes.event_type = "a"`},
+	})); err != nil {
+		t.Fatalf("filtered sub: %v", err)
+	}
+	if _, err := p.SubscriptionCreate(ctx, newNR(map[string]any{
+		"name": "subscriptions/fu",
+		"body": map[string]any{"topic": "projects/proj/topics/ft"},
+	})); err != nil {
+		t.Fatalf("unfiltered sub: %v", err)
+	}
+	if _, err := p.TopicPublish(ctx, newNR(map[string]any{
+		"name": "topics/ft",
+		"body": map[string]any{"messages": []any{
+			map[string]any{"data": "bWF0Y2g=", "attributes": map[string]any{"event_type": "a"}},
+			map[string]any{"data": "bm9wZQ==", "attributes": map[string]any{"event_type": "b"}},
+		}},
+	})); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	fs := pubsubPull(t, p, "fs")
+	if len(fs) != 1 {
+		t.Fatalf("filtered sub got %d messages, want 1", len(fs))
+	}
+	got := fs[0].(map[string]any)["message"].(map[string]any)["data"]
+	if got != "bWF0Y2g=" {
+		t.Errorf("filtered sub data = %v, want bWF0Y2g=", got)
+	}
+	if fu := pubsubPull(t, p, "fu"); len(fu) != 2 {
+		t.Fatalf("unfiltered sub got %d messages, want 2", len(fu))
+	}
+}
+
+func TestPubSubUnparseableFilterRejected(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	if _, err := p.TopicCreate(ctx, newNR(map[string]any{"name": "topics/bt"})); err != nil {
+		t.Fatalf("topic: %v", err)
+	}
+	_, err := p.SubscriptionCreate(ctx, newNR(map[string]any{
+		"name": "subscriptions/bs",
+		"body": map[string]any{"topic": "projects/proj/topics/bt", "filter": "this is not a filter ((("},
+	}))
+	if err == nil {
+		t.Fatal("expected invalid filter to be rejected")
+	}
+	pe, ok := err.(*model.ProviderError)
+	if !ok || pe.Code != "InvalidArgument" {
+		t.Fatalf("expected InvalidArgument, got %v", err)
+	}
+}
+
+func TestPubSubDetachSubscription(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	if _, err := p.TopicCreate(ctx, newNR(map[string]any{"name": "topics/dt"})); err != nil {
+		t.Fatalf("topic: %v", err)
+	}
+	if _, err := p.SubscriptionCreate(ctx, newNR(map[string]any{
+		"name": "subscriptions/ds", "body": map[string]any{"topic": "projects/proj/topics/dt"},
+	})); err != nil {
+		t.Fatalf("sub: %v", err)
+	}
+	if _, err := p.TopicPublish(ctx, newNR(map[string]any{
+		"name": "topics/dt", "body": map[string]any{"messages": []any{map[string]any{"data": "aGk="}}},
+	})); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if _, err := p.SubscriptionDetach(ctx, newNR(map[string]any{"name": "subscriptions/ds"})); err != nil {
+		t.Fatalf("detach: %v", err)
+	}
+	get, err := p.SubscriptionGet(ctx, newNR(map[string]any{"name": "subscriptions/ds"}))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if detached, _ := get.Data["detached"].(bool); !detached {
+		t.Fatalf("expected detached=true, got %v", get.Data["detached"])
+	}
+	if _, err := p.SubscriptionPull(ctx, newNR(map[string]any{"name": "subscriptions/ds"})); err == nil {
+		t.Fatal("expected pull on detached subscription to fail")
+	} else if pe, ok := err.(*model.ProviderError); !ok || pe.Code != "FailedPrecondition" {
+		t.Fatalf("expected FailedPrecondition, got %v", err)
+	}
+	if msgs, _ := p.messages.List(ctx, "ds"); len(msgs) != 0 {
+		t.Fatalf("expected detached subscription backlog dropped, got %d", len(msgs))
+	}
+}
+
+func TestPubSubTopicDeleteOrphansSubscription(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	if _, err := p.TopicCreate(ctx, newNR(map[string]any{"name": "topics/ot"})); err != nil {
+		t.Fatalf("topic: %v", err)
+	}
+	if _, err := p.SubscriptionCreate(ctx, newNR(map[string]any{
+		"name": "subscriptions/os", "body": map[string]any{"topic": "projects/proj/topics/ot"},
+	})); err != nil {
+		t.Fatalf("sub: %v", err)
+	}
+	if _, err := p.TopicDelete(ctx, newNR(map[string]any{"name": "topics/ot"})); err != nil {
+		t.Fatalf("delete topic: %v", err)
+	}
+	get, err := p.SubscriptionGet(ctx, newNR(map[string]any{"name": "subscriptions/os"}))
+	if err != nil {
+		t.Fatalf("get sub: %v", err)
+	}
+	if get.Data["topic"] != "_deleted-topic_" {
+		t.Fatalf("expected topic _deleted-topic_, got %v", get.Data["topic"])
+	}
+}

--- a/internal/gcp/pubsubfilter/filter.go
+++ b/internal/gcp/pubsubfilter/filter.go
@@ -1,0 +1,343 @@
+// Package pubsubfilter parses and evaluates Cloud Pub/Sub subscription filters.
+//
+// A filter selects which messages a subscription receives, based on message
+// attributes. The supported grammar mirrors the commonly used subset of the
+// real Pub/Sub filter language:
+//
+//	expr        := term ( "OR" term )*
+//	term        := factor ( "AND" factor )*
+//	factor      := "NOT" factor | "(" expr ")" | predicate
+//	predicate   := attrKey ( "=" | "!=" ) string
+//	             | "hasPrefix" "(" attrKey "," string ")"
+//	attrKey     := "attributes" ( "." | ":" ) ident
+//	string      := '"' escaped-char* '"'
+//
+// Anything outside this grammar is rejected, so an unparseable filter makes
+// SubscriptionCreate fail with InvalidArgument (matching real Pub/Sub, where a
+// filter is validated at creation and is immutable thereafter).
+package pubsubfilter
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Filter is a compiled subscription filter.
+type Filter struct {
+	expr node
+	src  string
+}
+
+// Match reports whether the message attributes satisfy the filter.
+func (f *Filter) Match(attrs map[string]string) bool {
+	if f == nil || f.expr == nil {
+		return true
+	}
+	return f.expr.eval(attrs)
+}
+
+// String returns the original filter expression.
+func (f *Filter) String() string { return f.src }
+
+// Compile parses expr into a Filter. An empty expression compiles to a nil
+// filter (match everything).
+func Compile(expr string) (*Filter, error) {
+	if strings.TrimSpace(expr) == "" {
+		return nil, nil
+	}
+	p := &parser{tokens: tokenize(expr)}
+	n, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if p.peek().kind != tokEOF {
+		return nil, fmt.Errorf("unexpected token %q", p.peek().text)
+	}
+	return &Filter{expr: n, src: expr}, nil
+}
+
+// ─── AST ──────────────────────────────────────────────────────────────────────
+
+type node interface {
+	eval(attrs map[string]string) bool
+}
+
+type orNode struct{ left, right node }
+
+func (n orNode) eval(a map[string]string) bool { return n.left.eval(a) || n.right.eval(a) }
+
+type andNode struct{ left, right node }
+
+func (n andNode) eval(a map[string]string) bool { return n.left.eval(a) && n.right.eval(a) }
+
+type notNode struct{ inner node }
+
+func (n notNode) eval(a map[string]string) bool { return !n.inner.eval(a) }
+
+type cmpNode struct {
+	key   string
+	value string
+	neq   bool
+}
+
+func (n cmpNode) eval(a map[string]string) bool {
+	v, ok := a[n.key]
+	if n.neq {
+		return !ok || v != n.value
+	}
+	return ok && v == n.value
+}
+
+type prefixNode struct {
+	key    string
+	prefix string
+}
+
+func (n prefixNode) eval(a map[string]string) bool {
+	v, ok := a[n.key]
+	return ok && strings.HasPrefix(v, n.prefix)
+}
+
+// ─── Lexer ────────────────────────────────────────────────────────────────────
+
+type tokKind int
+
+const (
+	tokEOF tokKind = iota
+	tokIdent
+	tokString
+	tokLParen
+	tokRParen
+	tokDot
+	tokColon
+	tokComma
+	tokEq
+	tokNeq
+)
+
+type token struct {
+	kind tokKind
+	text string
+}
+
+func tokenize(s string) []token {
+	var toks []token
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+			i++
+		case c == '(':
+			toks = append(toks, token{tokLParen, "("})
+			i++
+		case c == ')':
+			toks = append(toks, token{tokRParen, ")"})
+			i++
+		case c == ',':
+			toks = append(toks, token{tokComma, ","})
+			i++
+		case c == '.':
+			toks = append(toks, token{tokDot, "."})
+			i++
+		case c == ':':
+			toks = append(toks, token{tokColon, ":"})
+			i++
+		case c == '=':
+			toks = append(toks, token{tokEq, "="})
+			i++
+		case c == '!':
+			if i+1 < len(s) && s[i+1] == '=' {
+				toks = append(toks, token{tokNeq, "!="})
+				i += 2
+			} else {
+				toks = append(toks, token{tokIdent, "!"})
+				i++
+			}
+		case c == '"':
+			j := i + 1
+			var b strings.Builder
+			closed := false
+			for j < len(s) {
+				if s[j] == '\\' && j+1 < len(s) {
+					b.WriteByte(s[j+1])
+					j += 2
+					continue
+				}
+				if s[j] == '"' {
+					closed = true
+					j++
+					break
+				}
+				b.WriteByte(s[j])
+				j++
+			}
+			if !closed {
+				toks = append(toks, token{tokIdent, s[i:]})
+				i = len(s)
+				continue
+			}
+			toks = append(toks, token{tokString, b.String()})
+			i = j
+		case isIdentStart(c):
+			j := i + 1
+			for j < len(s) && isIdentPart(s[j]) {
+				j++
+			}
+			toks = append(toks, token{tokIdent, s[i:j]})
+			i = j
+		default:
+			// Unknown character: emit as an ident so the parser rejects it.
+			toks = append(toks, token{tokIdent, string(c)})
+			i++
+		}
+	}
+	toks = append(toks, token{tokEOF, ""})
+	return toks
+}
+
+func isIdentStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isIdentPart(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9') || c == '-'
+}
+
+// ─── Parser ───────────────────────────────────────────────────────────────────
+
+type parser struct {
+	tokens []token
+	pos    int
+}
+
+func (p *parser) peek() token { return p.tokens[p.pos] }
+
+func (p *parser) next() token {
+	t := p.tokens[p.pos]
+	if t.kind != tokEOF {
+		p.pos++
+	}
+	return t
+}
+
+func (p *parser) parseExpr() (node, error) { return p.parseOr() }
+
+func (p *parser) parseOr() (node, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for p.isKeyword("or") {
+		p.next()
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = orNode{left, right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseAnd() (node, error) {
+	left, err := p.parseFactor()
+	if err != nil {
+		return nil, err
+	}
+	for p.isKeyword("and") {
+		p.next()
+		right, err := p.parseFactor()
+		if err != nil {
+			return nil, err
+		}
+		left = andNode{left, right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseFactor() (node, error) {
+	if p.isKeyword("not") {
+		p.next()
+		inner, err := p.parseFactor()
+		if err != nil {
+			return nil, err
+		}
+		return notNode{inner}, nil
+	}
+	if p.peek().kind == tokLParen {
+		p.next()
+		n, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if p.next().kind != tokRParen {
+			return nil, fmt.Errorf("expected ')'")
+		}
+		return n, nil
+	}
+	return p.parsePredicate()
+}
+
+func (p *parser) parsePredicate() (node, error) {
+	if p.isKeyword("hasprefix") {
+		p.next()
+		if p.next().kind != tokLParen {
+			return nil, fmt.Errorf("expected '(' after hasPrefix")
+		}
+		key, err := p.parseAttrKey()
+		if err != nil {
+			return nil, err
+		}
+		if p.next().kind != tokComma {
+			return nil, fmt.Errorf("expected ',' in hasPrefix")
+		}
+		if p.peek().kind != tokString {
+			return nil, fmt.Errorf("expected quoted string in hasPrefix")
+		}
+		val := p.next().text
+		if p.next().kind != tokRParen {
+			return nil, fmt.Errorf("expected ')' after hasPrefix")
+		}
+		return prefixNode{key: key, prefix: val}, nil
+	}
+
+	key, err := p.parseAttrKey()
+	if err != nil {
+		return nil, err
+	}
+	switch p.next().kind {
+	case tokEq:
+		if p.peek().kind != tokString {
+			return nil, fmt.Errorf("expected quoted string after '='")
+		}
+		return cmpNode{key: key, value: p.next().text}, nil
+	case tokNeq:
+		if p.peek().kind != tokString {
+			return nil, fmt.Errorf("expected quoted string after '!='")
+		}
+		return cmpNode{key: key, value: p.next().text, neq: true}, nil
+	default:
+		return nil, fmt.Errorf("expected '=' or '!=' in filter")
+	}
+}
+
+// parseAttrKey parses "attributes" ("."|":") ident.
+func (p *parser) parseAttrKey() (string, error) {
+	if !p.isKeyword("attributes") {
+		return "", fmt.Errorf("expected 'attributes'")
+	}
+	p.next()
+	if k := p.next().kind; k != tokDot && k != tokColon {
+		return "", fmt.Errorf("expected '.' or ':' after attributes")
+	}
+	id := p.next()
+	if id.kind != tokIdent || !isIdentStart(id.text[0]) {
+		return "", fmt.Errorf("expected attribute name")
+	}
+	return id.text, nil
+}
+
+func (p *parser) isKeyword(kw string) bool {
+	t := p.peek()
+	return t.kind == tokIdent && strings.EqualFold(t.text, kw)
+}

--- a/internal/gcp/pubsubfilter/filter_test.go
+++ b/internal/gcp/pubsubfilter/filter_test.go
@@ -1,0 +1,64 @@
+package pubsubfilter
+
+import "testing"
+
+func TestCompileAndMatch(t *testing.T) {
+	cases := []struct {
+		filter string
+		attrs  map[string]string
+		want   bool
+	}{
+		{`attributes.event_type = "ocr-invoice"`, map[string]string{"event_type": "ocr-invoice"}, true},
+		{`attributes.event_type = "ocr-invoice"`, map[string]string{"event_type": "portal.upload"}, false},
+		{`attributes.event_type = "ocr-invoice"`, nil, false},
+		{`attributes:event_type != "ocr-invoice"`, map[string]string{"event_type": "x"}, true},
+		{`attributes:event_type != "ocr-invoice"`, map[string]string{"event_type": "ocr-invoice"}, false},
+		{`hasPrefix(attributes.event_type, "portal.")`, map[string]string{"event_type": "portal.upload"}, true},
+		{`hasPrefix(attributes.event_type, "portal.")`, map[string]string{"event_type": "ocr-invoice"}, false},
+		{`attributes.a = "1" AND attributes.b = "2"`, map[string]string{"a": "1", "b": "2"}, true},
+		{`attributes.a = "1" AND attributes.b = "2"`, map[string]string{"a": "1"}, false},
+		{`attributes.a = "1" OR attributes.b = "2"`, map[string]string{"b": "2"}, true},
+		{`NOT attributes.a = "1"`, map[string]string{"a": "2"}, true},
+		{`NOT attributes.a = "1"`, map[string]string{"a": "1"}, false},
+		{`(attributes.a = "1" OR attributes.b = "2") AND attributes.c = "3"`, map[string]string{"a": "1", "c": "3"}, true},
+		{`attributes.a = "1" AND (attributes.b = "2" OR attributes.c = "3")`, map[string]string{"a": "1", "c": "3"}, true},
+	}
+	for _, c := range cases {
+		f, err := Compile(c.filter)
+		if err != nil {
+			t.Fatalf("Compile(%q): %v", c.filter, err)
+		}
+		if got := f.Match(c.attrs); got != c.want {
+			t.Errorf("Compile(%q).Match(%v) = %v, want %v", c.filter, c.attrs, got, c.want)
+		}
+	}
+}
+
+func TestCompileEmptyMatchesAll(t *testing.T) {
+	f, err := Compile("")
+	if err != nil {
+		t.Fatalf("Compile empty: %v", err)
+	}
+	if f != nil {
+		t.Fatalf("expected nil filter for empty expression")
+	}
+	if !f.Match(map[string]string{"a": "b"}) {
+		t.Error("nil filter should match everything")
+	}
+}
+
+func TestCompileInvalid(t *testing.T) {
+	for _, expr := range []string{
+		"this is not a filter (((",
+		`attributes.event_type`,
+		`attributes.event_type = unquoted`,
+		`hasPrefix(attributes.event_type)`,
+		`hasPrefix(attributes.event_type, "x"`,
+		`attributes. = "x"`,
+		`attributes.a == "x"`,
+	} {
+		if _, err := Compile(expr); err == nil {
+			t.Errorf("Compile(%q) succeeded, want error", expr)
+		}
+	}
+}

--- a/tests/integration/gcp/sdk-rest/sdkrest_extra_test.go
+++ b/tests/integration/gcp/sdk-rest/sdkrest_extra_test.go
@@ -162,17 +162,20 @@ func TestSDKPubSubDeleteNotFound(t *testing.T) {
 	topic := "projects/proj/topics/" + unique("del")
 	_, err = svc.Projects.Topics.Create(topic, &pubsub.Topic{Name: topic}).Do()
 	require.NoError(t, err)
-	_, err = svc.Projects.Topics.Delete(topic).Do()
-	require.NoError(t, err)
-	_, err = svc.Projects.Topics.Get(topic).Do()
-	requireNotFound(t, err)
 
+	// The subscription must be created while the topic still exists (Pub/Sub
+	// rejects a subscription for a missing topic with NotFound).
 	sub := "projects/proj/subscriptions/" + unique("del-sub")
 	_, err = svc.Projects.Subscriptions.Create(sub, &pubsub.Subscription{Name: sub, Topic: topic}).Do()
 	require.NoError(t, err)
 	_, err = svc.Projects.Subscriptions.Delete(sub).Do()
 	require.NoError(t, err)
 	_, err = svc.Projects.Subscriptions.Get(sub).Do()
+	requireNotFound(t, err)
+
+	_, err = svc.Projects.Topics.Delete(topic).Do()
+	require.NoError(t, err)
+	_, err = svc.Projects.Topics.Get(topic).Do()
 	requireNotFound(t, err)
 }
 


### PR DESCRIPTION
## Description

Verified Pub/Sub gaps G7, G10 and G11 from the compatibility audit (`plan_docs/gcp-parity-gaps-plan.md`):

- **Subscription `filter` was ignored:** not stored, not validated, not enforced. Real Pub/Sub validates a filter at creation, returns it on Get/List, only delivers matching messages, and never lets it change.
- **`DetachSubscription` was unimplemented** (UNIMPLEMENTED over gRPC).
- **Topic delete left subscriptions dangling** instead of setting their topic to `_deleted-topic_`.
- Bonus: `CreateSubscription` accepted a subscription for a **missing topic**; real Pub/Sub returns `NotFound`.

## What's in this PR

- New `internal/gcp/pubsubfilter` package: a parser/evaluator for the Pub/Sub filter subset — `attributes.KEY =/!= "v"`, `attributes:KEY …`, `hasPrefix(attributes.KEY, "v")`, `AND`/`OR`/`NOT`, parentheses. Anything else is rejected.
- `provider/pubsub` + `grpc/pubsub`:
  - `CreateSubscription` validates the filter (`InvalidArgument` on bad syntax) and stores it; `Get`/`List` return it.
  - `Pull`/`StreamingPull` discard (and delete) messages that don't match the subscription's filter.
  - `UpdateSubscription` (gRPC) honors a mask: `filter` is rejected (`InvalidArgument`) even when unchanged; `labels` / `ack_deadline_seconds` apply.
  - `DetachSubscription` (REST `:detach` + gRPC) marks `detached`, drops the backlog, and `Pull` returns `FailedPrecondition`; `Get` reports `detached=true`.
  - Topic delete orphans subscriptions by rewriting `topic` to `_deleted-topic_` (REST + gRPC).
  - `CreateSubscription` returns `NotFound` for a missing topic.

## Out of scope

- Push-subscription delivery semantics and `filter` on push beyond storage/enforcement.
- Remaining gaps: Firestore `Listen` residuals (G15), GCS REST restore/lock/move + CORS.

## How to test

```bash
go build ./... && go vet ./internal/gcp/... && gofmt -l internal/gcp/
go test ./internal/gcp/pubsubfilter/ ./internal/gcp/provider/pubsub/ ./internal/gcp/grpc/pubsub/ ./internal/gcp/adapter/ -count=1
```

## Test report

- `go test ./internal/gcp/...` green; `vet`/`gofmt` clean.
- New: `pubsubfilter` table tests (match/invalid); provider filter/detach/orphan/invalid-filter; gRPC filter/detach/update-mask/orphan; codec `:detach` routing.
- **localgcp Pub/Sub: 28/28** (was 26/2) — `TestCreateSubscriptionNonExistentTopic` and `TestDeleteTopicOrphansSubscription` now pass.
- **floci Python Pub/Sub: 7/7** (was 4/3) — all three filter tests pass; floci Go Pub/Sub still passes.
- REST e2e: filtered sub receives 1 of 2, unfiltered 2; bad filter → 400; detach → 200, `detached=true`, pull → 400; topic delete → `_deleted-topic_`.

## Conformance audit

- `Subscription.filter` is create-time only, syntactically validated, and enforced on delivery (Pub/Sub filtering docs / Discovery `Subscription.filter`).
- `projects.subscriptions.detach` drops the backlog and makes Pull fail `FAILED_PRECONDITION` (`DetachSubscriptionResponse`).
- `projects.topics.delete`: "Existing subscriptions … are not deleted, but their `topic` field is set to `_deleted-topic_`."
- `projects.subscriptions.create` for a topic that does not exist → `NOT_FOUND`.
