### PR TITLE
fix(gcp/firestore): Listen live-delta removals, where/limit matching, RESET

### DIFF
--- a/internal/gcp/grpc/firestore/listen.go
+++ b/internal/gcp/grpc/firestore/listen.go
@@ -49,6 +49,13 @@ type listenTarget struct {
 	// frames is the emulator's approximation of that cursor (see the package
 	// doc's Listen fidelity note).
 	seq uint64
+
+	// view is the set of document names currently in this target's result set
+	// (the snapshot, adjusted by every live delta since). A live change is
+	// diffed against it to decide whether the document enters the view
+	// (DocumentChange), leaves it (DocumentRemove), or was deleted
+	// (DocumentDelete).
+	view map[string]struct{}
 }
 
 func (t listenTarget) isQuery() bool { return t.query != nil }
@@ -162,6 +169,7 @@ func (ls *listenSession) handleAddTarget(t *firestorepb.Target) error {
 		return err
 	}
 	lt := &target
+	lt.view = map[string]struct{}{}
 	ls.targets[id] = lt
 
 	if err := ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_TargetChange{
@@ -183,11 +191,11 @@ func (ls *listenSession) handleAddTarget(t *firestorepb.Target) error {
 	base := ls.srv.svc.CurrentSeq()
 
 	// A valid, unexpired resume token replays only this target's deltas after
-	// it; an absent, malformed, evicted, or pre-reset token falls back to the
-	// full initial snapshot. seq == 0 is treated as the start of time (not a
-	// resumable position) because the change log records only writes, not a
-	// document history, so replaying from zero cannot reconstruct documents
-	// that predate the log.
+	// it; an absent, malformed, evicted, or pre-reset token cannot be honored,
+	// so the target is reset and given a fresh snapshot. seq == 0 is treated as
+	// the start of time (not a resumable position) because the change log
+	// records only writes, not a document history, so replaying from zero
+	// cannot reconstruct documents that predate the log.
 	incremental := false
 	if rt, ok := t.GetResumeType().(*firestorepb.Target_ResumeToken); ok {
 		if seq, valid := DecodeResumeToken(rt.ResumeToken); valid && seq > 0 && ls.srv.svc.ReplayableFrom(seq) {
@@ -202,10 +210,17 @@ func (ls *listenSession) handleAddTarget(t *firestorepb.Target) error {
 					}
 				}
 			}
+			// Seed the view from current state so the first live delta diffs
+			// against the resumed result set instead of re-emitting all of it.
+			if err := ls.seedView(lt); err != nil {
+				return err
+			}
+		} else if err := ls.sendReset(id); err != nil {
+			return err
 		}
 	}
 	if !incremental {
-		if err := ls.sendSnapshot(id, *lt); err != nil {
+		if err := ls.sendSnapshot(id, lt); err != nil {
 			return err
 		}
 	}
@@ -286,8 +301,7 @@ func (ls *listenSession) handleRemoveTarget(id int32) error {
 func (ls *listenSession) handleChange(ev firestoreprovider.ChangeEvent) {
 	sent := false
 	for id, t := range ls.targets {
-		if ls.targetMatches(*t, ev) {
-			_ = ls.sendChange(id, ev)
+		if ls.applyChange(id, t, ev) {
 			if ev.Seq > t.seq {
 				t.seq = ev.Seq
 			}
@@ -302,6 +316,77 @@ func (ls *listenSession) handleChange(ev firestoreprovider.ChangeEvent) {
 	// on NO_CHANGE, so real-time deltas would otherwise never surface through
 	// Snapshots.
 	_ = ls.sendNoChange()
+}
+
+// applyChange diffs one live change against a target's current view and emits
+// the resulting deltas (DocumentChange on entry/update, DocumentRemove on
+// exit, DocumentDelete on delete). It reports whether any frame was sent.
+func (ls *listenSession) applyChange(id int32, t *listenTarget, ev firestoreprovider.ChangeEvent) bool {
+	if !ls.targetMatches(*t, ev) {
+		return false
+	}
+	if !t.isQuery() {
+		if ev.Doc == nil {
+			delete(t.view, ev.Name)
+			return ls.sendDocumentDelete(id, ev.Name) == nil
+		}
+		t.view[ev.Name] = struct{}{}
+		return ls.sendDocumentChange(id, *ev.Doc) == nil
+	}
+
+	// Re-run the target's query so where/order_by/limit apply to the delta: a
+	// document that stops matching (or is pushed out by a limit) is no longer in
+	// the new result set, and one that starts matching (or moves into a limit)
+	// is. A delete is delivered by scope alone (below) because its body is gone.
+	docs, err := ls.queryDocs(t)
+	if err != nil {
+		return false
+	}
+	newView := make(map[string]firestorestore.Document, len(docs))
+	for _, d := range docs {
+		newView[d.Name] = d
+	}
+
+	changed := false
+	for name := range t.view {
+		if _, ok := newView[name]; ok {
+			continue
+		}
+		if ev.Doc == nil && name == ev.Name {
+			continue // emitted as DocumentDelete below
+		}
+		if ls.sendDocumentRemove(id, name) == nil {
+			changed = true
+		}
+	}
+	if ev.Doc == nil {
+		if ls.sendDocumentDelete(id, ev.Name) == nil {
+			changed = true
+		}
+	}
+	for name, d := range newView {
+		if _, ok := t.view[name]; ok {
+			if name == ev.Name && ev.Doc != nil {
+				if ls.sendDocumentChange(id, *ev.Doc) == nil {
+					changed = true
+				}
+			}
+			continue
+		}
+		doc := d
+		if name == ev.Name && ev.Doc != nil {
+			doc = *ev.Doc
+		}
+		if ls.sendDocumentChange(id, doc) == nil {
+			changed = true
+		}
+	}
+
+	t.view = make(map[string]struct{}, len(newView))
+	for name := range newView {
+		t.view[name] = struct{}{}
+	}
+	return changed
 }
 
 func (ls *listenSession) assignTargetID() int32 {
@@ -328,17 +413,10 @@ func resolveTarget(t *firestorepb.Target) (listenTarget, error) {
 }
 
 // sendSnapshot streams one DocumentChange per matching document for the initial
-// state of a target.
-func (ls *listenSession) sendSnapshot(id int32, t listenTarget) error {
+// state of a target and records those documents in the target's view.
+func (ls *listenSession) sendSnapshot(id int32, t *listenTarget) error {
 	if t.isQuery() {
-		project, database, rel, ok := splitParent(t.parent)
-		if !ok {
-			return status.Error(codes.InvalidArgument, "invalid query parent resource name")
-		}
-		if project == "" {
-			project = ls.srv.resolveProject(ls.stream.Context())
-		}
-		docs, err := ls.srv.svc.RunQuery(ls.stream.Context(), project, database, rel, t.query, nil)
+		docs, err := ls.queryDocs(t)
 		if err != nil {
 			return mapError(err)
 		}
@@ -346,6 +424,7 @@ func (ls *listenSession) sendSnapshot(id int32, t listenTarget) error {
 			if err := ls.sendDocumentChange(id, d); err != nil {
 				return err
 			}
+			t.view[d.Name] = struct{}{}
 		}
 		return nil
 	}
@@ -361,8 +440,59 @@ func (ls *listenSession) sendSnapshot(id int32, t listenTarget) error {
 		if err := ls.sendDocumentChange(id, doc); err != nil {
 			return err
 		}
+		t.view[doc.Name] = struct{}{}
 	}
 	return nil
+}
+
+// queryDocs runs a query target's StructuredQuery against the current store
+// state, applying collection scope, where, order_by, and limit.
+func (ls *listenSession) queryDocs(t *listenTarget) ([]firestorestore.Document, error) {
+	project, database, rel, ok := splitParent(t.parent)
+	if !ok {
+		return nil, status.Error(codes.InvalidArgument, "invalid query parent resource name")
+	}
+	if project == "" {
+		project = ls.srv.resolveProject(ls.stream.Context())
+	}
+	return ls.srv.svc.RunQuery(ls.stream.Context(), project, database, rel, t.query, nil)
+}
+
+// seedView populates a target's view from current state without emitting a
+// snapshot. It is used after an incremental replay so subsequent live deltas
+// diff against the resumed result set rather than re-emitting all of it.
+func (ls *listenSession) seedView(t *listenTarget) error {
+	if t.isQuery() {
+		docs, err := ls.queryDocs(t)
+		if err != nil {
+			return mapError(err)
+		}
+		for _, d := range docs {
+			t.view[d.Name] = struct{}{}
+		}
+		return nil
+	}
+	for _, name := range t.documents {
+		doc, err := ls.srv.svc.GetDocument(ls.stream.Context(), name, nil, nil)
+		if err != nil {
+			var pe *model.ProviderError
+			if errors.As(err, &pe) && pe.HTTPStatus == 404 {
+				continue
+			}
+			return mapError(err)
+		}
+		t.view[doc.Name] = struct{}{}
+	}
+	return nil
+}
+
+func (ls *listenSession) sendReset(id int32) error {
+	return ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_TargetChange{
+		TargetChange: &firestorepb.TargetChange{
+			TargetChangeType: firestorepb.TargetChange_RESET,
+			TargetIds:        []int32{id},
+		},
+	}})
 }
 
 func (ls *listenSession) sendDocumentChange(id int32, d firestorestore.Document) error {
@@ -374,19 +504,27 @@ func (ls *listenSession) sendDocumentChange(id int32, d firestorestore.Document)
 	}})
 }
 
+func (ls *listenSession) sendDocumentDelete(id int32, name string) error {
+	return ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_DocumentDelete{
+		DocumentDelete: &firestorepb.DocumentDelete{
+			Document:         name,
+			RemovedTargetIds: []int32{id},
+		},
+	}})
+}
+
+func (ls *listenSession) sendDocumentRemove(id int32, name string) error {
+	return ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_DocumentRemove{
+		DocumentRemove: &firestorepb.DocumentRemove{
+			Document:         name,
+			RemovedTargetIds: []int32{id},
+		},
+	}})
+}
+
 func (ls *listenSession) sendChange(id int32, ev firestoreprovider.ChangeEvent) error {
 	if ev.Doc == nil {
-		// A delete drops the document from every target that previously matched
-		// it. This engine resolves a ChangeEvent per target (the caller only
-		// invokes sendChange for targets where targetMatches is true), so the
-		// responding target is named in removed_target_ids, mirroring the
-		// TargetIds set on the DocumentChange path for non-delete events.
-		return ls.send(&firestorepb.ListenResponse{ResponseType: &firestorepb.ListenResponse_DocumentDelete{
-			DocumentDelete: &firestorepb.DocumentDelete{
-				Document:         ev.Name,
-				RemovedTargetIds: []int32{id},
-			},
-		}})
+		return ls.sendDocumentDelete(id, ev.Name)
 	}
 	return ls.sendDocumentChange(id, *ev.Doc)
 }

--- a/internal/gcp/grpc/firestore/listen_test.go
+++ b/internal/gcp/grpc/firestore/listen_test.go
@@ -511,18 +511,21 @@ func TestListenResumeTokenFallsBackToSnapshot(t *testing.T) {
 		t.Fatalf("Send: %v", err)
 	}
 
-	responses := recvN(t, stream, 4, 3*time.Second) // ADD, a (full snapshot), CURRENT, NO_CHANGE
+	responses := recvN(t, stream, 5, 3*time.Second) // ADD, RESET, a (full snapshot), CURRENT, NO_CHANGE
 	if responses[0].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_ADD {
 		t.Fatal("expected ADD")
 	}
-	dc := responses[1].GetDocumentChange()
+	if responses[1].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_RESET {
+		t.Fatalf("expected RESET for un-honorable token, got %v", responses[1])
+	}
+	dc := responses[2].GetDocumentChange()
 	if dc == nil || dc.Document.Fields["v"].GetStringValue() != "1" {
 		t.Fatal("expected full snapshot with item a")
 	}
-	if responses[2].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_CURRENT {
+	if responses[3].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_CURRENT {
 		t.Fatal("expected CURRENT")
 	}
-	if responses[3].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_NO_CHANGE {
+	if responses[4].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_NO_CHANGE {
 		t.Fatal("expected NO_CHANGE")
 	}
 }
@@ -815,9 +818,9 @@ func TestListenResumeTokenBelowFloorFallsBackToSnapshot(t *testing.T) {
 		t.Fatalf("change floor = %d, want > 2 after eviction", floor)
 	}
 
-	// Resume from the now-expired token. A correct server falls back to a full
-	// snapshot (a1 + a2); a stale incremental replay would send no deltas at all
-	// because no "a" write happened after seq 2.
+	// Resume from the now-expired token. A correct server resets the target and
+	// falls back to a full snapshot (a1 + a2); a stale incremental replay would
+	// send no deltas at all because no "a" write happened after seq 2.
 	if err := stream.Send(removeTargetReq(1)); err != nil {
 		t.Fatalf("remove target: %v", err)
 	}
@@ -828,12 +831,15 @@ func TestListenResumeTokenBelowFloorFallsBackToSnapshot(t *testing.T) {
 	if err := stream.Send(addTargetReq(rt)); err != nil {
 		t.Fatalf("resume target: %v", err)
 	}
-	rs = recvN(t, stream, 5, 10*time.Second) // ADD, a1, a2, CURRENT, NO_CHANGE
+	rs = recvN(t, stream, 6, 10*time.Second) // ADD, RESET, a1, a2, CURRENT, NO_CHANGE
 	if rs[0].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_ADD {
 		t.Fatalf("frame 0: expected ADD, got %v", rs[0])
 	}
+	if rs[1].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_RESET {
+		t.Fatalf("frame 1: expected RESET, got %v", rs[1])
+	}
 	got := map[string]bool{}
-	for _, r := range rs[1:3] {
+	for _, r := range rs[2:4] {
 		dc := r.GetDocumentChange()
 		if dc == nil {
 			t.Fatalf("expected snapshot DocumentChange, got %v", r)
@@ -842,5 +848,185 @@ func TestListenResumeTokenBelowFloorFallsBackToSnapshot(t *testing.T) {
 	}
 	if !got[listenParent+"/a/a1"] || !got[listenParent+"/a/a2"] {
 		t.Fatalf("snapshot documents = %v, want a1 and a2", got)
+	}
+}
+
+func pbString(s string) *firestorepb.Value {
+	return &firestorepb.Value{ValueType: &firestorepb.Value_StringValue{StringValue: s}}
+}
+
+func pbBool(b bool) *firestorepb.Value {
+	return &firestorepb.Value{ValueType: &firestorepb.Value_BooleanValue{BooleanValue: b}}
+}
+
+// whereQueryTarget builds a single-collection query target with an EQUAL field
+// filter, so live deltas must honor the where predicate.
+func whereQueryTarget(tid int32, collection, field string, val *firestorepb.Value) *firestorepb.Target {
+	return &firestorepb.Target{
+		TargetId: tid,
+		TargetType: &firestorepb.Target_Query{
+			Query: &firestorepb.Target_QueryTarget{
+				Parent: listenParent,
+				QueryType: &firestorepb.Target_QueryTarget_StructuredQuery{
+					StructuredQuery: &firestorepb.StructuredQuery{
+						From: []*firestorepb.StructuredQuery_CollectionSelector{{CollectionId: collection}},
+						Where: &firestorepb.StructuredQuery_Filter{
+							FilterType: &firestorepb.StructuredQuery_Filter_FieldFilter{
+								FieldFilter: &firestorepb.StructuredQuery_FieldFilter{
+									Field: &firestorepb.StructuredQuery_FieldReference{FieldPath: field},
+									Op:    firestorepb.StructuredQuery_FieldFilter_EQUAL,
+									Value: val,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestListenQueryWhereLiveUpdateEmitsDocumentRemove asserts that a live update
+// which makes a document stop matching a query target's where predicate emits a
+// DocumentRemove naming that target, rather than a DocumentChange.
+func TestListenQueryWhereLiveUpdateEmitsDocumentRemove(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const tid int32 = 11
+	for _, id := range []string{"leave", "stay"} {
+		svc.CreateDocument(ctx, "test", "(default)", "items", id, map[string]*firestorestore.Value{
+			"active": firestorestore.BoolVal(true),
+		})
+	}
+
+	lctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	if err := stream.Send(addTargetReq(whereQueryTarget(tid, "items", "active", pbBool(true)))); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	rs := recvN(t, stream, 5, 3*time.Second) // ADD, leave, stay, CURRENT, NO_CHANGE
+	if rs[0].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_ADD {
+		t.Fatalf("expected ADD, got %v", rs[0])
+	}
+	visible := map[string]bool{}
+	for _, r := range rs[1:3] {
+		dc := r.GetDocumentChange()
+		if dc == nil {
+			t.Fatalf("expected snapshot DocumentChange, got %v", r)
+		}
+		visible[dc.Document.Name] = true
+	}
+	if !visible[listenParent+"/items/leave"] || !visible[listenParent+"/items/stay"] {
+		t.Fatalf("snapshot = %v, want leave and stay", visible)
+	}
+
+	svc.PatchDocument(ctx, "test", "(default)", "items/leave", map[string]*firestorestore.Value{
+		"active": firestorestore.BoolVal(false),
+	}, nil, nil)
+
+	rs = recvN(t, stream, 2, 3*time.Second) // DocumentRemove + NO_CHANGE
+	dr := rs[0].GetDocumentRemove()
+	if dr == nil {
+		t.Fatalf("expected DocumentRemove, got %v", rs[0])
+	}
+	if dr.Document != listenParent+"/items/leave" {
+		t.Fatalf("DocumentRemove for %q, want %q", dr.Document, listenParent+"/items/leave")
+	}
+	if !containsTargetID(dr.RemovedTargetIds, tid) {
+		t.Fatalf("removed_target_ids = %v, want [%d]", dr.RemovedTargetIds, tid)
+	}
+	if rs[1].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_NO_CHANGE {
+		t.Fatalf("expected NO_CHANGE, got %v", rs[1])
+	}
+}
+
+// TestListenQueryWhereLiveDeleteEmitsDocumentDelete asserts that deleting a
+// document that was in a where-filtered target's view emits DocumentDelete (not
+// DocumentRemove).
+func TestListenQueryWhereLiveDeleteEmitsDocumentDelete(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const tid int32 = 12
+	svc.CreateDocument(ctx, "test", "(default)", "items", "one", map[string]*firestorestore.Value{
+		"active": firestorestore.BoolVal(true),
+	})
+
+	lctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	if err := stream.Send(addTargetReq(whereQueryTarget(tid, "items", "active", pbBool(true)))); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	recvN(t, stream, 4, 3*time.Second) // ADD, one, CURRENT, NO_CHANGE
+
+	svc.DeleteDocument(ctx, "test", "(default)", "items/one", nil)
+
+	rs := recvN(t, stream, 2, 3*time.Second) // DocumentDelete + NO_CHANGE
+	dd := rs[0].GetDocumentDelete()
+	if dd == nil {
+		t.Fatalf("expected DocumentDelete, got %v", rs[0])
+	}
+	if dd.Document != listenParent+"/items/one" {
+		t.Fatalf("DocumentDelete for %q, want %q", dd.Document, listenParent+"/items/one")
+	}
+	if !containsTargetID(dd.RemovedTargetIds, tid) {
+		t.Fatalf("removed_target_ids = %v, want [%d]", dd.RemovedTargetIds, tid)
+	}
+	if rs[1].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_NO_CHANGE {
+		t.Fatalf("expected NO_CHANGE, got %v", rs[1])
+	}
+}
+
+// TestListenUnresumableTokenEmitsReset asserts that a target whose resume token
+// cannot be honored is reset (TargetChange_RESET) before its fresh snapshot,
+// instead of silently falling back.
+func TestListenUnresumableTokenEmitsReset(t *testing.T) {
+	client, svc, cleanup := listenTestClient(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	svc.CreateDocument(ctx, "test", "(default)", "items", "a", map[string]*firestorestore.Value{
+		"v": firestorestore.StringVal("1"),
+	})
+
+	lctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Listen(lctx)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	rt := queryTarget(1, "items")
+	rt.ResumeType = &firestorepb.Target_ResumeToken{ResumeToken: []byte("bad")}
+	if err := stream.Send(addTargetReq(rt)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	rs := recvN(t, stream, 5, 3*time.Second) // ADD, RESET, a, CURRENT, NO_CHANGE
+	if rs[0].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_ADD {
+		t.Fatalf("expected ADD, got %v", rs[0])
+	}
+	if tc := rs[1].GetTargetChange(); tc == nil || tc.TargetChangeType != firestorepb.TargetChange_RESET {
+		t.Fatalf("expected RESET, got %v", rs[1])
+	}
+	if dc := rs[2].GetDocumentChange(); dc == nil || dc.Document.Name != listenParent+"/items/a" {
+		t.Fatalf("expected snapshot DocumentChange for a, got %v", rs[2])
+	}
+	if rs[3].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_CURRENT {
+		t.Fatalf("expected CURRENT, got %v", rs[3])
+	}
+	if rs[4].GetTargetChange().GetTargetChangeType() != firestorepb.TargetChange_NO_CHANGE {
+		t.Fatalf("expected NO_CHANGE, got %v", rs[4])
 	}
 }

--- a/internal/gcp/grpc/firestore/transcode.go
+++ b/internal/gcp/grpc/firestore/transcode.go
@@ -10,11 +10,11 @@
 //
 //   - Bounded history. The change-feed retains the most recent
 //     changeLogRetention events and drops older ones, advancing a floor. A resume
-//     token below the floor (or from before a Reset) is treated as expired: the
-//     target is not incrementally replayed and receives a fresh snapshot instead,
-//     which matches real Firestore's behavior for an expired resume token. A
-//     token of 0 is likewise not a resumable position, because the log records
-//     writes rather than a full document history.
+//     token below the floor (or from before a Reset), malformed, or of zero, is
+//     treated as expired: the target is reset (TargetChange_RESET) and receives a
+//     fresh snapshot, matching real Firestore's behavior for an un-honorable
+//     resume token. A token of 0 is likewise not a resumable position, because the
+//     log records writes rather than a full document history.
 //   - Per-target cursors. Each target tracks the last sequence delivered to it.
 //     Its TargetChange_CURRENT frame carries that target's own sequence. The
 //     empty-target_ids NO_CHANGE frame's token must cover all targets at once; it


### PR DESCRIPTION
## Description

Firestore `Listen` residual parity gaps (audit item G15, `plan_docs/gcp-parity-gaps-plan.md`). `Listen` already streamed snapshots and realtime updates, and already sent `TargetChange(ADD)` before the first `DocumentChange` and `TargetChange(REMOVE)` on `remove_target` (those earlier findings were false positives). The genuine residuals were:

- **Live deltas ignored the target query.** A realtime change was matched by collection scope only, so a document that stopped matching a `where` predicate (or was pushed out by `order_by` + `limit`) was never removed from the client's view.
- **No `DocumentRemove` / `removedTargetIds`** when a document left a query view.
- **An un-resumable resume token re-snapshotted silently** instead of emitting `TargetChange(RESET)`.

## What's in this PR

`internal/gcp/grpc/firestore/listen.go`:
- Each target keeps a `view` set of the document names currently in its result set.
- A live change re-runs the target's query (`where` + `order_by` + `limit`) and diffs the new result set against the view, emitting `DocumentChange` on entry/update, `DocumentRemove` on leave (or limit eviction), and `DocumentDelete` on delete.
- When a resume token cannot be honored, the target emits `TargetChange(RESET)` before the fresh snapshot; after an incremental replay the view is seeded from current state so the first live delta diffs instead of re-emitting the whole result set.
- Scope pre-filter retained so out-of-scope bulk writes don't trigger queries.

New tests: `TestListenQueryWhereLiveUpdateEmitsDocumentRemove`, `TestListenQueryWhereLiveDeleteEmitsDocumentDelete`, `TestListenUnresumableTokenEmitsReset`; the existing fallback tests now assert `RESET`.

## Out of scope

- The localgcp Listen frame-shape expectations that are non-compliant with real Firestore (see below) and the two known semantic divergences where jaiscloud is correct.
- Other verified gaps (GCS REST restore/lock/move + CORS, Logging `DeleteLog` investigation).

## How to test

```bash
go build ./... && go vet ./internal/gcp/... && gofmt -l internal/gcp/
go test ./internal/gcp/grpc/firestore/ ./internal/gcp/provider/firestore/ ./internal/gcp/store/firestore/ -count=1
go test ./internal/gcp/... -count=1
```

## Test report

- `go test ./internal/gcp/...` green; `vet`/`gofmt` clean; new Listen tests pass (16/16 in the package).
- **jaiscloud** `tests/integration/gcp/sdk-firestore` (ephemeral server on `:8081`): pass (incl. `TestSDKFirestoreSnapshots`, which uses `Listen`).
- **floci** `sdk-test-go` `TestFirestore`: pass.
- **localgcp** Firestore replay: 26 pass / 7 fail — unchanged from baseline; the `RESET` case is now asserted. The 7 remaining are all non-compliant-harness expectations, not jaiscloud gaps:
  - `TestDeleteNonexistent`, `TestQueryIN_Empty` — jaiscloud matches real Firestore (idempotent delete; `IN []` rejected).
  - `TestListenRemoveTarget`, `TestListenCollectionRealTimeUpdates`, `TestListenIgnoresUnrelatedCollections`, `TestListenMultipleClients`, `TestListenResumeTokenBasic` — the harness reads a fixed number of frames and does not account for the initial `ADD`/`CURRENT`/`NO_CHANGE` sequence of an empty snapshot.

## Conformance audit

- Firestore `Listen` `TargetChange.RESET`: "targets have been reset and are no longer in sync" — sent when an un-resumable resume token cannot be honored, followed by a fresh snapshot.
- `DocumentRemove` / `DocumentDelete.removedTargetIds`: delivered when a document leaves a target's result set, including when a `where`/`limit` query no longer matches it.
- Live deltas must honor the same query as the initial snapshot (`StructuredQuery` where/order_by/limit).
