### PR TITLE
fix(gcp/logging): support org/folder/billing scopes and URL-encoded log IDs

### DIFF
--- a/internal/gcp/grpc/logging/logname.go
+++ b/internal/gcp/grpc/logging/logname.go
@@ -1,0 +1,94 @@
+package logging
+
+import (
+	"net/url"
+	"strings"
+
+	"jaiscloud/internal/model"
+)
+
+// logScopes is the set of resource-container collections that may parent a
+// Cloud Logging log, per Logging v2: projects, organizations, folders, and
+// billingAccounts. A log name uses the form {scope}/{scopeID}/logs/{LOG_ID}.
+var logScopes = map[string]struct{}{
+	"projects":        {},
+	"organizations":   {},
+	"folders":         {},
+	"billingAccounts": {},
+}
+
+func invalidLogName(name string) error {
+	return model.NewProviderError("InvalidArgument", "invalid log name: "+name, 400)
+}
+
+func invalidParent(name string) error {
+	return model.NewProviderError("InvalidArgument", "invalid resource name: "+name, 400)
+}
+
+// parseLogName parses a Cloud Logging log resource name of the form
+// {scope}/{scopeID}/logs/{LOG_ID}, where {scope} is one of "projects",
+// "organizations", "folders", or "billingAccounts". The route uses non-empty
+// segments ([^/]+) and LOG_ID is URL-encoded, so it is URL-decoded here.
+//
+// It returns the canonical two-segment scope parent ("projects/p",
+// "organizations/123", ...) and the decoded log ID. Malformed names, including
+// empty segments, an unknown scope, a missing/wrong "logs" segment, a blank
+// log ID, and an invalid percent-escape, return an InvalidArgument error.
+//
+// A leading "/" is stripped for backward compatibility with clients that send
+// "/projects/..." (real Cloud Logging processes such names after removing the
+// leading slash).
+func parseLogName(name string) (scopeParent, logID string, err error) {
+	trimmed := strings.TrimPrefix(name, "/")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 4 || parts[2] != "logs" {
+		return "", "", invalidLogName(name)
+	}
+	if _, ok := logScopes[parts[0]]; !ok || parts[1] == "" || parts[3] == "" {
+		return "", "", invalidLogName(name)
+	}
+	decoded, derr := url.PathUnescape(parts[3])
+	if derr != nil || decoded == "" {
+		return "", "", invalidLogName(name)
+	}
+	return parts[0] + "/" + parts[1], decoded, nil
+}
+
+// canonicalLogName builds the canonical log resource name for a scope parent
+// and a decoded log ID. The LOG_ID is re-encoded so equivalent spellings
+// (for example "%2f" vs "%2F", or a leading slash) collapse to one stored form
+// and appear URL-encoded in ListLogs, matching real Cloud Logging.
+func canonicalLogName(scopeParent, logID string) string {
+	return scopeParent + "/logs/" + url.PathEscape(logID)
+}
+
+// parseScopeParent normalizes a parent resource name used by ListLogs (parent)
+// and ListLogEntries (resource_names) to a canonical two-segment scope parent.
+// It accepts a container parent ("projects/p", "organizations/123",
+// "folders/f", "billingAccounts/b"), a full log name (the parent portion is
+// returned), or a bare project ID (legacy "p" -> "projects/p"). Malformed names
+// return an InvalidArgument error.
+func parseScopeParent(name string) (string, error) {
+	trimmed := strings.TrimPrefix(name, "/")
+	parts := strings.Split(trimmed, "/")
+	switch len(parts) {
+	case 1:
+		if parts[0] == "" {
+			return "", invalidParent(name)
+		}
+		return "projects/" + parts[0], nil
+	case 2:
+		if _, ok := logScopes[parts[0]]; !ok || parts[1] == "" {
+			return "", invalidParent(name)
+		}
+		return parts[0] + "/" + parts[1], nil
+	case 4:
+		scopeParent, _, perr := parseLogName(trimmed)
+		if perr != nil {
+			return "", perr
+		}
+		return scopeParent, nil
+	default:
+		return "", invalidParent(name)
+	}
+}

--- a/internal/gcp/grpc/logging/logname_test.go
+++ b/internal/gcp/grpc/logging/logname_test.go
@@ -1,0 +1,108 @@
+package logging
+
+import "testing"
+
+func TestParseLogNameScopes(t *testing.T) {
+	cases := []struct {
+		name  string
+		scope string
+		logID string
+	}{
+		{"projects/my-project/logs/syslog", "projects/my-project", "syslog"},
+		{"organizations/123/logs/syslog", "organizations/123", "syslog"},
+		{"folders/456/logs/syslog", "folders/456", "syslog"},
+		{"billingAccounts/0X0X0X-0X0X0X-0X0X0X/logs/syslog", "billingAccounts/0X0X0X-0X0X0X-0X0X0X", "syslog"},
+		// LOG_ID is URL-encoded; %2F decodes to a slash.
+		{"projects/p/logs/cloudaudit.googleapis.com%2Factivity", "projects/p", "cloudaudit.googleapis.com/activity"},
+		{"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity", "organizations/1234567890", "cloudresourcemanager.googleapis.com/activity"},
+		{"folders/9/logs/a%2Fb%2Fc", "folders/9", "a/b/c"},
+		// Leading slash is stripped for backward compatibility.
+		{"/projects/p/logs/leading", "projects/p", "leading"},
+	}
+	for _, tc := range cases {
+		scope, logID, err := parseLogName(tc.name)
+		if err != nil {
+			t.Errorf("parseLogName(%q) error = %v", tc.name, err)
+			continue
+		}
+		if scope != tc.scope || logID != tc.logID {
+			t.Errorf("parseLogName(%q) = (%q, %q), want (%q, %q)", tc.name, scope, logID, tc.scope, tc.logID)
+		}
+	}
+}
+
+func TestParseLogNameRejectsMalformed(t *testing.T) {
+	bad := []string{
+		"",
+		"projects//logs/",
+		"projects/p/logs/",
+		"projects//logs/x",
+		"projects/p/logs",
+		"projects/p/logs/a/b",
+		"projects/p/notlogs/x",
+		"projects/p/logs/%zz",
+		"bots/x/logs/y",
+		"logs/y",
+		"projects/p",
+		"organizations//logs/x",
+		"folders/1/notlogs/x",
+		"billingAccounts/1/logs/x/y",
+	}
+	for _, name := range bad {
+		if _, _, err := parseLogName(name); err == nil {
+			t.Errorf("parseLogName(%q) succeeded, want InvalidArgument", name)
+		}
+	}
+}
+
+func TestCanonicalLogName(t *testing.T) {
+	cases := []struct {
+		scope, logID, want string
+	}{
+		{"projects/p", "syslog", "projects/p/logs/syslog"},
+		{"organizations/123", "cloudresourcemanager.googleapis.com/activity", "organizations/123/logs/cloudresourcemanager.googleapis.com%2Factivity"},
+		{"folders/9", "a/b", "folders/9/logs/a%2Fb"},
+	}
+	for _, tc := range cases {
+		if got := canonicalLogName(tc.scope, tc.logID); got != tc.want {
+			t.Errorf("canonicalLogName(%q, %q) = %q, want %q", tc.scope, tc.logID, got, tc.want)
+		}
+	}
+}
+
+func TestParseScopeParent(t *testing.T) {
+	good := map[string]string{
+		"projects/my-project":    "projects/my-project",
+		"organizations/123":      "organizations/123",
+		"folders/456":            "folders/456",
+		"billingAccounts/0X0X":   "billingAccounts/0X0X",
+		"projects/p/logs/syslog": "projects/p",
+		"organizations/1/logs/x": "organizations/1",
+		"legacy-bare-project":    "projects/legacy-bare-project",
+	}
+	for in, want := range good {
+		got, err := parseScopeParent(in)
+		if err != nil {
+			t.Errorf("parseScopeParent(%q) error = %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("parseScopeParent(%q) = %q, want %q", in, got, want)
+		}
+	}
+
+	bad := []string{
+		"",
+		"projects/",
+		"projects/p/logs",
+		"projects//logs/x",
+		"bots/x",
+		"projects/p/logs/a/b",
+		"a/b/c",
+	}
+	for _, in := range bad {
+		if _, err := parseScopeParent(in); err == nil {
+			t.Errorf("parseScopeParent(%q) succeeded, want InvalidArgument", in)
+		}
+	}
+}

--- a/internal/gcp/grpc/logging/scope_test.go
+++ b/internal/gcp/grpc/logging/scope_test.go
@@ -1,0 +1,207 @@
+package logging
+
+import (
+	"context"
+	"testing"
+
+	loggingpb "cloud.google.com/go/logging/apiv2/loggingpb"
+
+	ltype "google.golang.org/genproto/googleapis/logging/type"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestLoggingOrganizationScopeIsolation(t *testing.T) {
+	client, cleanup := loggingTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const (
+		orgLog  = "organizations/123/logs/shared-id"
+		projLog = "projects/test/logs/shared-id"
+	)
+	if _, err := client.WriteLogEntries(ctx, &loggingpb.WriteLogEntriesRequest{
+		Entries: []*loggingpb.LogEntry{
+			logEntry(orgLog, "org-entry", ltype.LogSeverity_INFO),
+			logEntry(projLog, "proj-entry", ltype.LogSeverity_INFO),
+		},
+	}); err != nil {
+		t.Fatalf("WriteLogEntries: %v", err)
+	}
+
+	listScope := func(resource string) []*loggingpb.LogEntry {
+		t.Helper()
+		resp, err := client.ListLogEntries(ctx, &loggingpb.ListLogEntriesRequest{
+			ResourceNames: []string{resource},
+		})
+		if err != nil {
+			t.Fatalf("ListLogEntries(%q): %v", resource, err)
+		}
+		return resp.GetEntries()
+	}
+
+	orgEntries := listScope("organizations/123")
+	if len(orgEntries) != 1 || orgEntries[0].GetTextPayload() != "org-entry" {
+		t.Fatalf("organizations scope = %+v, want only org-entry", orgEntries)
+	}
+	projEntries := listScope("projects/test")
+	if len(projEntries) != 1 || projEntries[0].GetTextPayload() != "proj-entry" {
+		t.Fatalf("projects scope = %+v, want only proj-entry", projEntries)
+	}
+
+	logs, err := client.ListLogs(ctx, &loggingpb.ListLogsRequest{Parent: "organizations/123"})
+	if err != nil {
+		t.Fatalf("ListLogs(organizations/123): %v", err)
+	}
+	// The organizations scope must not surface the project's identically named log.
+	if len(logs.GetLogNames()) != 1 || logs.GetLogNames()[0] != orgLog {
+		t.Fatalf("ListLogs(organizations/123) = %v, want [%s]", logs.GetLogNames(), orgLog)
+	}
+}
+
+func TestLoggingDeleteLogScopeIsolation(t *testing.T) {
+	client, cleanup := loggingTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const (
+		orgA  = "organizations/123/logs/a"
+		orgB  = "organizations/123/logs/b"
+		projA = "projects/test/logs/a"
+	)
+	if _, err := client.WriteLogEntries(ctx, &loggingpb.WriteLogEntriesRequest{
+		Entries: []*loggingpb.LogEntry{
+			logEntry(orgA, "org-a", ltype.LogSeverity_INFO),
+			logEntry(orgB, "org-b", ltype.LogSeverity_INFO),
+			logEntry(projA, "proj-a", ltype.LogSeverity_INFO),
+		},
+	}); err != nil {
+		t.Fatalf("WriteLogEntries: %v", err)
+	}
+
+	if _, err := client.DeleteLog(ctx, &loggingpb.DeleteLogRequest{LogName: orgA}); err != nil {
+		t.Fatalf("DeleteLog(%s): %v", orgA, err)
+	}
+
+	orgEntries := func() []*loggingpb.LogEntry {
+		resp, err := client.ListLogEntries(ctx, &loggingpb.ListLogEntriesRequest{
+			ResourceNames: []string{"organizations/123"},
+		})
+		if err != nil {
+			t.Fatalf("ListLogEntries: %v", err)
+		}
+		return resp.GetEntries()
+	}
+	if got := orgEntries(); len(got) != 1 || got[0].GetTextPayload() != "org-b" {
+		t.Fatalf("organizations scope after delete = %+v, want only org-b", got)
+	}
+	// Deleting in the organizations scope must not touch the project's log of
+	// the same ID.
+	projResp, err := client.ListLogEntries(ctx, &loggingpb.ListLogEntriesRequest{
+		ResourceNames: []string{"projects/test"},
+	})
+	if err != nil {
+		t.Fatalf("ListLogEntries(projects/test): %v", err)
+	}
+	if got := projResp.GetEntries(); len(got) != 1 || got[0].GetTextPayload() != "proj-a" {
+		t.Fatalf("projects scope after org delete = %+v, want only proj-a", got)
+	}
+
+	// Idempotent: deleting a well-formed, now-absent log must not error.
+	if _, err := client.DeleteLog(ctx, &loggingpb.DeleteLogRequest{LogName: orgA}); err != nil {
+		t.Fatalf("second DeleteLog(%s) = %v, want no error", orgA, err)
+	}
+}
+
+func TestLoggingDeleteLogMalformed(t *testing.T) {
+	client, cleanup := loggingTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	for _, name := range []string{"bots/x/logs/y", "projects/p/logs/", "projects//logs/x", "projects/p/logs"} {
+		if _, err := client.DeleteLog(ctx, &loggingpb.DeleteLogRequest{LogName: name}); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("DeleteLog(%q) err = %v, want InvalidArgument", name, err)
+		}
+	}
+}
+
+func TestLoggingWriteRequestLevelLogName(t *testing.T) {
+	client, cleanup := loggingTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const logName = "organizations/77/logs/default-log"
+	if _, err := client.WriteLogEntries(ctx, &loggingpb.WriteLogEntriesRequest{
+		LogName: logName,
+		Entries: []*loggingpb.LogEntry{
+			{Severity: ltype.LogSeverity_INFO, Payload: &loggingpb.LogEntry_TextPayload{TextPayload: "via-default"}},
+		},
+	}); err != nil {
+		t.Fatalf("WriteLogEntries: %v", err)
+	}
+
+	resp, err := client.ListLogEntries(ctx, &loggingpb.ListLogEntriesRequest{
+		ResourceNames: []string{"organizations/77"},
+	})
+	if err != nil {
+		t.Fatalf("ListLogEntries: %v", err)
+	}
+	if len(resp.GetEntries()) != 1 || resp.GetEntries()[0].GetTextPayload() != "via-default" {
+		t.Fatalf("entries = %+v, want one via-default", resp.GetEntries())
+	}
+	if got := resp.GetEntries()[0].GetLogName(); got != logName {
+		t.Fatalf("log name = %q, want %q", got, logName)
+	}
+}
+
+func TestLoggingEncodedLogID(t *testing.T) {
+	client, cleanup := loggingTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	const logName = "projects/test/logs/cloudaudit.googleapis.com%2Factivity"
+	if _, err := client.WriteLogEntries(ctx, &loggingpb.WriteLogEntriesRequest{
+		Entries: []*loggingpb.LogEntry{logEntry(logName, "audit", ltype.LogSeverity_INFO)},
+	}); err != nil {
+		t.Fatalf("WriteLogEntries: %v", err)
+	}
+
+	// ListLogs returns the URL-encoded log name, as real Cloud Logging does.
+	logs, err := client.ListLogs(ctx, &loggingpb.ListLogsRequest{Parent: "projects/test"})
+	if err != nil {
+		t.Fatalf("ListLogs: %v", err)
+	}
+	if len(logs.GetLogNames()) != 1 || logs.GetLogNames()[0] != logName {
+		t.Fatalf("ListLogs = %v, want [%s]", logs.GetLogNames(), logName)
+	}
+
+	if _, err := client.DeleteLog(ctx, &loggingpb.DeleteLogRequest{LogName: logName}); err != nil {
+		t.Fatalf("DeleteLog: %v", err)
+	}
+	resp, err := client.ListLogEntries(ctx, &loggingpb.ListLogEntriesRequest{
+		ResourceNames: []string{"projects/test"},
+	})
+	if err != nil {
+		t.Fatalf("ListLogEntries: %v", err)
+	}
+	if len(resp.GetEntries()) != 0 {
+		t.Fatalf("entries after encoded delete = %+v, want none", resp.GetEntries())
+	}
+}
+
+func TestLoggingMalformedResourceParent(t *testing.T) {
+	client, cleanup := loggingTestService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if _, err := client.ListLogEntries(ctx, &loggingpb.ListLogEntriesRequest{
+		ResourceNames: []string{"bots/x"},
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("ListLogEntries(bots/x) err = %v, want InvalidArgument", err)
+	}
+	if _, err := client.ListLogs(ctx, &loggingpb.ListLogsRequest{
+		Parent: "projects/p/logs",
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("ListLogs(projects/p/logs) err = %v, want InvalidArgument", err)
+	}
+}

--- a/internal/gcp/grpc/logging/service.go
+++ b/internal/gcp/grpc/logging/service.go
@@ -29,6 +29,7 @@ package logging
 import (
 	"context"
 	"encoding/base64"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -70,29 +71,15 @@ func logName(project, id string) string {
 	return resource.ResourceID(project)("log", id)
 }
 
-// splitLogName parses "projects/{p}/logs/{l}".
-func splitLogName(name string) (project, logID string, ok bool) {
-	parts := strings.Split(name, "/")
-	if len(parts) != 4 || parts[0] != "projects" || parts[2] != "logs" {
-		return "", "", false
-	}
-	return parts[1], parts[3], true
-}
-
-// projectFromResourceName extracts the project from "projects/{p}" (or a
-// longer "projects/{p}/logs/{l}" name) or a bare project id.
-func projectFromResourceName(name string) string {
-	if name == "" {
+// defaultScope resolves the scope parent used when a request omits its
+// resource name, from gRPC routing metadata or the configured default project.
+// It returns "" when nothing resolves (an empty store key lists nothing).
+func (s *Service) defaultScope(ctx context.Context) string {
+	scope, err := parseScopeParent(grpcutil.ProjectFromMetadata(ctx, s.defaultProj))
+	if err != nil {
 		return ""
 	}
-	parts := strings.Split(name, "/")
-	if len(parts) >= 2 && parts[0] == "projects" {
-		return parts[1]
-	}
-	if !strings.Contains(name, "/") {
-		return name
-	}
-	return ""
+	return scope
 }
 
 // ─── LoggingServiceV2 ─────────────────────────────────────────────────────────
@@ -138,10 +125,11 @@ func (s *Service) WriteLogEntries(ctx context.Context, req *loggingpb.WriteLogEn
 		if e.Timestamp.IsZero() {
 			e.Timestamp = clock.Now()
 		}
-		_, _, ok := splitLogName(e.LogName)
-		if !ok {
-			return nil, mapError(model.NewProviderError("InvalidArgument", "invalid log name: "+e.LogName, 400))
+		scope, logID, perr := parseLogName(e.LogName)
+		if perr != nil {
+			return nil, mapError(perr)
 		}
+		e.LogName = canonicalLogName(scope, logID)
 		entries = append(entries, e)
 	}
 
@@ -151,8 +139,8 @@ func (s *Service) WriteLogEntries(ctx context.Context, req *loggingpb.WriteLogEn
 
 	// Pass 2: write every validated entry.
 	for _, e := range entries {
-		project, _, _ := splitLogName(e.LogName)
-		if err := s.store.Write(ctx, project, e); err != nil {
+		scope, _, _ := parseLogName(e.LogName)
+		if err := s.store.Write(ctx, scope, e); err != nil {
 			return nil, mapError(err)
 		}
 	}
@@ -165,20 +153,39 @@ func (s *Service) ListLogEntries(ctx context.Context, req *loggingpb.ListLogEntr
 		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid filter: "+err.Error(), 400))
 	}
 
-	project := ""
+	var scopes []string
+	seenScope := make(map[string]struct{}, len(req.GetResourceNames()))
 	for _, rn := range req.GetResourceNames() {
-		if p := projectFromResourceName(rn); p != "" {
-			project = p
-			break
+		scope, perr := parseScopeParent(rn)
+		if perr != nil {
+			return nil, mapError(perr)
+		}
+		if _, seen := seenScope[scope]; !seen {
+			seenScope[scope] = struct{}{}
+			scopes = append(scopes, scope)
 		}
 	}
-	if project == "" {
-		project = grpcutil.ProjectFromMetadata(ctx, s.defaultProj)
+	if len(scopes) == 0 {
+		if scope := s.defaultScope(ctx); scope != "" {
+			scopes = append(scopes, scope)
+		}
 	}
 
-	entries, err := s.store.List(ctx, project)
-	if err != nil {
-		return nil, mapError(err)
+	var entries []loggingstore.LogEntry
+	for _, scope := range scopes {
+		list, lerr := s.store.List(ctx, scope)
+		if lerr != nil {
+			return nil, mapError(lerr)
+		}
+		entries = append(entries, list...)
+	}
+	if len(scopes) > 1 {
+		sort.SliceStable(entries, func(i, j int) bool {
+			if entries[i].Timestamp.Equal(entries[j].Timestamp) {
+				return entries[i].ID < entries[j].ID
+			}
+			return entries[i].Timestamp.Before(entries[j].Timestamp)
+		})
 	}
 	filtered := entries[:0]
 	for _, e := range entries {
@@ -203,11 +210,17 @@ func (s *Service) ListLogEntries(ctx context.Context, req *loggingpb.ListLogEntr
 }
 
 func (s *Service) ListLogs(ctx context.Context, req *loggingpb.ListLogsRequest) (*loggingpb.ListLogsResponse, error) {
-	project := projectFromResourceName(req.GetParent())
-	if project == "" {
-		project = grpcutil.ProjectFromMetadata(ctx, s.defaultProj)
+	scope := ""
+	if parent := req.GetParent(); parent == "" {
+		scope = s.defaultScope(ctx)
+	} else {
+		parsed, perr := parseScopeParent(parent)
+		if perr != nil {
+			return nil, mapError(perr)
+		}
+		scope = parsed
 	}
-	names, err := s.store.ListLogs(ctx, project)
+	names, err := s.store.ListLogs(ctx, scope)
 	if err != nil {
 		return nil, mapError(err)
 	}
@@ -217,11 +230,11 @@ func (s *Service) ListLogs(ctx context.Context, req *loggingpb.ListLogsRequest) 
 }
 
 func (s *Service) DeleteLog(ctx context.Context, req *loggingpb.DeleteLogRequest) (*emptypb.Empty, error) {
-	project, _, ok := splitLogName(req.GetLogName())
-	if !ok {
-		return nil, mapError(model.NewProviderError("InvalidArgument", "invalid log name: "+req.GetLogName(), 400))
+	scope, logID, perr := parseLogName(req.GetLogName())
+	if perr != nil {
+		return nil, mapError(perr)
 	}
-	if err := s.store.DeleteLog(ctx, project, req.GetLogName()); err != nil {
+	if err := s.store.DeleteLog(ctx, scope, canonicalLogName(scope, logID)); err != nil {
 		return nil, mapError(err)
 	}
 	return &emptypb.Empty{}, nil

--- a/internal/gcp/grpc/logging/tail.go
+++ b/internal/gcp/grpc/logging/tail.go
@@ -8,7 +8,6 @@ import (
 
 	loggingpb "cloud.google.com/go/logging/apiv2/loggingpb"
 
-	grpcutil "jaiscloud/internal/gcp/grpc"
 	"jaiscloud/internal/model"
 
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -43,16 +42,16 @@ func tailPollInterval(bw *durationpb.Duration) time.Duration {
 	return d
 }
 
-// tailProject resolves the project from the request's resource_names, falling
-// back to routing metadata and then the configured default — the same
+// tailScope resolves the scope parent from the request's resource_names,
+// falling back to routing metadata and then the configured default — the same
 // resolution ListLogEntries uses.
-func (s *Service) tailProject(ctx context.Context, req *loggingpb.TailLogEntriesRequest) string {
+func (s *Service) tailScope(ctx context.Context, req *loggingpb.TailLogEntriesRequest) string {
 	for _, rn := range req.GetResourceNames() {
-		if p := projectFromResourceName(rn); p != "" {
-			return p
+		if scope, err := parseScopeParent(rn); err == nil {
+			return scope
 		}
 	}
-	return grpcutil.ProjectFromMetadata(ctx, s.defaultProj)
+	return s.defaultScope(ctx)
 }
 
 // latestEntryID returns the highest stored entry id for the project, or -1 when
@@ -101,7 +100,7 @@ func (s *Service) TailLogEntries(stream loggingpb.LoggingServiceV2_TailLogEntrie
 	}
 
 	ctx := stream.Context()
-	project := s.tailProject(ctx, req)
+	project := s.tailScope(ctx, req)
 	lastID, err := s.latestEntryID(ctx, project)
 	if err != nil {
 		return mapError(err)
@@ -146,7 +145,7 @@ func (s *Service) TailLogEntries(stream loggingpb.LoggingServiceV2_TailLogEntrie
 			}
 			u := tailUpdate{
 				pred:     p,
-				project:  s.tailProject(ctx, r),
+				project:  s.tailScope(ctx, r),
 				interval: tailPollInterval(r.GetBufferWindow()),
 			}
 			select {

--- a/internal/gcp/store/logging/memory.go
+++ b/internal/gcp/store/logging/memory.go
@@ -10,7 +10,7 @@ import (
 type MemoryStore struct {
 	mu      sync.RWMutex
 	nextID  int64
-	entries map[string][]LogEntry // projectID → entries
+	entries map[string][]LogEntry // scope → entries
 }
 
 // NewMemoryStore returns an empty in-memory store.
@@ -18,19 +18,19 @@ func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{entries: make(map[string][]LogEntry)}
 }
 
-func (s *MemoryStore) Write(_ context.Context, projectID string, e LogEntry) error {
+func (s *MemoryStore) Write(_ context.Context, scope string, e LogEntry) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	e.ID = s.nextID
 	s.nextID++
-	s.entries[projectID] = append(s.entries[projectID], e)
+	s.entries[scope] = append(s.entries[scope], e)
 	return nil
 }
 
-func (s *MemoryStore) List(_ context.Context, projectID string) ([]LogEntry, error) {
+func (s *MemoryStore) List(_ context.Context, scope string) ([]LogEntry, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	src := s.entries[projectID]
+	src := s.entries[scope]
 	result := make([]LogEntry, len(src))
 	copy(result, src)
 	sort.Slice(result, func(i, j int) bool {
@@ -42,11 +42,11 @@ func (s *MemoryStore) List(_ context.Context, projectID string) ([]LogEntry, err
 	return result, nil
 }
 
-func (s *MemoryStore) ListLogs(_ context.Context, projectID string) ([]string, error) {
+func (s *MemoryStore) ListLogs(_ context.Context, scope string) ([]string, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	seen := make(map[string]struct{})
-	for _, e := range s.entries[projectID] {
+	for _, e := range s.entries[scope] {
 		if e.LogName != "" {
 			seen[e.LogName] = struct{}{}
 		}
@@ -59,17 +59,17 @@ func (s *MemoryStore) ListLogs(_ context.Context, projectID string) ([]string, e
 	return result, nil
 }
 
-func (s *MemoryStore) DeleteLog(_ context.Context, projectID, logName string) error {
+func (s *MemoryStore) DeleteLog(_ context.Context, scope, logName string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	src := s.entries[projectID]
+	src := s.entries[scope]
 	kept := src[:0]
 	for _, e := range src {
 		if e.LogName != logName {
 			kept = append(kept, e)
 		}
 	}
-	s.entries[projectID] = kept
+	s.entries[scope] = kept
 	return nil
 }
 

--- a/internal/gcp/store/logging/memory_test.go
+++ b/internal/gcp/store/logging/memory_test.go
@@ -55,6 +55,47 @@ func TestMemoryStoreCRUD(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreScopeIsolation(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	base := time.Now().UTC()
+
+	if err := s.Write(ctx, "projects/p1", testEntry("projects/p1/logs/a", "proj-a", 200, base)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Write(ctx, "organizations/123", testEntry("organizations/123/logs/a", "org-a", 200, base)); err != nil {
+		t.Fatal(err)
+	}
+
+	proj, err := s.List(ctx, "projects/p1")
+	if err != nil || len(proj) != 1 || proj[0].TextPayload != "proj-a" {
+		t.Fatalf("projects/p1 list = %+v, %v", proj, err)
+	}
+	org, err := s.List(ctx, "organizations/123")
+	if err != nil || len(org) != 1 || org[0].TextPayload != "org-a" {
+		t.Fatalf("organizations/123 list = %+v, %v", org, err)
+	}
+
+	projLogs, err := s.ListLogs(ctx, "projects/p1")
+	if err != nil || len(projLogs) != 1 || projLogs[0] != "projects/p1/logs/a" {
+		t.Fatalf("projects/p1 logs = %v, %v", projLogs, err)
+	}
+	orgLogs, err := s.ListLogs(ctx, "organizations/123")
+	if err != nil || len(orgLogs) != 1 || orgLogs[0] != "organizations/123/logs/a" {
+		t.Fatalf("organizations/123 logs = %v, %v", orgLogs, err)
+	}
+
+	if err := s.DeleteLog(ctx, "organizations/123", "organizations/123/logs/a"); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := s.List(ctx, "organizations/123"); len(got) != 0 {
+		t.Fatalf("organizations/123 after delete = %+v, want empty", got)
+	}
+	if got, _ := s.List(ctx, "projects/p1"); len(got) != 1 {
+		t.Fatalf("projects/p1 must be untouched by org delete = %+v", got)
+	}
+}
+
 func TestMemoryStoreReset(t *testing.T) {
 	ctx := context.Background()
 	s := NewMemoryStore()

--- a/internal/gcp/store/logging/postgres.go
+++ b/internal/gcp/store/logging/postgres.go
@@ -27,7 +27,7 @@ func nullableJSON(v any) any {
 	return json.RawMessage(b)
 }
 
-func (s *PostgresStore) Write(ctx context.Context, projectID string, e LogEntry) error {
+func (s *PostgresStore) Write(ctx context.Context, scope string, e LogEntry) error {
 	if e.Timestamp.IsZero() {
 		e.Timestamp = clock.Now()
 	}
@@ -35,16 +35,16 @@ func (s *PostgresStore) Write(ctx context.Context, projectID string, e LogEntry)
 		INSERT INTO jc_log_entries
 			(project_id, log_name, resource_type, resource_labels, severity, payload_type, text_payload, json_payload, timestamp, insert_id, labels)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
-	`, projectID, e.LogName, e.ResourceType, nullableJSON(e.ResourceLabels), e.Severity, e.PayloadType, e.TextPayload,
+	`, scope, e.LogName, e.ResourceType, nullableJSON(e.ResourceLabels), e.Severity, e.PayloadType, e.TextPayload,
 		nullableJSON(e.JsonPayload), e.Timestamp, e.InsertID, nullableJSON(e.Labels))
 	return err
 }
 
-func (s *PostgresStore) List(ctx context.Context, projectID string) ([]LogEntry, error) {
+func (s *PostgresStore) List(ctx context.Context, scope string) ([]LogEntry, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT id, log_name, resource_type, resource_labels, severity, payload_type, text_payload, json_payload, timestamp, insert_id, labels
 		FROM jc_log_entries WHERE project_id=$1 ORDER BY timestamp, id
-	`, projectID)
+	`, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -70,10 +70,10 @@ func (s *PostgresStore) List(ctx context.Context, projectID string) ([]LogEntry,
 	return result, rows.Err()
 }
 
-func (s *PostgresStore) ListLogs(ctx context.Context, projectID string) ([]string, error) {
+func (s *PostgresStore) ListLogs(ctx context.Context, scope string) ([]string, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT DISTINCT log_name FROM jc_log_entries WHERE project_id=$1 ORDER BY log_name
-	`, projectID)
+	`, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -89,8 +89,8 @@ func (s *PostgresStore) ListLogs(ctx context.Context, projectID string) ([]strin
 	return result, rows.Err()
 }
 
-func (s *PostgresStore) DeleteLog(ctx context.Context, projectID, logName string) error {
-	_, err := s.pool.Exec(ctx, `DELETE FROM jc_log_entries WHERE project_id=$1 AND log_name=$2`, projectID, logName)
+func (s *PostgresStore) DeleteLog(ctx context.Context, scope, logName string) error {
+	_, err := s.pool.Exec(ctx, `DELETE FROM jc_log_entries WHERE project_id=$1 AND log_name=$2`, scope, logName)
 	return err
 }
 

--- a/internal/gcp/store/logging/store.go
+++ b/internal/gcp/store/logging/store.go
@@ -27,15 +27,17 @@ type LogEntry struct {
 	Labels         map[string]string `json:"labels,omitempty"`
 }
 
-// Store is the Cloud Logging store. Entries are project-scoped; queries return
+// Store is the Cloud Logging store. Entries are isolated by scope parent, the
+// two-segment Cloud Logging resource container ("projects/p",
+// "organizations/123", "folders/f", "billingAccounts/b"); queries return
 // entries ordered by (timestamp, id) ascending.
 type Store interface {
-	Write(ctx context.Context, projectID string, e LogEntry) error
-	// List returns every entry in the project, ordered by (timestamp, id).
-	List(ctx context.Context, projectID string) ([]LogEntry, error)
-	// ListLogs returns the distinct full log names under the project, sorted.
-	ListLogs(ctx context.Context, projectID string) ([]string, error)
+	Write(ctx context.Context, scope string, e LogEntry) error
+	// List returns every entry in the scope, ordered by (timestamp, id).
+	List(ctx context.Context, scope string) ([]LogEntry, error)
+	// ListLogs returns the distinct full log names under the scope, sorted.
+	ListLogs(ctx context.Context, scope string) ([]string, error)
 	// DeleteLog deletes every entry whose log name equals logName.
-	DeleteLog(ctx context.Context, projectID, logName string) error
+	DeleteLog(ctx context.Context, scope, logName string) error
 	Reset(ctx context.Context)
 }


### PR DESCRIPTION
## Description

Real-GCP logging scope/validation gaps. Cloud Logging log names support four parent scopes plus a wildcard binding, require non-empty segments, and URL-encode the `[LOG_ID]`. jaiscloud accepted only `projects/...`, accepted empty segments, and did not decode `%2F`.

Grounded in the Logging v2 Discovery Document (`projects.logs.delete` / `ListLogEntries` / `ListLogs` / `WriteLogEntries`) and `google/logging/v2/logging.proto`.

## What's in this PR

- New shared LogName parser (`internal/gcp/grpc/logging/logname.go`): accepts `projects/`, `organizations/`, `folders/`, `billingAccounts/` scopes; URL-decodes the log ID (`%2F` → `/`); rejects malformed/empty segments (`projects//logs/`, `projects/p/logs`, `bots/x/logs/y`, bad escapes) with `InvalidArgument`; canonical re-encoding so ListLogs returns encoded names like real GCP.
- Wired through `WriteLogEntries` (entry `log_name` + request-level `log_name`), `ListLogEntries` (`resource_names`), `ListLogs` (`parent`), `DeleteLog`, and `TailLogEntries`.
- Store uses the scope parent (`projects/p`, `organizations/123`, …) as the isolation key in the existing `project_id` TEXT column — no migration; memory/Postgres parity.
- `DeleteLog` remains an idempotent no-op for a well-formed absent log and the log reappears on new writes.

## Out of scope

- Log buckets (`_Default`) / eventual-consistency modeling.
- `organizations/`+`folders/`/`billingAccounts/` resource hierarchy beyond using the scope string as the isolation key.
- GCS REST verbs + CORS (separate PR).

## How to test

```bash
go build ./... && go vet ./internal/gcp/... ./cmd/jaiscloud-gcp/ && gofmt -l internal/gcp/
go test ./internal/gcp/grpc/logging/ ./internal/gcp/store/logging/ -count=1
```

## Test report

- `go test ./internal/gcp/...` green; `vet`/`gofmt` clean.
- New parser tests (all four scopes, `%2F`, malformed/empty rejection) and service tests (org vs project isolation, delete, idempotent missing delete, request-level `log_name`).
- jaiscloud `tests/integration/gcp/sdk-logging`: **pass**. floci Go `TestLogging`: **pass**. localgcp harness logging: **4/4**.

## Conformance audit

- `LogName` = `projects/{p}/logs/{l}` (also `organizations/`, `folders/`, `billingAccounts/`); wildcard binding `*/*/logs/*`.
- `[LOG_ID]` is URL-encoded; route patterns use `[^/]+` (non-empty segments) — malformed → `INVALID_ARGUMENT`.
- `DeleteLog` deletes all entries of the log, is a no-op for an absent log, and the log reappears on new writes.
