### PR TITLE
fix(gcp/storage): objects.restore/move, lockRetentionPolicy, bucket CORS

### DIFF
--- a/cmd/jaiscloud-gcp/main.go
+++ b/cmd/jaiscloud-gcp/main.go
@@ -436,6 +436,7 @@ func startCmd() *cobra.Command {
 
 			var gatewayOpts []func(*gateway.Server)
 			gatewayOpts = append(gatewayOpts, gateway.WithBarrier(barrier))
+			gatewayOpts = append(gatewayOpts, gateway.WithGCSCORSLookup(storageP.GetBucketCORSRules))
 			if cfg.GCPMetadataEnabled {
 				metaCfg := gcpadapter.MetadataConfig{
 					ProjectID:      cfg.ProjectID,

--- a/internal/gateway/cors.go
+++ b/internal/gateway/cors.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -113,4 +114,91 @@ func intFromAny(v any) (int, bool) {
 		return int(n), true
 	}
 	return 0, false
+}
+
+// ─── GCS bucket CORS ──────────────────────────────────────────────────────────
+
+// gcsCORSExtractBucket pulls the GCS bucket name from a request path. The JSON
+// API paths are /storage/v1/b/{bucket}/..., /upload/storage/v1/b/{bucket}/...,
+// and /download/storage/v1/b/{bucket}/...; raw media downloads use
+// /{bucket}/{object...}. The bucket name may be percent-encoded.
+func gcsCORSExtractBucket(r *http.Request) string {
+	p := r.URL.EscapedPath()
+	for _, prefix := range []string{"/storage/v1/b/", "/download/storage/v1/b/", "/upload/storage/v1/b/"} {
+		if strings.HasPrefix(p, prefix) {
+			return unescapeFirstSegment(strings.TrimPrefix(p, prefix))
+		}
+	}
+	return unescapeFirstSegment(strings.TrimPrefix(p, "/"))
+}
+
+// unescapeFirstSegment returns the first path segment of p, percent-decoded.
+func unescapeFirstSegment(p string) string {
+	if i := strings.IndexByte(p, '/'); i >= 0 {
+		p = p[:i]
+	}
+	if u, err := url.PathUnescape(p); err == nil {
+		return u
+	}
+	return p
+}
+
+// gcsCORSMatchRule returns the first GCS CORS rule that allows the given origin
+// and method. GCS rule keys are lowercase (origin/method/responseHeader/
+// maxAgeSeconds); an empty method skips method matching (regular responses). A
+// "*" in origins or methods matches anything.
+func gcsCORSMatchRule(rules []map[string]any, origin, method string) (map[string]any, bool) {
+	for _, rule := range rules {
+		if !corsMatchOrigin(origin, anySlice(rule["origin"])) {
+			continue
+		}
+		if method != "" && !gcsCORSMatchMethod(method, anySlice(rule["method"])) {
+			continue
+		}
+		return rule, true
+	}
+	return nil, false
+}
+
+func gcsCORSMatchMethod(method string, allowed []string) bool {
+	for _, a := range allowed {
+		if a == "*" || strings.EqualFold(a, method) {
+			return true
+		}
+	}
+	return false
+}
+
+// gcsCORSPreflightHeaders writes the Access-Control-* headers for an OPTIONS
+// preflight that matched a GCS CORS rule. Access-Control-Allow-Headers reflects
+// the client's requested headers (GCS has no allow-list for request headers);
+// Access-Control-Max-Age comes from the rule's maxAgeSeconds.
+func gcsCORSPreflightHeaders(w http.ResponseWriter, rule map[string]any, origin, reqHeaders string) {
+	h := w.Header()
+	h.Set("Access-Control-Allow-Origin", origin)
+	h.Set("Vary", "Origin")
+	if methods := strings.Join(anySlice(rule["method"]), ", "); methods != "" {
+		h.Set("Access-Control-Allow-Methods", methods)
+	}
+	if reqHeaders != "" {
+		h.Set("Access-Control-Allow-Headers", reqHeaders)
+	}
+	if age, ok := intFromAny(rule["maxAgeSeconds"]); ok && age > 0 {
+		h.Set("Access-Control-Max-Age", strconv.Itoa(age))
+	}
+}
+
+// gcsCORSAddResponseHeaders adds the CORS headers for a regular (non-preflight)
+// GCS response when Origin is present and a matching rule exists. The rule's
+// responseHeader list becomes Access-Control-Expose-Headers.
+func gcsCORSAddResponseHeaders(h http.Header, rules []map[string]any, origin string) {
+	rule, ok := gcsCORSMatchRule(rules, origin, "")
+	if !ok {
+		return
+	}
+	h.Set("Access-Control-Allow-Origin", origin)
+	h.Set("Vary", "Origin")
+	if expose := strings.Join(anySlice(rule["responseHeader"]), ", "); expose != "" {
+		h.Set("Access-Control-Expose-Headers", expose)
+	}
 }

--- a/internal/gateway/cors_test.go
+++ b/internal/gateway/cors_test.go
@@ -118,3 +118,84 @@ func TestCORS_PreflightHeaders_MaxAge(t *testing.T) {
 		t.Fatalf("want ACAO header set")
 	}
 }
+
+// ─── GCS bucket CORS ──────────────────────────────────────────────────────────
+
+func gcsRule() []map[string]any {
+	return []map[string]any{
+		{
+			"origin":         []any{"https://example.com"},
+			"method":         []any{"GET", "POST"},
+			"responseHeader": []any{"Content-Type", "x-goog-meta-foo"},
+			"maxAgeSeconds":  float64(3600),
+		},
+	}
+}
+
+func TestGCSCORSExtractBucket(t *testing.T) {
+	cases := map[string]string{
+		"/storage/v1/b/mybucket/o/obj.txt":          "mybucket",
+		"/storage/v1/b/mybucket":                    "mybucket",
+		"/upload/storage/v1/b/mybucket/o":           "mybucket",
+		"/download/storage/v1/b/mybucket/o/obj.txt": "mybucket",
+		"/mybucket/obj.txt":                         "mybucket",
+	}
+	for path, want := range cases {
+		req, _ := http.NewRequest(http.MethodOptions, path, nil)
+		if got := gcsCORSExtractBucket(req); got != want {
+			t.Errorf("path %q: want %q, got %q", path, want, got)
+		}
+	}
+}
+
+func TestGCSCORSMatchRule(t *testing.T) {
+	if _, ok := gcsCORSMatchRule(gcsRule(), "https://example.com", "GET"); !ok {
+		t.Fatal("want match for allowed origin+method")
+	}
+	if _, ok := gcsCORSMatchRule(gcsRule(), "https://evil.com", "GET"); ok {
+		t.Fatal("want no match for unlisted origin")
+	}
+	if _, ok := gcsCORSMatchRule(gcsRule(), "https://example.com", "DELETE"); ok {
+		t.Fatal("want no match for disallowed method")
+	}
+	wild := []map[string]any{{"origin": []any{"*"}, "method": []any{"*"}}}
+	if _, ok := gcsCORSMatchRule(wild, "https://any.com", "PUT"); !ok {
+		t.Fatal("wildcard origin+method must match")
+	}
+}
+
+func TestGCSCORSPreflightHeaders(t *testing.T) {
+	w := httptest.NewRecorder()
+	gcsCORSPreflightHeaders(w, gcsRule()[0], "https://example.com", "X-Requested-With")
+	h := w.Header()
+	if h.Get("Access-Control-Allow-Origin") != "https://example.com" {
+		t.Errorf("want ACAO, got %q", h.Get("Access-Control-Allow-Origin"))
+	}
+	if h.Get("Access-Control-Allow-Methods") != "GET, POST" {
+		t.Errorf("want methods GET, POST, got %q", h.Get("Access-Control-Allow-Methods"))
+	}
+	if h.Get("Access-Control-Allow-Headers") != "X-Requested-With" {
+		t.Errorf("want requested headers reflected, got %q", h.Get("Access-Control-Allow-Headers"))
+	}
+	if h.Get("Access-Control-Max-Age") != "3600" {
+		t.Errorf("want Max-Age 3600, got %q", h.Get("Access-Control-Max-Age"))
+	}
+}
+
+func TestGCSCORSResponseHeaders(t *testing.T) {
+	h := http.Header{}
+	gcsCORSAddResponseHeaders(h, gcsRule(), "https://example.com")
+	if h.Get("Access-Control-Allow-Origin") != "https://example.com" {
+		t.Errorf("want ACAO, got %q", h.Get("Access-Control-Allow-Origin"))
+	}
+	if h.Get("Access-Control-Expose-Headers") != "Content-Type, x-goog-meta-foo" {
+		t.Errorf("want expose headers, got %q", h.Get("Access-Control-Expose-Headers"))
+	}
+
+	// No match → no CORS headers added.
+	h2 := http.Header{}
+	gcsCORSAddResponseHeaders(h2, gcsRule(), "https://evil.com")
+	if h2.Get("Access-Control-Allow-Origin") != "" {
+		t.Error("want no ACAO for unlisted origin")
+	}
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -46,6 +46,10 @@ type Server struct {
 	// corsLookup returns the stored CORS rules for a given S3 bucket name.
 	// If nil, CORS preflight handling is disabled.
 	corsLookup func(bucket string) []map[string]any
+	// gcsCorsLookup returns the stored CORS rules for a given GCS bucket name.
+	// If nil, GCS CORS preflight handling is disabled. Only the GCP binary
+	// wires this, so S3/AWS behavior is unaffected.
+	gcsCorsLookup func(bucket string) []map[string]any
 	// barrier gates cloud requests during import/reset (503 while write-lock held).
 	barrier middleware.BarrierMiddleware
 }
@@ -73,6 +77,17 @@ func WithExtraRoutes(attach func(chi.Router)) func(*Server) {
 func WithCORSLookup(fn func(bucket string) []map[string]any) func(*Server) {
 	return func(s *Server) {
 		s.corsLookup = fn
+	}
+}
+
+// WithGCSCORSLookup wires in a function that returns stored GCS bucket CORS
+// rules (GCS's Bucket.cors shape). When set, the server intercepts OPTIONS
+// preflight requests on GCS paths and adds Access-Control-* headers to regular
+// GCS responses that carry an Origin header. It is independent of
+// WithCORSLookup, so wiring it never alters S3/AWS CORS behavior.
+func WithGCSCORSLookup(fn func(bucket string) []map[string]any) func(*Server) {
+	return func(s *Server) {
+		s.gcsCorsLookup = fn
 	}
 }
 
@@ -229,6 +244,22 @@ func (s *Server) handleCloudRequest(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	// GCS bucket CORS preflight (independent of the S3 path above).
+	if s.gcsCorsLookup != nil {
+		origin := r.Header.Get("Origin")
+		if origin != "" && r.Method == http.MethodOptions {
+			reqMethod := r.Header.Get("Access-Control-Request-Method")
+			bucket := gcsCORSExtractBucket(r)
+			rule, ok := gcsCORSMatchRule(s.gcsCorsLookup(bucket), origin, reqMethod)
+			if !ok {
+				http.Error(w, "CORS request not allowed", http.StatusForbidden)
+				return
+			}
+			gcsCORSPreflightHeaders(w, rule, origin, r.Header.Get("Access-Control-Request-Headers"))
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+	}
 
 	streaming := isS3StreamingUpload(r) || isGCSStreamingUpload(r)
 
@@ -346,6 +377,11 @@ func (s *Server) handleCloudRequest(w http.ResponseWriter, r *http.Request) {
 			bucket := corsExtractBucket(r)
 			rules := s.corsLookup(bucket)
 			CORSAddResponseHeaders(headers, rules, origin)
+		}
+	}
+	if s.gcsCorsLookup != nil {
+		if origin := r.Header.Get("Origin"); origin != "" {
+			gcsCORSAddResponseHeaders(headers, s.gcsCorsLookup(gcsCORSExtractBucket(r)), origin)
 		}
 	}
 	if stream, ok := resp.Data["_stream"].(io.ReadCloser); ok {

--- a/internal/gcp/adapter/gcs.go
+++ b/internal/gcp/adapter/gcs.go
@@ -112,6 +112,11 @@ func (c *GCSCodec) decodeStorage(r *http.Request, body []byte, rest string) (*mo
 		default:
 			nr.Action = "BucketsGet"
 		}
+	case len(seg) == 3 && seg[0] == "b" && seg[2] == "lockRetentionPolicy":
+		// /b/{bucket}/lockRetentionPolicy — buckets.lockRetentionPolicy. The
+		// ifMetagenerationMatch query param is captured by queryToParams.
+		nr.Params["bucket"] = seg[1]
+		nr.Action = "BucketsLockRetentionPolicy"
 	case len(seg) >= 3 && seg[0] == "b" && seg[2] == "iam":
 		// /b/{bucket}/iam
 		nr.Params["bucket"] = seg[1]
@@ -202,6 +207,28 @@ func (c *GCSCodec) decodeStorage(r *http.Request, body []byte, rest string) (*mo
 			}
 			nr.Params["body"] = m
 		}
+	case len(seg) >= 3 && seg[0] == "b" && seg[2] == "o" && segmentIndex(seg, "moveTo") >= 0:
+		// /b/{srcBucket}/o/{srcObject...}/moveTo/o/{dstObject...} (same bucket)
+		// or /b/{srcBucket}/o/{srcObject...}/moveTo/b/{dstBucket}/o/{dstObject...}
+		// (cross-bucket; the discovery doc models the same-bucket form, but real
+		// GCS clients use the /moveTo/b/.../o/... form too, so both are accepted).
+		mi := segmentIndex(seg, "moveTo")
+		nr.Params["sourceBucket"] = seg[1]
+		nr.Params["sourceObject"] = strings.Join(seg[3:mi], "/")
+		if mi+3 < len(seg) && seg[mi+1] == "b" && seg[mi+3] == "o" {
+			nr.Params["destinationBucket"] = seg[mi+2]
+			nr.Params["destinationObject"] = strings.Join(seg[mi+4:], "/")
+		} else {
+			nr.Params["destinationBucket"] = seg[1]
+			nr.Params["destinationObject"] = strings.Join(seg[mi+2:], "/")
+		}
+		nr.Action = "ObjectsMove"
+	case len(seg) >= 5 && seg[0] == "b" && seg[2] == "o" && seg[len(seg)-1] == "restore":
+		// /b/{bucket}/o/{object...}/restore — objects.restore (soft-delete restore).
+		// The generation to restore is carried by the ?generation= query param.
+		nr.Params["bucket"] = seg[1]
+		nr.Params["object"] = strings.Join(seg[3:len(seg)-1], "/")
+		nr.Action = "ObjectsRestore"
 	case len(seg) >= 4 && seg[0] == "b" && seg[2] == "o" && seg[len(seg)-1] == "compose":
 		// /b/{bucket}/o/{destination...}/compose
 		nr.Params["bucket"] = seg[1]

--- a/internal/gcp/adapter/gcs_test.go
+++ b/internal/gcp/adapter/gcs_test.go
@@ -311,3 +311,90 @@ func TestGCSCodecCopyToRouting(t *testing.T) {
 		t.Error("expected copy request body to be parsed")
 	}
 }
+
+func TestGCSCodecRestoreRouting(t *testing.T) {
+	c := &GCSCodec{}
+	r := httptest.NewRequest("POST", "/storage/v1/b/bkt/o/dir/obj.txt/restore?generation=1234", nil)
+	nr, err := c.Decode(r, nil)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if nr.Action != "ObjectsRestore" {
+		t.Fatalf("expected ObjectsRestore, got %q", nr.Action)
+	}
+	if b, _ := nr.Params["bucket"].(string); b != "bkt" {
+		t.Errorf("expected bucket bkt, got %q", b)
+	}
+	if o, _ := nr.Params["object"].(string); o != "dir/obj.txt" {
+		t.Errorf("expected object dir/obj.txt, got %q", o)
+	}
+	if g, _ := nr.Params["generation"].(string); g != "1234" {
+		t.Errorf("expected generation 1234, got %q", g)
+	}
+}
+
+func TestGCSCodecMoveRoutingSameBucket(t *testing.T) {
+	c := &GCSCodec{}
+	r := httptest.NewRequest("POST", "/storage/v1/b/bkt/o/dir/src.txt/moveTo/o/dir/dst.txt", nil)
+	nr, err := c.Decode(r, nil)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if nr.Action != "ObjectsMove" {
+		t.Fatalf("expected ObjectsMove, got %q", nr.Action)
+	}
+	if b, _ := nr.Params["sourceBucket"].(string); b != "bkt" {
+		t.Errorf("expected sourceBucket bkt, got %q", b)
+	}
+	if o, _ := nr.Params["sourceObject"].(string); o != "dir/src.txt" {
+		t.Errorf("expected sourceObject dir/src.txt, got %q", o)
+	}
+	if b, _ := nr.Params["destinationBucket"].(string); b != "bkt" {
+		t.Errorf("expected destinationBucket bkt, got %q", b)
+	}
+	if o, _ := nr.Params["destinationObject"].(string); o != "dir/dst.txt" {
+		t.Errorf("expected destinationObject dir/dst.txt, got %q", o)
+	}
+}
+
+func TestGCSCodecMoveRoutingCrossBucket(t *testing.T) {
+	c := &GCSCodec{}
+	r := httptest.NewRequest("POST", "/storage/v1/b/srcbkt/o/src.txt/moveTo/b/dstbkt/o/dst.txt", nil)
+	nr, err := c.Decode(r, nil)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if nr.Action != "ObjectsMove" {
+		t.Fatalf("expected ObjectsMove, got %q", nr.Action)
+	}
+	if b, _ := nr.Params["sourceBucket"].(string); b != "srcbkt" {
+		t.Errorf("expected sourceBucket srcbkt, got %q", b)
+	}
+	if o, _ := nr.Params["sourceObject"].(string); o != "src.txt" {
+		t.Errorf("expected sourceObject src.txt, got %q", o)
+	}
+	if b, _ := nr.Params["destinationBucket"].(string); b != "dstbkt" {
+		t.Errorf("expected destinationBucket dstbkt, got %q", b)
+	}
+	if o, _ := nr.Params["destinationObject"].(string); o != "dst.txt" {
+		t.Errorf("expected destinationObject dst.txt, got %q", o)
+	}
+}
+
+func TestGCSCodecLockRetentionPolicyRouting(t *testing.T) {
+	c := &GCSCodec{}
+	r := httptest.NewRequest("POST", "/storage/v1/b/bkt/lockRetentionPolicy?ifMetagenerationMatch=1", nil)
+	nr, err := c.Decode(r, nil)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if nr.Action != "BucketsLockRetentionPolicy" {
+		t.Fatalf("expected BucketsLockRetentionPolicy, got %q", nr.Action)
+	}
+	if b, _ := nr.Params["bucket"].(string); b != "bkt" {
+		t.Errorf("expected bucket bkt, got %q", b)
+	}
+	if m, _ := nr.Params["ifMetagenerationMatch"].(string); m != "1" {
+		t.Errorf("expected ifMetagenerationMatch 1, got %q", m)
+	}
+}

--- a/internal/gcp/provider/storage/rest_verbs_test.go
+++ b/internal/gcp/provider/storage/rest_verbs_test.go
@@ -1,0 +1,399 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"jaiscloud/internal/gcp/wire"
+	"jaiscloud/internal/model"
+)
+
+func insertVersionedBucket(t *testing.T, p *Provider, bucket string) {
+	t.Helper()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{
+		"name":       bucket,
+		"versioning": map[string]any{"enabled": true},
+	}
+	if _, err := p.BucketsInsert(context.Background(), nr); err != nil {
+		t.Fatalf("insert versioned bucket: %v", err)
+	}
+}
+
+func getErrStatus(err error) int {
+	if pe, ok := err.(*model.ProviderError); ok {
+		return pe.HTTPStatus
+	}
+	return 0
+}
+
+// ─── objects.move ─────────────────────────────────────────────────────────────
+
+func TestObjectsMoveCopiesAndRemovesSource(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	insertTestObject(t, p, "bkt", "src.txt", "text/plain", map[string]any{"keep": "yes"})
+
+	srcResp, err := p.ObjectsGet(ctx, bucketParamsWithObj("bkt", "src.txt"))
+	if err != nil {
+		t.Fatalf("get source: %v", err)
+	}
+	srcGen, _ := srcResp.Data["generation"].(string)
+
+	nr := bucketParams()
+	nr.Params["sourceBucket"] = "bkt"
+	nr.Params["sourceObject"] = "src.txt"
+	nr.Params["destinationBucket"] = "bkt"
+	nr.Params["destinationObject"] = "dst.txt"
+	resp, err := p.ObjectsMove(ctx, nr)
+	if err != nil {
+		t.Fatalf("move: %v", err)
+	}
+	if resp.Data["name"] != "dst.txt" {
+		t.Errorf("expected destination name dst.txt, got %v", resp.Data["name"])
+	}
+	dstGen, _ := resp.Data["generation"].(string)
+	if dstGen == "" || dstGen == srcGen {
+		t.Errorf("expected a new generation, got %q (source %q)", dstGen, srcGen)
+	}
+	md, _ := resp.Data["metadata"].(map[string]any)
+	if md["keep"] != "yes" {
+		t.Errorf("expected metadata copied, got %v", md)
+	}
+
+	media, err := p.ObjectsGetMedia(ctx, bucketParamsWithObj("bkt", "dst.txt"))
+	if err != nil {
+		t.Fatalf("get destination media: %v", err)
+	}
+	if got := string(streamBytes(t, media)); got != "hello" {
+		t.Fatalf("expected moved content 'hello', got %q", got)
+	}
+
+	if _, err := p.ObjectsGet(ctx, bucketParamsWithObj("bkt", "src.txt")); err == nil {
+		t.Fatal("expected source to be removed after move")
+	} else if getErrStatus(err) != 404 {
+		t.Fatalf("expected 404 for removed source, got %v", err)
+	}
+}
+
+func TestObjectsMoveCrossBucket(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	insertTestObject(t, p, "srcbkt", "src.txt", "text/plain", nil)
+
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "dstbkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert destination bucket: %v", err)
+	}
+
+	nr = bucketParams()
+	nr.Params["sourceBucket"] = "srcbkt"
+	nr.Params["sourceObject"] = "src.txt"
+	nr.Params["destinationBucket"] = "dstbkt"
+	nr.Params["destinationObject"] = "dst.txt"
+	resp, err := p.ObjectsMove(ctx, nr)
+	if err != nil {
+		t.Fatalf("cross-bucket move: %v", err)
+	}
+	if resp.Data["bucket"] != "dstbkt" || resp.Data["name"] != "dst.txt" {
+		t.Errorf("expected moved object in dstbkt/dst.txt, got %v/%v", resp.Data["bucket"], resp.Data["name"])
+	}
+	if _, err := p.ObjectsGet(ctx, bucketParamsWithObj("srcbkt", "src.txt")); err == nil {
+		t.Fatal("expected source removed after cross-bucket move")
+	}
+	if _, err := p.ObjectsGet(ctx, bucketParamsWithObj("dstbkt", "dst.txt")); err != nil {
+		t.Fatalf("expected destination present: %v", err)
+	}
+}
+
+func TestObjectsMoveMissingSource(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+
+	nr = bucketParams()
+	nr.Params["sourceBucket"] = "bkt"
+	nr.Params["sourceObject"] = "missing.txt"
+	nr.Params["destinationBucket"] = "bkt"
+	nr.Params["destinationObject"] = "dst.txt"
+	if _, err := p.ObjectsMove(ctx, nr); err == nil {
+		t.Fatal("expected 404 moving a missing source")
+	} else if getErrStatus(err) != 404 {
+		t.Fatalf("expected 404 ProviderError, got %v", err)
+	}
+}
+
+// ─── objects.restore ──────────────────────────────────────────────────────────
+
+func TestObjectsRestoreSoftDeletedGeneration(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	insertVersionedBucket(t, p, "bkt")
+
+	nr := bucketParams()
+	nr.Params["bucket"] = "bkt"
+	nr.Params["object"] = "o.txt"
+	nr.Params[wire.MediaKey] = []byte("hello")
+	ins, err := p.ObjectsInsert(ctx, nr)
+	if err != nil {
+		t.Fatalf("insert object: %v", err)
+	}
+	gen, _ := ins.Data["generation"].(string)
+	if gen == "" {
+		t.Fatal("expected a generation on insert")
+	}
+
+	// Deleting in a versioned bucket tombstones the live generation.
+	if _, err := p.ObjectsDelete(ctx, bucketParamsWithObj("bkt", "o.txt")); err != nil {
+		t.Fatalf("delete object: %v", err)
+	}
+	if _, err := p.ObjectsGet(ctx, bucketParamsWithObj("bkt", "o.txt")); err == nil {
+		t.Fatal("expected object to be soft-deleted")
+	}
+
+	nr = bucketParamsWithObj("bkt", "o.txt")
+	nr.Params["generation"] = gen
+	resp, err := p.ObjectsRestore(ctx, nr)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	if resp.Data["generation"] != gen {
+		t.Errorf("expected restored generation %q, got %v", gen, resp.Data["generation"])
+	}
+	if _, present := resp.Data["timeDeleted"]; present {
+		t.Errorf("expected timeDeleted cleared on restore, got %v", resp.Data["timeDeleted"])
+	}
+
+	if _, err := p.ObjectsGet(ctx, bucketParamsWithObj("bkt", "o.txt")); err != nil {
+		t.Fatalf("expected restored object to be live: %v", err)
+	}
+}
+
+func TestObjectsRestoreMissingGeneration(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	insertVersionedBucket(t, p, "bkt")
+
+	nr := bucketParams()
+	nr.Params["bucket"] = "bkt"
+	nr.Params["object"] = "o.txt"
+	nr.Params[wire.MediaKey] = []byte("hello")
+	if _, err := p.ObjectsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert object: %v", err)
+	}
+
+	nr = bucketParamsWithObj("bkt", "o.txt")
+	nr.Params["generation"] = "999999"
+	if _, err := p.ObjectsRestore(ctx, nr); err == nil {
+		t.Fatal("expected 404 restoring a missing generation")
+	} else if getErrStatus(err) != 404 {
+		t.Fatalf("expected 404 ProviderError, got %v", err)
+	}
+}
+
+func TestObjectsRestoreRequiresGeneration(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	insertTestObject(t, p, "bkt", "o.txt", "text/plain", nil)
+
+	if _, err := p.ObjectsRestore(ctx, bucketParamsWithObj("bkt", "o.txt")); err == nil {
+		t.Fatal("expected InvalidRequest when generation is omitted")
+	} else if getErrStatus(err) != 400 {
+		t.Fatalf("expected 400 ProviderError, got %v", err)
+	}
+}
+
+// ─── buckets.lockRetentionPolicy ──────────────────────────────────────────────
+
+func TestBucketsLockRetentionPolicy(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{
+		"name":            "bkt",
+		"retentionPolicy": map[string]any{"retentionPeriod": "3600"},
+	}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+
+	nr = bucketParams()
+	nr.Params["bucket"] = "bkt"
+	resp, err := p.BucketsLockRetentionPolicy(ctx, nr)
+	if err != nil {
+		t.Fatalf("lock retention policy: %v", err)
+	}
+	rp, _ := resp.Data["retentionPolicy"].(map[string]any)
+	if rp == nil {
+		t.Fatal("expected retentionPolicy on locked bucket")
+	}
+	if locked, _ := rp["isLocked"].(bool); !locked {
+		t.Errorf("expected isLocked=true, got %v", rp["isLocked"])
+	}
+	if et, _ := rp["effectiveTime"].(string); et == "" {
+		t.Error("expected effectiveTime to be set on lock")
+	}
+
+	// Locking is idempotent.
+	if _, err := p.BucketsLockRetentionPolicy(ctx, nr); err != nil {
+		t.Fatalf("second lock should be idempotent: %v", err)
+	}
+
+	// Removing a locked policy must fail.
+	removeNR := bucketParams()
+	removeNR.Params["bucket"] = "bkt"
+	removeNR.Params["body"] = map[string]any{"retentionPolicy": nil}
+	if _, err := p.BucketsUpdate(ctx, removeNR); err == nil {
+		t.Fatal("expected locked retention policy removal to fail")
+	}
+
+	// Shortening a locked policy must fail.
+	shortenNR := bucketParams()
+	shortenNR.Params["bucket"] = "bkt"
+	shortenNR.Params["body"] = map[string]any{"retentionPolicy": map[string]any{"retentionPeriod": "60"}}
+	if _, err := p.BucketsUpdate(ctx, shortenNR); err == nil {
+		t.Fatal("expected locked retention policy shortening to fail")
+	}
+
+	// Extending a locked policy is allowed and preserves the lock.
+	extendNR := bucketParams()
+	extendNR.Params["bucket"] = "bkt"
+	extendNR.Params["body"] = map[string]any{"retentionPolicy": map[string]any{"retentionPeriod": "7200"}}
+	ext, err := p.BucketsUpdate(ctx, extendNR)
+	if err != nil {
+		t.Fatalf("extending a locked policy should succeed: %v", err)
+	}
+	extRP, _ := ext.Data["retentionPolicy"].(map[string]any)
+	if locked, _ := extRP["isLocked"].(bool); !locked {
+		t.Errorf("expected isLocked preserved after extension, got %v", extRP["isLocked"])
+	}
+	if extRP["retentionPeriod"] != "7200" {
+		t.Errorf("expected retentionPeriod 7200 after extension, got %v", extRP["retentionPeriod"])
+	}
+}
+
+func TestBucketsLockRetentionPolicyNoPolicy(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+
+	nr = bucketParams()
+	nr.Params["bucket"] = "bkt"
+	if _, err := p.BucketsLockRetentionPolicy(ctx, nr); err == nil {
+		t.Fatal("expected 404 for a bucket with no retention policy")
+	} else if getErrStatus(err) != 404 {
+		t.Fatalf("expected 404 ProviderError, got %v", err)
+	}
+}
+
+// ─── Bucket.cors ──────────────────────────────────────────────────────────────
+
+func testCORSConfig() []any {
+	return []any{
+		map[string]any{
+			"origin":         []any{"https://example.com"},
+			"method":         []any{"GET", "POST"},
+			"responseHeader": []any{"Content-Type"},
+			"maxAgeSeconds":  float64(3600),
+		},
+	}
+}
+
+func TestBucketCORSRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt", "cors": testCORSConfig()}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+
+	nr = bucketParams()
+	nr.Params["bucket"] = "bkt"
+	resp, err := p.BucketsGet(ctx, nr)
+	if err != nil {
+		t.Fatalf("get bucket: %v", err)
+	}
+	got, _ := resp.Data["cors"].([]any)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 cors rule on get, got %v", resp.Data["cors"])
+	}
+	rule, _ := got[0].(map[string]any)
+	if rule["maxAgeSeconds"] != float64(3600) {
+		t.Errorf("expected maxAgeSeconds 3600, got %v", rule["maxAgeSeconds"])
+	}
+
+	// The gateway lookup sees the stored rules.
+	rules := p.GetBucketCORSRules("bkt")
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 stored CORS rule, got %d", len(rules))
+	}
+
+	// buckets.list returns it too.
+	list, err := p.BucketsList(ctx, bucketParams())
+	if err != nil {
+		t.Fatalf("list buckets: %v", err)
+	}
+	items, _ := list.Data["items"].([]any)
+	found := false
+	for _, it := range items {
+		m, _ := it.(map[string]any)
+		if m["name"] == "bkt" {
+			found = true
+			if _, ok := m["cors"].([]any); !ok {
+				t.Errorf("expected cors in bucket list, got %v", m["cors"])
+			}
+		}
+	}
+	if !found {
+		t.Fatal("bucket not found in list")
+	}
+
+	// Updating replaces the CORS config.
+	newCORS := []any{
+		map[string]any{
+			"origin":        []any{"*"},
+			"method":        []any{"GET"},
+			"maxAgeSeconds": float64(600),
+		},
+	}
+	nr = bucketParams()
+	nr.Params["bucket"] = "bkt"
+	nr.Params["body"] = map[string]any{"cors": newCORS}
+	upd, err := p.BucketsUpdate(ctx, nr)
+	if err != nil {
+		t.Fatalf("update bucket cors: %v", err)
+	}
+	gotUpd, _ := upd.Data["cors"].([]any)
+	if len(gotUpd) != 1 {
+		t.Fatalf("expected 1 cors rule after update, got %v", upd.Data["cors"])
+	}
+	if u, _ := gotUpd[0].(map[string]any); u["maxAgeSeconds"] != float64(600) {
+		t.Errorf("expected maxAgeSeconds 600 after update, got %v", u["maxAgeSeconds"])
+	}
+
+	// Clearing CORS with an explicit null removes it.
+	nr = bucketParams()
+	nr.Params["bucket"] = "bkt"
+	nr.Params["body"] = map[string]any{"cors": nil}
+	cleared, err := p.BucketsUpdate(ctx, nr)
+	if err != nil {
+		t.Fatalf("clear bucket cors: %v", err)
+	}
+	if _, present := cleared.Data["cors"]; present {
+		t.Errorf("expected cors cleared, got %v", cleared.Data["cors"])
+	}
+	if len(p.GetBucketCORSRules("bkt")) != 0 {
+		t.Error("expected no stored CORS rules after clearing")
+	}
+}

--- a/internal/gcp/provider/storage/storage.go
+++ b/internal/gcp/provider/storage/storage.go
@@ -207,6 +207,7 @@ func (p *Provider) Routes() map[string]provider.HandlerFunc {
 		"Storage.BucketsInsert":               p.BucketsInsert,
 		"Storage.BucketsGet":                  p.BucketsGet,
 		"Storage.BucketsUpdate":               p.BucketsUpdate,
+		"Storage.BucketsLockRetentionPolicy":  p.BucketsLockRetentionPolicy,
 		"Storage.BucketsDelete":               p.BucketsDelete,
 		"Storage.BucketsGetIamPolicy":         p.BucketsGetIamPolicy,
 		"Storage.BucketsSetIamPolicy":         p.BucketsSetIamPolicy,
@@ -223,6 +224,8 @@ func (p *Provider) Routes() map[string]provider.HandlerFunc {
 		"Storage.ObjectsDelete":               p.ObjectsDelete,
 		"Storage.ObjectsRewrite":              p.ObjectsRewrite,
 		"Storage.ObjectsCopy":                 p.ObjectsCopy,
+		"Storage.ObjectsMove":                 p.ObjectsMove,
+		"Storage.ObjectsRestore":              p.ObjectsRestore,
 		"Storage.ObjectsCompose":              p.ObjectsCompose,
 		"Storage.ObjectACLList":               p.ObjectACLList,
 		"Storage.ObjectACLInsert":             p.ObjectACLInsert,
@@ -244,6 +247,11 @@ type bucketMeta struct {
 	RetentionPolicy map[string]any `json:"retentionPolicy,omitempty"`
 	Lifecycle       map[string]any `json:"lifecycle,omitempty"`
 	Encryption      map[string]any `json:"encryption,omitempty"`
+	// Cors is the bucket's cross-origin resource sharing config (GCS
+	// Bucket.cors): a list of {origin[], method[], responseHeader[],
+	// maxAgeSeconds} rules. Stored verbatim so it round-trips through the
+	// bucket-meta JSON on both the memory and Postgres stores.
+	Cors []any `json:"cors,omitempty"`
 }
 
 type objectMeta struct {
@@ -567,6 +575,7 @@ func (p *Provider) BucketsInsert(ctx context.Context, nr *model.NormalizedReques
 	b.RetentionPolicy = bodyMap(body, "retentionPolicy")
 	b.Lifecycle = bodyMap(body, "lifecycle")
 	b.Encryption = bodyMap(body, "encryption")
+	b.Cors = bodySlice(body, "cors")
 	b.TimeCreated = clock.Now().Format(time.RFC3339Nano)
 	b.Updated = b.TimeCreated
 	b.Metageneration = "1"
@@ -617,7 +626,24 @@ func (p *Provider) BucketsUpdate(ctx context.Context, nr *model.NormalizedReques
 			b.Versioning = bodyMap(body, "versioning")
 		}
 		if _, ok := body["retentionPolicy"]; ok {
-			b.RetentionPolicy = bodyMap(body, "retentionPolicy")
+			newRP := bodyMap(body, "retentionPolicy")
+			oldRP, _ := meta["retentionPolicy"].(map[string]any)
+			if locked, _ := oldRP["isLocked"].(bool); locked {
+				// Once a bucket's retention policy is locked it can be
+				// extended but never removed or shortened (GCS makes the lock
+				// irreversible). Preserve the lock and its effectiveTime.
+				if newRP == nil || retentionPeriodSeconds(newRP) < retentionPeriodSeconds(oldRP) {
+					return nil, model.NewProviderError("InvalidRequest",
+						"Bucket retention policy is locked and cannot be removed or shortened", 400)
+				}
+				newRP["isLocked"] = true
+				if _, ok := newRP["effectiveTime"]; !ok {
+					if et, ok := oldRP["effectiveTime"]; ok {
+						newRP["effectiveTime"] = et
+					}
+				}
+			}
+			b.RetentionPolicy = newRP
 		}
 		if _, ok := body["lifecycle"]; ok {
 			b.Lifecycle = bodyMap(body, "lifecycle")
@@ -625,9 +651,63 @@ func (p *Provider) BucketsUpdate(ctx context.Context, nr *model.NormalizedReques
 		if _, ok := body["encryption"]; ok {
 			b.Encryption = bodyMap(body, "encryption")
 		}
+		if _, ok := body["cors"]; ok {
+			b.Cors = bodySlice(body, "cors")
+		}
 		b.Metageneration = bumpMeta(gcs.BucketMetageneration(meta))
 		b.Updated = clock.Now().Format(time.RFC3339Nano)
 		return bucketToMap(b), nil
+	})
+	if err != nil {
+		if errors.Is(err, gcs.ErrNoSuchBucket) {
+			return nil, model.NewProviderError("NotFound", "bucket not found", 404)
+		}
+		if errors.Is(err, gcs.ErrPreconditionFailed) {
+			return nil, model.NewProviderError("PreconditionFailed", "At least one of the pre-conditions you specified did not hold", 412)
+		}
+		return nil, err
+	}
+	return provider.OK(toBucketMap(nr, mapToBucket(updated))), nil
+}
+
+// BucketsLockRetentionPolicy implements buckets.lockRetentionPolicy. Locking is
+// irreversible: the bucket's retentionPolicy.isLocked is set true (with an
+// effectiveTime) and the metageneration bumped. The optional
+// ifMetagenerationMatch is validated atomically with the mutation. A bucket
+// with no retention policy, or an unknown bucket, is NotFound; an already
+// locked policy is returned unchanged (locking is idempotent).
+func (p *Provider) BucketsLockRetentionPolicy(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	name, _ := nr.Params["bucket"].(string)
+	if name == "" {
+		return nil, model.NewProviderError("InvalidRequest", "missing bucket name", 400)
+	}
+	var pre *gcs.Precondition
+	if v, ok := parseInt64Param(nr, "ifMetagenerationMatch"); ok {
+		pre = &gcs.Precondition{MetagenerationMatch: &v}
+	}
+	updated, err := p.objects.UpdateBucketMetaAtomic(ctx, name, func(meta map[string]any) (map[string]any, error) {
+		if !gcs.BucketMetagenerationMatches(meta, pre) {
+			return nil, gcs.ErrPreconditionFailed
+		}
+		rp, _ := meta["retentionPolicy"].(map[string]any)
+		if len(rp) == 0 {
+			return nil, model.NewProviderError("NotFound", "bucket has no retention policy", 404)
+		}
+		if locked, _ := rp["isLocked"].(bool); locked {
+			return meta, nil
+		}
+		next := make(map[string]any, len(rp)+1)
+		for k, v := range rp {
+			next[k] = v
+		}
+		next["isLocked"] = true
+		if _, ok := next["effectiveTime"]; !ok {
+			next["effectiveTime"] = clock.Now().Format(time.RFC3339Nano)
+		}
+		meta["retentionPolicy"] = next
+		meta["metageneration"] = bumpMeta(gcs.BucketMetageneration(meta))
+		meta["updated"] = clock.Now().Format(time.RFC3339Nano)
+		return meta, nil
 	})
 	if err != nil {
 		if errors.Is(err, gcs.ErrNoSuchBucket) {
@@ -1210,6 +1290,30 @@ func (p *Provider) BucketVersioned(ctx context.Context, bucket string) bool {
 	return p.bucketVersioned(ctx, bucket)
 }
 
+// GetBucketCORSRules returns the stored CORS rules for a bucket, in the shape
+// the gateway CORS interceptor expects. It is wired into the gateway via
+// WithGCSCORSLookup and is deliberately context-free (the gateway calls it
+// outside a request context). Nil when the bucket or its cors config is absent.
+func (p *Provider) GetBucketCORSRules(bucket string) []map[string]any {
+	meta, err := p.objects.GetBucket(context.Background(), bucket)
+	if err != nil {
+		return nil
+	}
+	switch v := meta["cors"].(type) {
+	case []map[string]any:
+		return v
+	case []any:
+		out := make([]map[string]any, 0, len(v))
+		for _, r := range v {
+			if m, ok := r.(map[string]any); ok {
+				out = append(out, m)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
 // readSourceRaw reads and decrypts an object's plaintext bytes.
 func (p *Provider) readSourceRaw(ctx context.Context, nr *model.NormalizedRequest, bucket, object string, params map[string]any) (gcs.ObjectMeta, []byte, error) {
 	meta, err := p.getObjectForRead(ctx, bucket, object, params)
@@ -1364,6 +1468,148 @@ func (p *Provider) copyObject(ctx context.Context, nr *model.NormalizedRequest) 
 		return objectMeta{}, err
 	}
 	return final, nil
+}
+
+// sourcePrecondition parses the ifSourceGenerationMatch/NotMatch and
+// ifSourceMetagenerationMatch/NotMatch query params used by objects.move to
+// guard the source object. Nil when none is present.
+func sourcePrecondition(nr *model.NormalizedRequest) *gcs.Precondition {
+	var pre gcs.Precondition
+	set := false
+	if v, ok := parseInt64Param(nr, "ifSourceGenerationMatch"); ok {
+		pre.GenerationMatch = &v
+		set = true
+	}
+	if v, ok := parseInt64Param(nr, "ifSourceGenerationNotMatch"); ok {
+		pre.GenerationNotMatch = &v
+		set = true
+	}
+	if v, ok := parseInt64Param(nr, "ifSourceMetagenerationMatch"); ok {
+		pre.MetagenerationMatch = &v
+		set = true
+	}
+	if v, ok := parseInt64Param(nr, "ifSourceMetagenerationNotMatch"); ok {
+		pre.MetagenerationNotMatch = &v
+		set = true
+	}
+	if !set {
+		return nil
+	}
+	return &pre
+}
+
+// objectMetaPreconditionMatches reports whether p is satisfied by the given
+// (live) object metadata. A nil p always matches. Mirrors the store's
+// unexported objectPreconditionMatches for callers holding an already-read
+// ObjectMeta.
+func objectMetaPreconditionMatches(m gcs.ObjectMeta, p *gcs.Precondition) bool {
+	if p == nil {
+		return true
+	}
+	gen, _ := strconv.ParseInt(m.Generation, 10, 64)
+	metagen, _ := strconv.ParseInt(m.Metageneration, 10, 64)
+	if p.GenerationMatch != nil && gen != *p.GenerationMatch {
+		return false
+	}
+	if p.GenerationNotMatch != nil && gen == *p.GenerationNotMatch {
+		return false
+	}
+	if p.MetagenerationMatch != nil && metagen != *p.MetagenerationMatch {
+		return false
+	}
+	if p.MetagenerationNotMatch != nil && metagen == *p.MetagenerationNotMatch {
+		return false
+	}
+	return true
+}
+
+// ObjectsMove implements objects.move. It copies the source object's bytes and
+// metadata to the destination under a fresh generation, then deletes the source
+// — a copy-then-delete, matching the gRPC MoveObject semantics. The destination
+// write goes first so a failure never loses the source's bytes. Destination
+// preconditions (ifGenerationMatch/...) are enforced atomically by the write;
+// source preconditions (ifSourceGenerationMatch/...) are validated against the
+// source metadata before the copy.
+func (p *Provider) ObjectsMove(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	srcBucket, _ := nr.Params["sourceBucket"].(string)
+	srcObject, _ := nr.Params["sourceObject"].(string)
+	dstBucket, _ := nr.Params["destinationBucket"].(string)
+	dstObject, _ := nr.Params["destinationObject"].(string)
+	if dstBucket == "" {
+		dstBucket = srcBucket
+	}
+	if srcBucket == "" || srcObject == "" || dstBucket == "" || dstObject == "" {
+		return nil, model.NewProviderError("InvalidRequest", "move requires source and destination object names", 400)
+	}
+	if srcBucket == dstBucket && srcObject == dstObject {
+		return nil, model.NewProviderError("InvalidRequest", "source and destination object must differ", 400)
+	}
+	if err := p.scopeToBucket(ctx, nr, dstBucket); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return nil, model.NewProviderError("NotFound", "destination bucket not found", 404)
+		}
+		return nil, err
+	}
+
+	srcMeta, raw, err := p.readSourceRaw(ctx, nr, srcBucket, srcObject, map[string]any{})
+	if err != nil {
+		return nil, err
+	}
+	if !objectMetaPreconditionMatches(srcMeta, sourcePrecondition(nr)) {
+		return nil, model.NewProviderError("PreconditionFailed", "At least one of the pre-conditions you specified did not hold", 412)
+	}
+
+	now := clock.Now()
+	o := fromStoreObject(nr, srcMeta)
+	o.Name = dstObject
+	o.Bucket = dstBucket
+	o.Generation = p.nextGen()
+	o.Metageneration = "1"
+	o.TimeCreated = now.Format(time.RFC3339Nano)
+	o.Updated = o.TimeCreated
+	o.Retention = nil
+	o.RetentionExpirationTime = ""
+	o.ID = dstBucket + "/" + dstObject + "/" + o.Generation
+	o.Etag = "CAE="
+	base := baseURL(nr)
+	o.SelfLink = objectSelfLink(base, dstBucket, dstObject)
+	o.MediaLink = objectMediaLink(base, dstBucket, dstObject)
+
+	final, err := p.writeObjectRaw(ctx, nr, dstBucket, dstObject, o, raw, p.bucketVersioned(ctx, dstBucket), "", true)
+	if err != nil {
+		return nil, err
+	}
+	if err := p.DeleteObjectData(ctx, srcBucket, srcObject, objectPrecondition(nr)); err != nil {
+		return nil, err
+	}
+	return provider.OK(toMap(final)), nil
+}
+
+// ObjectsRestore implements objects.restore: a non-live (soft-deleted) object
+// generation is made live again, superseding the current live generation if
+// any. The store's RestoreObjectGeneration validates the ifGeneration*/
+// ifMetageneration* preconditions atomically with the mutation.
+func (p *Provider) ObjectsRestore(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	bucket, _ := nr.Params["bucket"].(string)
+	object, _ := nr.Params["object"].(string)
+	generation, _ := nr.Params["generation"].(string)
+	if bucket == "" || object == "" || generation == "" {
+		return nil, model.NewProviderError("InvalidRequest", "restore requires bucket, object, and generation", 400)
+	}
+	meta, err := p.objects.RestoreObjectGeneration(ctx, bucket, object, generation, objectPrecondition(nr))
+	if err != nil {
+		switch {
+		case errors.Is(err, gcs.ErrNoSuchBucket):
+			return nil, model.NewProviderError("NotFound", "bucket not found", 404)
+		case errors.Is(err, gcs.ErrNoSuchObject):
+			return nil, model.NewProviderError("NotFound", "object generation not found", 404)
+		case errors.Is(err, gcs.ErrPreconditionFailed):
+			return nil, model.NewProviderError("PreconditionFailed", "At least one of the pre-conditions you specified did not hold", 412)
+		default:
+			return nil, err
+		}
+	}
+	return provider.OK(toMap(fromStoreObject(nr, meta))), nil
 }
 
 // ObjectsCompose implements objects.compose (the GCS JSON API compose action
@@ -1826,6 +2072,9 @@ func toBucketMap(nr *model.NormalizedRequest, b bucketMeta) map[string]any {
 	if b.Encryption != nil {
 		out["encryption"] = b.Encryption
 	}
+	if b.Cors != nil {
+		out["cors"] = b.Cors
+	}
 	return out
 }
 
@@ -1836,6 +2085,35 @@ func bodyMap(body map[string]any, key string) map[string]any {
 	}
 	m, _ := body[key].(map[string]any)
 	return m
+}
+
+// bodySlice returns the named array-valued field from the request body, or nil.
+func bodySlice(body map[string]any, key string) []any {
+	if body == nil {
+		return nil
+	}
+	v, _ := body[key].([]any)
+	return v
+}
+
+// retentionPeriodSeconds extracts a retention policy's period in seconds.
+// GCS carries retentionPeriod as a decimal-second string; a Go-style duration
+// is also accepted for tolerance. Returns 0 when absent/unparseable.
+func retentionPeriodSeconds(rp map[string]any) int64 {
+	if rp == nil {
+		return 0
+	}
+	period, _ := rp["retentionPeriod"].(string)
+	if period == "" {
+		return 0
+	}
+	if n, err := strconv.ParseInt(period, 10, 64); err == nil {
+		return n
+	}
+	if d, err := time.ParseDuration(period); err == nil {
+		return int64(d.Seconds())
+	}
+	return 0
 }
 
 // parseRetentionPeriod parses a retentionPeriod string. GCS carries this as a


### PR DESCRIPTION
## Description

GCS JSON API REST gaps verified in the compatibility audit:
- `objects.restore` (soft-delete restore) was unrouted.
- `objects.move` was unrouted.
- `buckets.lockRetentionPolicy` was unrouted.
- Bucket `cors` was not stored/returned/enforced, so preflight and cross-origin object responses were missing.

Grounded in the GCS Discovery Document (`https://storage.googleapis.com/$discovery/rest?version=v1`) and the GCS CORS docs.

## What's in this PR

- `internal/gcp/adapter/gcs.go`: decode `restore`, `moveTo` (same-bucket `.../moveTo/o/{dest}` and cross-bucket `.../moveTo/b/{b}/o/{o}`), and `buckets.lockRetentionPolicy`.
- `internal/gcp/provider/storage/storage.go`:
  - `ObjectsRestore` — atomic restore of a soft-deleted generation (`?generation=`, `ifGeneration*`/`ifMetageneration*`); missing gen/bucket → 404.
  - `ObjectsMove` — copy-then-delete with a new destination generation; source preconditions (`ifSourceGeneration*`) and destination preconditions; missing source → 404.
  - `BucketsLockRetentionPolicy` — sets `retentionPolicy.isLocked=true` + `effectiveTime`, bumps metageneration, honors `ifMetagenerationMatch` (412); lock is irreversible (removing/shortening a locked policy → 400, extending allowed).
  - `bucketMeta` gains `cors` (persisted/returned on insert/get/list/patch/update).
- `internal/gateway/cors.go` + `server.go`: a GCS bucket-CORS lookup (`WithGCSCORSLookup`) wired only in `cmd/jaiscloud-gcp`: `OPTIONS` preflight → 200 with `Access-Control-Allow-Origin/Methods/Headers/Max-Age`, and matching-origin responses get `Access-Control-Allow-Origin` + `Access-Control-Expose-Headers`. S3 path unchanged (`cmd/jaiscloud-aws` still builds/vets).

## Out of scope

- Signed-URL generation (`/_localgcp/sign`) and the bare-PUT resumable shape (separate, out of scope).
- Logging scopes (separate PR).

## How to test

```bash
go build ./... && go vet ./internal/gcp/... ./cmd/jaiscloud-gcp/ ./cmd/jaiscloud-aws/ && gofmt -l internal/gcp/ cmd/
go test ./internal/gcp/provider/storage/ ./internal/gcp/adapter/ ./internal/gcp/store/gcs/ -count=1
```

## Test report

- `go test ./internal/gcp/...` green; `vet`/`gofmt` clean; AWS still builds/vets.
- New provider tests for move/restore/lock/CORS and adapter routing; gateway CORS helper tests.
- Raw-HTTP e2e: bucket with `cors` round-trips; `OPTIONS` preflight + `ACAO`/`Expose-Headers`; upload + `moveTo` (dst new gen, src 404); `lockRetentionPolicy` (`isLocked`, `effectiveTime`, 412 on mismatch, 400 on removing a locked policy); soft-delete + restore.
- jaiscloud `tests/integration/gcp/sdk` (GCS REST SDK): **pass**. floci Python GCS: **9/9**. floci Go GCS with `STORAGE_EMULATOR_HOST_GRPC` set: pass (the gRPC subtest needs the gRPC host; without it the client fails on ADC, unrelated to this PR). localgcp harness GCS: **20/22**, identical to the pre-change baseline (the 2 are the out-of-scope signed-URL/resumable cases).

## Conformance audit

- `objects.restore` / `objects.move` / `buckets.lockRetentionPolicy` paths, params, and response shapes per GCS Discovery.
- `Bucket.cors` = array of `{origin, method, responseHeader, maxAgeSeconds}`; responses to requests with a matching `Origin` carry `Access-Control-Allow-Origin`.
- Locking a retention policy is irreversible (only extension permitted).
