### PR TITLE
fix(gcp/storage): resumable-upload semantics, V4 signed URLs, gcloud upload paths

### DIFF
--- a/internal/gcp/adapter/gcs.go
+++ b/internal/gcp/adapter/gcs.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"mime"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -26,6 +25,10 @@ func (c *GCSCodec) Decode(r *http.Request, body []byte) (*model.NormalizedReques
 	switch {
 	case strings.HasPrefix(path, "/upload/storage/v1/"):
 		return c.decodeUpload(r, body, strings.TrimPrefix(path, "/upload/storage/v1/"))
+	case strings.HasPrefix(path, "/resumable/upload/storage/v1/"):
+		// Discovery-documented resumable initiation path
+		// (mediaUpload.protocols.resumable.path) used by `gcloud storage cp`.
+		return c.decodeUpload(r, body, strings.TrimPrefix(path, "/resumable/upload/storage/v1/"))
 	case strings.HasPrefix(path, "/download/storage/v1/"):
 		return c.decodeDownload(r, body, strings.TrimPrefix(path, "/download/storage/v1/"))
 	case strings.HasPrefix(path, "/storage/v1/"):
@@ -50,12 +53,36 @@ func (c *GCSCodec) decodeRawMedia(r *http.Request, body []byte) (*model.Normaliz
 	metadataFromHeaders(r, nr.Params)
 	nr.Params["bucket"] = seg[0]
 	nr.Params["object"] = strings.Join(seg[1:], "/")
+	signed := hasSignedSignature(r)
+	if signed {
+		nr.Params[wire.SignedURLKey] = true
+	}
 	if r.Method == http.MethodGet || r.Method == http.MethodHead {
 		nr.Action = "ObjectsGetMedia"
+	} else if signed && r.Method == http.MethodPut {
+		// V4 signed-URL upload: PUT stores the object through the media path.
+		nr.Action = "ObjectsInsert"
+		if body == nil {
+			nr.Params[wire.StreamKey] = r.Body
+		} else {
+			nr.Params[wire.MediaKey] = body
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "" {
+			nr.Params[wire.ContentTypeKey] = ct
+		}
 	} else {
 		return nil, model.NewProviderError("InvalidRequest", "unsupported storage path", 404)
 	}
 	return nr, nil
+}
+
+// hasSignedSignature reports whether the request carries a V4 signed-URL
+// signature query parameter (case-preserving key). Presence marks the request
+// as a signed URL; format/expiry validation happens in the storage provider,
+// which deliberately does not verify the cryptographic signature.
+func hasSignedSignature(r *http.Request) bool {
+	_, ok := r.URL.Query()["X-Goog-Signature"]
+	return ok
 }
 
 // decodeDownload handles /download/storage/v1/... — always a media download, so
@@ -82,6 +109,18 @@ func (c *GCSCodec) decodeStorage(r *http.Request, body []byte, rest string) (*mo
 	// selfLink/mediaLink fields (the SDKs follow mediaLink, so it must point
 	// back at this emulator, not real GCS).
 	nr.Params[wire.BaseURLKey] = baseURLFromRequest(r)
+
+	// Resumable-session requests can arrive on the JSON path when a client
+	// rewrites the session URI's /upload/storage/v1/ prefix to /storage/v1/
+	// (emulator accommodation; real GCS serves sessions only at
+	// /upload/storage/v1/). Route before the generic switch so the object
+	// collection branch below does not swallow them.
+	if uploadType, _ := nr.Params["uploadType"].(string); uploadType == "resumable" {
+		return c.decodeStorageResumable(r, body, seg, nr)
+	}
+	if id, _ := nr.Params["upload_id"].(string); id != "" {
+		return c.decodeStorageResumable(r, body, seg, nr)
+	}
 
 	switch {
 	case len(seg) == 1 && seg[0] == "b":
@@ -301,6 +340,47 @@ func (c *GCSCodec) decodeStorage(r *http.Request, body []byte, rest string) (*mo
 	return nr, nil
 }
 
+// decodeStorageResumable decodes a resumable-session request that arrived on
+// the JSON /storage/v1/ path (a client-rewritten session URI). Mirrors the
+// /upload/storage/v1/ resumable branch in decodeUpload: upload_id present →
+// chunk/status, absent → session start.
+func (c *GCSCodec) decodeStorageResumable(r *http.Request, body []byte, seg []string, nr *model.NormalizedRequest) (*model.NormalizedRequest, error) {
+	if !(len(seg) >= 3 && seg[0] == "b" && seg[2] == "o") {
+		return nil, model.NewProviderError("InvalidRequest", "unsupported storage path", 404)
+	}
+	nr.Params["bucket"] = seg[1]
+	if len(seg) > 3 {
+		nr.Params["object"] = strings.Join(seg[3:], "/")
+	}
+	if n, _ := nr.Params["name"].(string); n != "" {
+		nr.Params["object"] = n
+	}
+	if id, _ := nr.Params["upload_id"].(string); id != "" {
+		nr.Action = "ObjectsInsertResumable"
+		nr.Params[wire.MediaKey] = body
+		if cr := r.Header.Get("Content-Range"); cr != "" {
+			nr.Params["contentRange"] = cr
+		}
+		if r.Header.Get("X-GUploader-No-308") == "yes" {
+			nr.Params[wire.No308Key] = true
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "" {
+			nr.Params[wire.ContentTypeKey] = ct
+		}
+		return nr, nil
+	}
+	nr.Action = "ObjectsInsertStartResumable"
+	m, err := parseJSON(body)
+	if err != nil {
+		return nil, model.NewProviderError("InvalidRequest", "malformed JSON body", 400)
+	}
+	nr.Params["body"] = m
+	if ct := r.Header.Get("X-Upload-Content-Type"); ct != "" {
+		nr.Params[wire.ContentTypeKey] = ct
+	}
+	return nr, nil
+}
+
 // decodeUpload handles the media API under /upload/storage/v1/.
 func (c *GCSCodec) decodeUpload(r *http.Request, body []byte, rest string) (*model.NormalizedRequest, error) {
 	seg := splitEscaped(rest)
@@ -414,6 +494,21 @@ func (c *GCSCodec) Encode(nr *model.NormalizedRequest, resp *model.ProviderRespo
 		return status, headers, nil
 	}
 
+	// A length-0 resume-incomplete response carries the status override but no
+	// Range header. The override must be emitted independently of Range — the Go
+	// SDK's only signal of resume-incomplete under X-GUploader-No-308 is this
+	// header — so decouple the two and return an empty body.
+	if so, ok := resp.Data[wire.StatusOverrideKey].(string); ok && so != "" {
+		headers.Set("X-Http-Status-Code-Override", so)
+		return status, headers, nil
+	}
+
+	// A 308 Resume Incomplete with no Range (empty session) must return an
+	// empty body, not the "{}" the generic JSON marshal would emit.
+	if status == http.StatusPermanentRedirect {
+		return status, headers, nil
+	}
+
 	// Streaming download — the gateway will io.Copy the reader; return headers only.
 	if _, ok := resp.Data["_stream"].(io.ReadCloser); ok {
 		if ct, _ := resp.Data[wire.ContentTypeKey].(string); ct != "" {
@@ -446,6 +541,30 @@ func (c *GCSCodec) EncodeError(nr *model.NormalizedRequest, perr *model.Provider
 		status = http.StatusInternalServerError
 	}
 	headers := http.Header{}
+	if perr.Data != nil {
+		switch perr.Data["errorFormat"] {
+		case "plain":
+			// Offset-past-end 503 (resumable): a plain-text body, no envelope.
+			headers.Set("Content-Type", "text/plain; charset=utf-8")
+			return status, headers, []byte(perr.Message)
+		case "xml":
+			// Signed-URL errors use the XML API error document.
+			headers.Set("Content-Type", "application/xml")
+			var b strings.Builder
+			b.WriteString("<?xml version='1.0' encoding='utf-8'?><Error><Code>")
+			b.WriteString(perr.Code)
+			b.WriteString("</Code><Message>")
+			b.WriteString(perr.Message)
+			b.WriteString("</Message>")
+			if param, _ := perr.Data["parameterName"].(string); param != "" {
+				b.WriteString("<ParameterName>")
+				b.WriteString(param)
+				b.WriteString("</ParameterName>")
+			}
+			b.WriteString("</Error>")
+			return status, headers, []byte(b.String())
+		}
+	}
 	headers.Set("Content-Type", "application/json; charset=UTF-8")
 	env := map[string]any{
 		"error": map[string]any{
@@ -615,15 +734,22 @@ func parseJSON(body []byte) (map[string]any, error) {
 // buffered in memory.
 func parseMultipart(r *http.Request, body []byte, params map[string]any) error {
 	ct := r.Header.Get("Content-Type")
-	mediaType, p, err := mime.ParseMediaType(ct)
-	if err != nil || !strings.HasPrefix(mediaType, "multipart/") {
+	mediaType := strings.TrimSpace(ct)
+	if i := strings.IndexByte(mediaType, ';'); i >= 0 {
+		mediaType = strings.TrimSpace(mediaType[:i])
+	}
+	if !strings.HasPrefix(strings.ToLower(mediaType), "multipart/") {
+		return model.NewProviderError("InvalidRequest", "expected multipart body", 400)
+	}
+	boundary := extractBoundary(ct)
+	if boundary == "" {
 		return model.NewProviderError("InvalidRequest", "expected multipart body", 400)
 	}
 	var src io.Reader = bytes.NewReader(body)
 	if body == nil {
 		src = r.Body
 	}
-	mr := multipart.NewReader(src, p["boundary"])
+	mr := multipart.NewReader(src, boundary)
 	for partIdx := 0; ; partIdx++ {
 		part, err := mr.NextPart()
 		if err != nil {
@@ -657,4 +783,31 @@ func parseMultipart(r *http.Request, body []byte, params map[string]any) error {
 		return model.NewProviderError("InvalidRequest", "multipart body missing media part", 400)
 	}
 	return nil
+}
+
+// extractBoundary extracts the multipart boundary from a Content-Type header,
+// accepting bare, double-quoted, and single-quoted values. mime.ParseMediaType
+// is deliberately avoided: it rejects single-quoted boundaries containing '='
+// (an RFC-2045 tspecial), which gcloud/apitools emits (boundary='===...==').
+func extractBoundary(ct string) string {
+	idx := strings.Index(strings.ToLower(ct), "boundary=")
+	if idx < 0 {
+		return ""
+	}
+	rest := strings.TrimSpace(ct[idx+len("boundary="):])
+	if rest == "" {
+		return ""
+	}
+	if rest[0] == '"' || rest[0] == '\'' {
+		q := rest[0]
+		rest = rest[1:]
+		if j := strings.IndexByte(rest, q); j >= 0 {
+			return rest[:j]
+		}
+		return rest
+	}
+	if j := strings.IndexByte(rest, ';'); j >= 0 {
+		rest = rest[:j]
+	}
+	return strings.TrimSpace(rest)
 }

--- a/internal/gcp/adapter/gcs_test.go
+++ b/internal/gcp/adapter/gcs_test.go
@@ -398,3 +398,243 @@ func TestGCSCodecLockRetentionPolicyRouting(t *testing.T) {
 		t.Errorf("expected ifMetagenerationMatch 1, got %q", m)
 	}
 }
+
+func TestGCSCodecResumableUnknownEndContentRange(t *testing.T) {
+	// "bytes 0-*/*" (terminal unknown-end chunk) must pass through verbatim.
+	c := &GCSCodec{}
+	r := httptest.NewRequest("PUT", "/upload/storage/v1/b/bkt/o?uploadType=resumable&upload_id=1", nil)
+	r.Header.Set("Content-Range", "bytes 0-*/*")
+	nr, err := c.Decode(r, []byte("hello"))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if nr.Action != "ObjectsInsertResumable" {
+		t.Fatalf("expected ObjectsInsertResumable, got %q", nr.Action)
+	}
+	if cr, _ := nr.Params["contentRange"].(string); cr != "bytes 0-*/*" {
+		t.Errorf("expected contentRange bytes 0-*/*, got %q", cr)
+	}
+	if _, ok := nr.Params[wire.MediaKey].([]byte); !ok {
+		t.Error("expected media bytes captured")
+	}
+}
+
+func TestGCSCodecStoragePathResumableChunk(t *testing.T) {
+	// A rewritten session URI on the JSON path must decode as a chunk.
+	c := &GCSCodec{}
+	r := httptest.NewRequest("PUT", "/storage/v1/b/bkt/o?uploadType=resumable&upload_id=7", nil)
+	r.Header.Set("Content-Range", "bytes 0-4/*")
+	nr, err := c.Decode(r, []byte("hello"))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if nr.Action != "ObjectsInsertResumable" {
+		t.Fatalf("expected ObjectsInsertResumable, got %q", nr.Action)
+	}
+	if cr, _ := nr.Params["contentRange"].(string); cr != "bytes 0-4/*" {
+		t.Errorf("expected contentRange bytes 0-4/*, got %q", cr)
+	}
+	if b, _ := nr.Params["bucket"].(string); b != "bkt" {
+		t.Errorf("expected bucket bkt, got %q", b)
+	}
+}
+
+func TestGCSCodecStoragePathResumableStart(t *testing.T) {
+	// Initiation on the JSON path (emulator accommodation) decodes to start.
+	c := &GCSCodec{}
+	r := httptest.NewRequest("POST", "/storage/v1/b/bkt/o?uploadType=resumable&name=obj", nil)
+	nr, err := c.Decode(r, []byte(`{"name":"obj"}`))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if nr.Action != "ObjectsInsertStartResumable" {
+		t.Fatalf("expected ObjectsInsertStartResumable, got %q", nr.Action)
+	}
+	if b, _ := nr.Params["bucket"].(string); b != "bkt" {
+		t.Errorf("expected bucket bkt, got %q", b)
+	}
+	if o, _ := nr.Params["object"].(string); o != "obj" {
+		t.Errorf("expected object obj, got %q", o)
+	}
+}
+
+func TestGCSCodecResumableUploadPathStart(t *testing.T) {
+	// Discovery resumable-initiation path /resumable/upload/storage/v1/...
+	c := &GCSCodec{}
+	r := httptest.NewRequest("POST", "/resumable/upload/storage/v1/b/bkt/o?uploadType=resumable&name=obj", nil)
+	nr, err := c.Decode(r, []byte(`{"name":"obj"}`))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if nr.Action != "ObjectsInsertStartResumable" {
+		t.Fatalf("expected ObjectsInsertStartResumable, got %q", nr.Action)
+	}
+}
+
+func TestGCSCodecResumableUploadPathChunk(t *testing.T) {
+	c := &GCSCodec{}
+	r := httptest.NewRequest("PUT", "/resumable/upload/storage/v1/b/bkt/o?uploadType=resumable&upload_id=9", nil)
+	r.Header.Set("Content-Range", "bytes 0-3/*")
+	nr, err := c.Decode(r, []byte("data"))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if nr.Action != "ObjectsInsertResumable" {
+		t.Fatalf("expected ObjectsInsertResumable, got %q", nr.Action)
+	}
+}
+
+func TestDetectServiceResumableUploadPath(t *testing.T) {
+	r := httptest.NewRequest("POST", "/resumable/upload/storage/v1/b/bkt/o?uploadType=resumable", nil)
+	svc, _ := DetectService(r)
+	if svc != "storage" {
+		t.Fatalf("expected storage for /resumable/upload/..., got %q", svc)
+	}
+}
+
+func TestGCSCodecSignedGetDetected(t *testing.T) {
+	c := &GCSCodec{}
+	r := httptest.NewRequest("GET", "/bkt/obj.txt?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Signature=abc&X-Goog-Expires=300&X-Goog-Date=20260913T000000Z", nil)
+	nr, err := c.Decode(r, nil)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if nr.Action != "ObjectsGetMedia" {
+		t.Fatalf("expected ObjectsGetMedia, got %q", nr.Action)
+	}
+	if signed, _ := nr.Params[wire.SignedURLKey].(bool); !signed {
+		t.Error("expected SignedURLKey set for signed GET")
+	}
+}
+
+func TestGCSCodecSignedPutDetected(t *testing.T) {
+	c := &GCSCodec{}
+	r := httptest.NewRequest("PUT", "/bkt/obj.txt?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Signature=abc&X-Goog-Expires=300&X-Goog-Date=20260913T000000Z", nil)
+	r.Header.Set("Content-Type", "text/plain")
+	nr, err := c.Decode(r, []byte("data"))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if nr.Action != "ObjectsInsert" {
+		t.Fatalf("expected ObjectsInsert, got %q", nr.Action)
+	}
+	if signed, _ := nr.Params[wire.SignedURLKey].(bool); !signed {
+		t.Error("expected SignedURLKey set for signed PUT")
+	}
+	if b, _ := nr.Params[wire.MediaKey].([]byte); string(b) != "data" {
+		t.Errorf("expected media data, got %q", b)
+	}
+}
+
+func TestDetectServiceSignedPut(t *testing.T) {
+	r := httptest.NewRequest("PUT", "/bkt/obj.txt?X-Goog-Signature=abc", nil)
+	svc, _ := DetectService(r)
+	if svc != "storage" {
+		t.Fatalf("expected storage for signed PUT, got %q", svc)
+	}
+}
+
+func TestGCSCodecEncodeOverrideWithoutRange(t *testing.T) {
+	c := &GCSCodec{}
+	nr := &model.NormalizedRequest{}
+	resp := &model.ProviderResponse{
+		HTTPStatus: 200,
+		Data:       map[string]any{wire.StatusOverrideKey: "308"},
+	}
+	status, hdr, body := c.Encode(nr, resp)
+	if status != 200 {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if hdr.Get("X-Http-Status-Code-Override") != "308" {
+		t.Fatalf("expected X-Http-Status-Code-Override 308, got %q", hdr.Get("X-Http-Status-Code-Override"))
+	}
+	if hdr.Get("Range") != "" {
+		t.Fatalf("expected no Range header, got %q", hdr.Get("Range"))
+	}
+	if len(body) != 0 {
+		t.Fatalf("expected empty body, got %q", body)
+	}
+}
+
+func TestGCSCodecEncodePlain308EmptyBody(t *testing.T) {
+	c := &GCSCodec{}
+	nr := &model.NormalizedRequest{}
+	resp := &model.ProviderResponse{HTTPStatus: 308, Data: map[string]any{}}
+	status, hdr, body := c.Encode(nr, resp)
+	if status != 308 {
+		t.Fatalf("expected 308, got %d", status)
+	}
+	if hdr.Get("Range") != "" {
+		t.Fatalf("expected no Range, got %q", hdr.Get("Range"))
+	}
+	if len(body) != 0 {
+		t.Fatalf("expected empty body, got %q", body)
+	}
+}
+
+func TestGCSCodecEncodeErrorPlain(t *testing.T) {
+	c := &GCSCodec{}
+	perr := model.NewProviderError("InvalidRequest", "Invalid request.  offset", 503).
+		WithData(map[string]any{"errorFormat": "plain"})
+	status, hdr, body := c.EncodeError(nil, perr)
+	if status != 503 {
+		t.Fatalf("expected 503, got %d", status)
+	}
+	if ct := hdr.Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+		t.Fatalf("expected text/plain, got %q", ct)
+	}
+	if string(body) != "Invalid request.  offset" {
+		t.Fatalf("expected exact plain body, got %q", body)
+	}
+}
+
+func TestGCSCodecEncodeErrorXML(t *testing.T) {
+	c := &GCSCodec{}
+	perr := model.NewProviderError("ExpiredToken", "The provided token has expired.", 400).
+		WithData(map[string]any{"errorFormat": "xml"})
+	status, hdr, body := c.EncodeError(nil, perr)
+	if status != 400 {
+		t.Fatalf("expected 400, got %d", status)
+	}
+	if ct := hdr.Get("Content-Type"); ct != "application/xml" {
+		t.Fatalf("expected application/xml, got %q", ct)
+	}
+	s := string(body)
+	if !strings.Contains(s, "<Code>ExpiredToken</Code>") {
+		t.Fatalf("expected ExpiredToken code, got %q", s)
+	}
+	if strings.Contains(s, "<ParameterName>") {
+		t.Fatalf("expected no ParameterName, got %q", s)
+	}
+
+	perr = model.NewProviderError("MalformedSecurityHeader", "Your request has a malformed header.", 400).
+		WithData(map[string]any{"errorFormat": "xml", "parameterName": "Expires"})
+	_, _, body = c.EncodeError(nil, perr)
+	if s := string(body); !strings.Contains(s, "<ParameterName>Expires</ParameterName>") {
+		t.Fatalf("expected ParameterName Expires, got %q", s)
+	}
+}
+
+func TestGCSCodecParseMultipartSingleQuotedBoundary(t *testing.T) {
+	// gcloud/apitools emits `boundary='...=='` (single-quoted, with tspecial '='
+	// chars) — mime.ParseMediaType rejects this, so the boundary is extracted
+	// manually.
+	body := "--BND==\r\nContent-Type: application/json\r\n\r\n{\"name\":\"o.txt\"}\r\n--BND==\r\nContent-Type: text/plain\r\n\r\nhello\r\n--BND==--\r\n"
+	r := httptest.NewRequest("POST", "/upload/storage/v1/b/bkt/o?uploadType=multipart", strings.NewReader(body))
+	r.Header.Set("Content-Type", "multipart/related; boundary='BND=='")
+	nr := &model.NormalizedRequest{Params: map[string]any{}}
+	if err := parseMultipart(r, []byte(body), nr.Params); err != nil {
+		t.Fatalf("parseMultipart: %v", err)
+	}
+	if m, _ := nr.Params["body"].(map[string]any); m == nil || m["name"] != "o.txt" {
+		t.Fatalf("expected metadata name o.txt, got %v", m)
+	}
+	rc, ok := nr.Params[wire.StreamKey].(io.Reader)
+	if !ok {
+		t.Fatal("expected stream media part")
+	}
+	b, err := io.ReadAll(rc)
+	if err != nil || string(b) != "hello" {
+		t.Fatalf("expected media hello, got %q / %v", b, err)
+	}
+}

--- a/internal/gcp/adapter/router.go
+++ b/internal/gcp/adapter/router.go
@@ -54,10 +54,15 @@ func DetectService(r *http.Request) (service string, source DetectionSource) {
 }
 
 // isRawStorageMediaPath reports whether r is a GCS raw media download of the
-// form /{bucket}/{object} (GET/HEAD). Admin routes and JSON-API prefixes are
-// handled elsewhere; only genuine object downloads reach this fallback.
+// form /{bucket}/{object} (GET/HEAD), or a V4 signed-URL upload of the same
+// shape (PUT with an X-Goog-Signature query param). Admin routes and JSON-API
+// prefixes are handled elsewhere; only genuine object requests reach this
+// fallback.
 func isRawStorageMediaPath(r *http.Request) bool {
-	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+	switch {
+	case r.Method == http.MethodGet, r.Method == http.MethodHead:
+	case r.Method == http.MethodPut && hasSignedSignature(r):
+	default:
 		return false
 	}
 	p := strings.TrimPrefix(r.URL.Path, "/")

--- a/internal/gcp/adapter/services.go
+++ b/internal/gcp/adapter/services.go
@@ -30,7 +30,7 @@ type ServiceDescriptor struct {
 var gcpServices = []ServiceDescriptor{
 	{
 		ServiceName:    "storage",
-		PathPrefixes:   []string{"/storage/v1/", "/upload/storage/v1/", "/download/storage/v1/"},
+		PathPrefixes:   []string{"/storage/v1/", "/upload/storage/v1/", "/resumable/upload/storage/v1/", "/download/storage/v1/"},
 		ProviderPrefix: "Storage",
 		Codec:          func() adapter.Codec { return &GCSCodec{} },
 	},

--- a/internal/gcp/provider/storage/storage.go
+++ b/internal/gcp/provider/storage/storage.go
@@ -74,9 +74,23 @@ type Provider struct {
 
 	mu      sync.Mutex
 	uploads map[string]*uploadSession // resumable upload sessions (in-memory)
+	// completed tombstones for finished resumable uploads, so a post-completion
+	// status query returns 200 + the object. Bounded and TTL-swept; lost on
+	// restart (an in-memory concern, not durably mirrored).
+	completed map[string]*completedSession
 
 	genMu sync.Mutex
 	gen   int64 // monotonically-increasing object generation counter
+}
+
+// completedSession is a lightweight tombstone for a finished resumable upload,
+// holding the finalized object resource so a post-completion status query can
+// replay it.
+type completedSession struct {
+	Bucket     string
+	Object     string
+	objectJSON map[string]any
+	lastAccess time.Time
 }
 
 // uploadSession holds the state of an in-progress resumable upload.
@@ -102,6 +116,7 @@ func New(objects gcs.ObjectStore, resources store.ResourceStore, blobs blobfs.Bl
 		blobs:     blobs,
 		encryptor: encryptor,
 		uploads:   make(map[string]*uploadSession),
+		completed: make(map[string]*completedSession),
 		gen:       clock.Now().UnixNano(),
 	}
 	p.seedGeneration(context.Background())
@@ -170,11 +185,13 @@ func (p *Provider) Reset(_ context.Context) {
 		}
 	}
 	p.uploads = make(map[string]*uploadSession)
+	p.completed = make(map[string]*completedSession)
 	p.mu.Unlock()
 }
 
 // sweepSessions removes stale in-memory resumable sessions, closing and
-// deleting any spill files. The caller must hold p.mu.
+// deleting any spill files, and evicts expired completion tombstones. The
+// caller must hold p.mu.
 func (p *Provider) sweepSessions() {
 	now := clock.RealNow()
 	for id, sess := range p.uploads {
@@ -184,6 +201,11 @@ func (p *Provider) sweepSessions() {
 				os.Remove(sess.tmpPath)
 			}
 			delete(p.uploads, id)
+		}
+	}
+	for id, done := range p.completed {
+		if now.Sub(done.lastAccess) > resumableSessionTTL {
+			delete(p.completed, id)
 		}
 	}
 }
@@ -892,6 +914,11 @@ func (p *Provider) ObjectsList(ctx context.Context, nr *model.NormalizedRequest)
 }
 
 func (p *Provider) ObjectsInsert(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	if signed, _ := nr.Params[wire.SignedURLKey].(bool); signed {
+		if perr := p.validateSignedURL(nr); perr != nil {
+			return nil, perr
+		}
+	}
 	bucket, _ := nr.Params["bucket"].(string)
 	if bucket == "" {
 		return nil, model.NewProviderError("InvalidRequest", "missing bucket", 400)
@@ -1104,7 +1131,42 @@ func (p *Provider) ObjectsGet(ctx context.Context, nr *model.NormalizedRequest) 
 	return p.objectResponse(ctx, nr)
 }
 
+// validateSignedURL enforces V4 signed-URL parameter format and expiry. It
+// deliberately does not verify the cryptographic signature: the emulator
+// accepts any well-formed, unexpired signed URL (consistent with jaiscloud's
+// auth-bypass model, and the only approach compatible with SDK-signed URLs
+// whose key material never reaches the emulator).
+func (p *Provider) validateSignedURL(nr *model.NormalizedRequest) *model.ProviderError {
+	expiresStr, _ := nr.Params["X-Goog-Expires"].(string)
+	expires, err := strconv.ParseInt(expiresStr, 10, 64)
+	if err != nil || expires <= 0 || expires > 604800 {
+		return malformedSecurityHeader("Expires")
+	}
+	dateStr, _ := nr.Params["X-Goog-Date"].(string)
+	date, err := time.Parse("20060102T150405Z", dateStr)
+	if err != nil {
+		return malformedSecurityHeader("Date")
+	}
+	if date.Add(time.Duration(expires) * time.Second).Before(clock.Now()) {
+		return model.NewProviderError("ExpiredToken", "The provided token has expired.", 400).
+			WithData(map[string]any{"errorFormat": "xml"})
+	}
+	return nil
+}
+
+// malformedSecurityHeader builds the XML-API 400 error for a malformed signed
+// URL parameter (test-derived code/message shape).
+func malformedSecurityHeader(param string) *model.ProviderError {
+	return model.NewProviderError("MalformedSecurityHeader", "Your request has a malformed header.", 400).
+		WithData(map[string]any{"errorFormat": "xml", "parameterName": param})
+}
+
 func (p *Provider) ObjectsGetMedia(ctx context.Context, nr *model.NormalizedRequest) (*model.ProviderResponse, error) {
+	if signed, _ := nr.Params[wire.SignedURLKey].(bool); signed {
+		if perr := p.validateSignedURL(nr); perr != nil {
+			return nil, perr
+		}
+	}
 	bucket, _ := nr.Params["bucket"].(string)
 	object, _ := nr.Params["object"].(string)
 	// Metadata first: metadata gone → 404; metadata present + blob absent → 404
@@ -2559,6 +2621,10 @@ func (p *Provider) ObjectsInsertResumable(ctx context.Context, nr *model.Normali
 	p.mu.Lock()
 	sess, ok := p.uploads[uploadID]
 	if !ok {
+		if done, ok := p.completed[uploadID]; ok {
+			p.mu.Unlock()
+			return provider.OK(done.objectJSON), nil
+		}
 		p.mu.Unlock()
 		return nil, model.NewProviderError("NotFound", "unknown upload_id", 404)
 	}
@@ -2566,7 +2632,7 @@ func (p *Provider) ObjectsInsertResumable(ctx context.Context, nr *model.Normali
 	if ct, _ := nr.Params[wire.ContentTypeKey].(string); ct != "" {
 		sess.ContentType = ct
 	}
-	start, end, total, hasTotal, isStatus := parseContentRange(cr)
+	start, end, total, hasTotal, isStatus, endUnknown := parseContentRange(cr)
 	complete := false
 	if isStatus {
 		// Status query (bytes */N): finalize once all N bytes are received, so a
@@ -2574,29 +2640,33 @@ func (p *Provider) ObjectsInsertResumable(ctx context.Context, nr *model.Normali
 		// completion and receive the object resource.
 		complete = hasTotal && sess.length >= total
 	} else {
-		// Offset repair: only append a chunk that begins exactly where the
-		// accumulated bytes end; out-of-order/duplicate chunks are ignored.
-		if sess.length == start {
-			if sess.tmpFile != nil {
-				if _, err := sess.tmpFile.Write(media); err != nil {
-					p.mu.Unlock()
-					return nil, fmt.Errorf("resumable upload: write spill file: %w", err)
-				}
-			} else if int64(len(sess.buf))+int64(len(media)) > resumableSpillThreshold {
-				if err := spillSession(sess); err != nil {
-					p.mu.Unlock()
-					return nil, err
-				}
-				if _, err := sess.tmpFile.Write(media); err != nil {
-					p.mu.Unlock()
-					return nil, fmt.Errorf("resumable upload: write spill file: %w", err)
-				}
-			} else {
-				sess.buf = append(sess.buf, media...)
+		// A chunk starting past the persisted byte count is a client-side
+		// data-loss condition: reject with 503 (plain text).
+		if start > sess.length {
+			p.mu.Unlock()
+			return nil, offsetGapError(start, sess.length)
+		}
+		// Only append a chunk that begins exactly where the accumulated bytes
+		// end; a rewind (start < length) ignores re-sent bytes.
+		if start == sess.length {
+			if err := p.appendChunk(sess, media); err != nil {
+				p.mu.Unlock()
+				return nil, err
 			}
 			sess.length += int64(len(media))
 		}
-		complete = hasTotal && end+1 >= total && sess.length >= total
+		if endUnknown {
+			// Terminal unknown-end chunk (bytes <start>-*/<total>, emitted by the
+			// Node SDK in single-request mode): the whole object is in this
+			// request. Validate the declared total, if any, then finalize.
+			if hasTotal && sess.length != total {
+				p.mu.Unlock()
+				return nil, model.NewProviderError("InvalidRequest", "Invalid Content-Range", 400)
+			}
+			complete = true
+		} else {
+			complete = hasTotal && end+1 >= total && sess.length >= total
+		}
 	}
 	if complete {
 		delete(p.uploads, uploadID)
@@ -2639,11 +2709,10 @@ func (p *Provider) ObjectsInsertResumable(ctx context.Context, nr *model.Normali
 	}
 
 	if !complete {
-		rng := fmt.Sprintf("bytes=0-%d", length-1)
-		if length == 0 {
-			rng = "bytes=0-0"
+		data := map[string]any{}
+		if length > 0 {
+			data[wire.RangeKey] = fmt.Sprintf("bytes=0-%d", length-1)
 		}
-		data := map[string]any{wire.RangeKey: rng}
 		status := 308
 		if no308, _ := nr.Params[wire.No308Key].(bool); no308 {
 			// The SDK sets X-GUploader-No-308: yes; signal resume-incomplete
@@ -2667,7 +2736,54 @@ func (p *Provider) ObjectsInsertResumable(ctx context.Context, nr *model.Normali
 	if metadata != nil {
 		nr.Params[wire.MetaHeadersKey] = metadata
 	}
-	return p.ObjectsInsert(ctx, nr)
+	resp, err := p.ObjectsInsert(ctx, nr)
+	if err != nil {
+		return nil, err
+	}
+	// Record a bounded completion tombstone so a post-completion status query
+	// returns 200 + the object (real GCS replays the completed resource).
+	p.mu.Lock()
+	if len(p.completed) < maxUploadSessions {
+		p.completed[uploadID] = &completedSession{
+			Bucket:     bucket,
+			Object:     object,
+			objectJSON: resp.Data,
+			lastAccess: clock.RealNow(),
+		}
+	}
+	p.mu.Unlock()
+	return resp, nil
+}
+
+// appendChunk appends media to an in-progress session, spilling to a temp file
+// once the in-memory buffer exceeds the threshold. The caller must hold p.mu.
+func (p *Provider) appendChunk(sess *uploadSession, media []byte) error {
+	if sess.tmpFile != nil {
+		if _, err := sess.tmpFile.Write(media); err != nil {
+			return fmt.Errorf("resumable upload: write spill file: %w", err)
+		}
+		return nil
+	}
+	if int64(len(sess.buf))+int64(len(media)) > resumableSpillThreshold {
+		if err := spillSession(sess); err != nil {
+			return err
+		}
+		if _, err := sess.tmpFile.Write(media); err != nil {
+			return fmt.Errorf("resumable upload: write spill file: %w", err)
+		}
+		return nil
+	}
+	sess.buf = append(sess.buf, media...)
+	return nil
+}
+
+// offsetGapError builds the plain-text 503 returned when a resumable chunk
+// starts past the persisted byte count. The message text matches live GCS
+// (double space after "request."), attested by the Java SDK's put task and SAP
+// KB 2840945.
+func offsetGapError(start, length int64) *model.ProviderError {
+	msg := fmt.Sprintf("Invalid request.  According to the Content-Range header, the upload offset is %d byte(s), which exceeds already uploaded size of %d byte(s).", start, length)
+	return model.NewProviderError("InvalidRequest", msg, 503).WithData(map[string]any{"errorFormat": "plain"})
 }
 
 // spillSession flushes the in-memory buffer to a temp file and switches the
@@ -2690,8 +2806,10 @@ func spillSession(sess *uploadSession) error {
 
 // parseContentRange parses a "bytes <start>-<end>/<total>" header, or a status
 // query "bytes */<total>". total may be "*" (unknown) in which case hasTotal is
-// false. isStatus is true for the "bytes *" status query.
-func parseContentRange(cr string) (start, end, total int64, hasTotal, isStatus bool) {
+// false. isStatus is true for the "bytes *" status query. endUnknown is true
+// when the end position is "*" (bytes <start>-*/<total>), the terminal
+// single-request form emitted by Google's Node SDK.
+func parseContentRange(cr string) (start, end, total int64, hasTotal, isStatus, endUnknown bool) {
 	rest := strings.TrimPrefix(cr, "bytes ")
 	rangePart, totalPart, _ := strings.Cut(rest, "/")
 	if rangePart == "*" {
@@ -2699,12 +2817,16 @@ func parseContentRange(cr string) (start, end, total int64, hasTotal, isStatus b
 			total, _ = strconv.ParseInt(totalPart, 10, 64)
 			hasTotal = true
 		}
-		return 0, 0, total, hasTotal, true
+		return 0, 0, total, hasTotal, true, false
 	}
 	se := strings.SplitN(rangePart, "-", 2)
 	if len(se) == 2 {
 		start, _ = strconv.ParseInt(se[0], 10, 64)
-		end, _ = strconv.ParseInt(se[1], 10, 64)
+		if se[1] == "*" {
+			endUnknown = true
+		} else {
+			end, _ = strconv.ParseInt(se[1], 10, 64)
+		}
 	}
 	if totalPart != "" && totalPart != "*" {
 		total, _ = strconv.ParseInt(totalPart, 10, 64)

--- a/internal/gcp/provider/storage/storage_test.go
+++ b/internal/gcp/provider/storage/storage_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"jaiscloud/internal/blobfs"
 	"jaiscloud/internal/clock"
@@ -1291,7 +1292,8 @@ func TestResumableSessionEdgeCases(t *testing.T) {
 	}
 	uploadID := extractUploadID(t, start)
 
-	// Status query on an empty session → Range bytes=0-0.
+	// Status query on an empty session → 308 with no Range header (real GCS
+	// omits Range when no bytes are persisted).
 	nr = bucketParams()
 	nr.Params["upload_id"] = uploadID
 	nr.Params["contentRange"] = "bytes */5"
@@ -1299,8 +1301,8 @@ func TestResumableSessionEdgeCases(t *testing.T) {
 	if err != nil || resp.HTTPStatus != 308 {
 		t.Fatalf("status query on empty session: %v / %v", resp, err)
 	}
-	if rng, _ := resp.Data[wire.RangeKey].(string); rng != "bytes=0-0" {
-		t.Fatalf("expected Range bytes=0-0, got %q", rng)
+	if _, ok := resp.Data[wire.RangeKey]; ok {
+		t.Fatalf("empty session must omit Range, got %v", resp.Data[wire.RangeKey])
 	}
 
 	// A chunk may update the session content type.
@@ -1758,5 +1760,420 @@ func TestParseByteRange(t *testing.T) {
 			t.Errorf("parseByteRange(%q, %d) = (%d,%d,%v), want (%d,%d,%v)",
 				c.rng, total, s, e, ok, c.start, c.end, c.ok)
 		}
+	}
+}
+
+// ─── resumable upload semantics (Gap 1–4) ───────────────────────────────────
+
+func resumableStart(t *testing.T, p *Provider, bucket, object string) string {
+	t.Helper()
+	ctx := context.Background()
+	nr := bucketParams()
+	nr.Params["bucket"] = bucket
+	nr.Params["object"] = object
+	nr.Params[wire.ContentTypeKey] = "application/octet-stream"
+	start, err := p.ObjectsInsertStartResumable(ctx, nr)
+	if err != nil {
+		t.Fatalf("start resumable: %v", err)
+	}
+	return extractUploadID(t, start)
+}
+
+func TestResumableEmptyStatusQueryOmitsRange(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+	uploadID := resumableStart(t, p, "bkt", "x.bin")
+
+	// Empty-session status query -> 308 with no Range and no override.
+	nr = bucketParams()
+	nr.Params["upload_id"] = uploadID
+	nr.Params["contentRange"] = "bytes */5"
+	resp, err := p.ObjectsInsertResumable(ctx, nr)
+	if err != nil || resp.HTTPStatus != 308 {
+		t.Fatalf("status query: %v / %v", resp, err)
+	}
+	if _, ok := resp.Data[wire.RangeKey]; ok {
+		t.Error("empty session must omit Range")
+	}
+	if _, ok := resp.Data[wire.StatusOverrideKey]; ok {
+		t.Error("empty session must not carry a status override")
+	}
+
+	// length-0 + X-GUploader-No-308 -> 200 + override, no Range (Go SDK contract).
+	nr = bucketParams()
+	nr.Params["upload_id"] = uploadID
+	nr.Params["contentRange"] = "bytes */5"
+	nr.Params[wire.No308Key] = true
+	resp, err = p.ObjectsInsertResumable(ctx, nr)
+	if err != nil || resp.HTTPStatus != 200 {
+		t.Fatalf("no-308 status query: %v / %v", resp, err)
+	}
+	if so, _ := resp.Data[wire.StatusOverrideKey].(string); so != "308" {
+		t.Fatalf("expected status override 308, got %q", so)
+	}
+	if _, ok := resp.Data[wire.RangeKey]; ok {
+		t.Error("empty no-308 session must omit Range")
+	}
+}
+
+func TestResumableNonEmptyStatusKeepsRange(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+	uploadID := resumableStart(t, p, "bkt", "x.bin")
+
+	nr = bucketParams()
+	nr.Params["upload_id"] = uploadID
+	nr.Params["contentRange"] = "bytes 0-4/*"
+	nr.Params[wire.MediaKey] = []byte("hello")
+	if resp, err := p.ObjectsInsertResumable(ctx, nr); err != nil || resp.HTTPStatus != 308 {
+		t.Fatalf("chunk: %v / %v", resp, err)
+	}
+
+	nr = bucketParams()
+	nr.Params["upload_id"] = uploadID
+	nr.Params["contentRange"] = "bytes */100"
+	resp, err := p.ObjectsInsertResumable(ctx, nr)
+	if err != nil || resp.HTTPStatus != 308 {
+		t.Fatalf("status: %v / %v", resp, err)
+	}
+	if rng, _ := resp.Data[wire.RangeKey].(string); rng != "bytes=0-4" {
+		t.Fatalf("expected Range bytes=0-4, got %q", rng)
+	}
+}
+
+func TestResumableOffsetGapReturnsPlain503(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+	uploadID := resumableStart(t, p, "bkt", "x.bin")
+
+	nr = bucketParams()
+	nr.Params["upload_id"] = uploadID
+	nr.Params["contentRange"] = "bytes 4-5/6"
+	nr.Params[wire.MediaKey] = []byte("ok")
+	_, err := p.ObjectsInsertResumable(ctx, nr)
+	pe, ok := err.(*model.ProviderError)
+	if !ok {
+		t.Fatalf("expected ProviderError, got %v", err)
+	}
+	if pe.HTTPStatus != 503 {
+		t.Fatalf("expected 503, got %d", pe.HTTPStatus)
+	}
+	if f, _ := pe.Data["errorFormat"].(string); f != "plain" {
+		t.Fatalf("expected plain errorFormat, got %q", f)
+	}
+	if len(pe.Message) != 138 {
+		t.Fatalf("expected 138-byte message, got %d", len(pe.Message))
+	}
+	if !strings.Contains(strings.ToLower(pe.Message), "content-range") || strings.Contains(strings.ToLower(pe.Message), "earlier") {
+		t.Fatalf("unexpected message shape: %q", pe.Message)
+	}
+}
+
+func TestResumableRewindIgnored(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+	uploadID := resumableStart(t, p, "bkt", "x.bin")
+
+	nr = bucketParams()
+	nr.Params["upload_id"] = uploadID
+	nr.Params["contentRange"] = "bytes 0-4/*"
+	nr.Params[wire.MediaKey] = []byte("hello")
+	if resp, err := p.ObjectsInsertResumable(ctx, nr); err != nil || resp.HTTPStatus != 308 {
+		t.Fatalf("chunk: %v / %v", resp, err)
+	}
+
+	// Re-send the same chunk (rewind) -> 308, bytes unchanged.
+	nr = bucketParams()
+	nr.Params["upload_id"] = uploadID
+	nr.Params["contentRange"] = "bytes 0-4/*"
+	nr.Params[wire.MediaKey] = []byte("hello")
+	resp, err := p.ObjectsInsertResumable(ctx, nr)
+	if err != nil || resp.HTTPStatus != 308 {
+		t.Fatalf("rewind chunk: %v / %v", resp, err)
+	}
+	if rng, _ := resp.Data[wire.RangeKey].(string); rng != "bytes=0-4" {
+		t.Fatalf("expected Range bytes=0-4 after rewind, got %q", rng)
+	}
+}
+
+func TestResumableUnknownSizeFinalChunk(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+	uploadID := resumableStart(t, p, "bkt", "x.bin")
+
+	body := []byte("seventeen bytes!!")
+	nr = bucketParams()
+	nr.Params["upload_id"] = uploadID
+	nr.Params["contentRange"] = "bytes 0-*/*"
+	nr.Params[wire.MediaKey] = body
+	resp, err := p.ObjectsInsertResumable(ctx, nr)
+	if err != nil || resp.HTTPStatus != 200 {
+		t.Fatalf("unknown-size final: %v / %v", resp, err)
+	}
+	if size, _ := resp.Data["size"].(string); size != strconv.Itoa(len(body)) {
+		t.Fatalf("expected size %d, got %q", len(body), size)
+	}
+
+	media, err := p.ObjectsGetMedia(ctx, bucketParamsWithObj("bkt", "x.bin"))
+	if err != nil {
+		t.Fatalf("get media: %v", err)
+	}
+	if got := string(streamBytes(t, media)); got != string(body) {
+		t.Fatalf("expected %q, got %q", body, got)
+	}
+}
+
+func TestResumableUnknownSizeFinalKnownTotal(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+	uploadID := resumableStart(t, p, "bkt", "x.bin")
+
+	body := []byte("12345678901234567") // 17 bytes
+	nr = bucketParams()
+	nr.Params["upload_id"] = uploadID
+	nr.Params["contentRange"] = "bytes 0-*/17"
+	nr.Params[wire.MediaKey] = body
+	resp, err := p.ObjectsInsertResumable(ctx, nr)
+	if err != nil || resp.HTTPStatus != 200 {
+		t.Fatalf("known-total unknown-end final: %v / %v", resp, err)
+	}
+
+	// A mismatched declared total must 400.
+	uploadID = resumableStart(t, p, "bkt", "y.bin")
+	nr = bucketParams()
+	nr.Params["upload_id"] = uploadID
+	nr.Params["contentRange"] = "bytes 0-*/16"
+	nr.Params[wire.MediaKey] = body
+	_, err = p.ObjectsInsertResumable(ctx, nr)
+	pe, ok := err.(*model.ProviderError)
+	if !ok || pe.HTTPStatus != 400 {
+		t.Fatalf("expected 400 on size mismatch, got %v", err)
+	}
+}
+
+func TestResumablePostCompletionReplay(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+	uploadID := resumableStart(t, p, "bkt", "x.bin")
+
+	nr = bucketParams()
+	nr.Params["upload_id"] = uploadID
+	nr.Params["contentRange"] = "bytes 0-4/*"
+	nr.Params[wire.MediaKey] = []byte("hello")
+	if resp, err := p.ObjectsInsertResumable(ctx, nr); err != nil || resp.HTTPStatus != 308 {
+		t.Fatalf("chunk: %v / %v", resp, err)
+	}
+	nr = bucketParams()
+	nr.Params["upload_id"] = uploadID
+	nr.Params["contentRange"] = "bytes 5-10/11"
+	nr.Params[wire.MediaKey] = []byte(" world")
+	resp, err := p.ObjectsInsertResumable(ctx, nr)
+	if err != nil || resp.HTTPStatus != 200 {
+		t.Fatalf("final: %v / %v", resp, err)
+	}
+
+	// Post-completion status query -> 200 + object size.
+	nr = bucketParams()
+	nr.Params["upload_id"] = uploadID
+	nr.Params["contentRange"] = "bytes */11"
+	resp, err = p.ObjectsInsertResumable(ctx, nr)
+	if err != nil || resp.HTTPStatus != 200 {
+		t.Fatalf("post-completion status: %v / %v", resp, err)
+	}
+	if size, _ := resp.Data["size"].(string); size != "11" {
+		t.Fatalf("expected size 11, got %q", size)
+	}
+}
+
+func TestResumableTombstoneSweep(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+	uploadID := resumableStart(t, p, "bkt", "x.bin")
+
+	nr = bucketParams()
+	nr.Params["upload_id"] = uploadID
+	nr.Params["contentRange"] = "bytes 0-4/5"
+	nr.Params[wire.MediaKey] = []byte("hello")
+	if _, err := p.ObjectsInsertResumable(ctx, nr); err != nil {
+		t.Fatalf("final: %v", err)
+	}
+	p.mu.Lock()
+	if _, ok := p.completed[uploadID]; !ok {
+		p.mu.Unlock()
+		t.Fatal("expected a completion tombstone")
+	}
+	p.completed[uploadID].lastAccess = clock.RealNow().Add(-48 * time.Hour)
+	p.sweepSessions()
+	_, ok := p.completed[uploadID]
+	p.mu.Unlock()
+	if ok {
+		t.Error("expected tombstone to be swept after TTL")
+	}
+}
+
+// ─── V4 signed URLs (Gap 6) ────────────────────────────────────────────────
+
+func signedRequest(bucket, object, expires, date string) *model.NormalizedRequest {
+	nr := bucketParamsWithObj(bucket, object)
+	nr.Params[wire.SignedURLKey] = true
+	nr.Params["X-Goog-Algorithm"] = "GOOG4-RSA-SHA256"
+	nr.Params["X-Goog-Credential"] = "test@test.iam.gserviceaccount.com/20260913/auto/storage/goog4_request"
+	nr.Params["X-Goog-SignedHeaders"] = "host"
+	nr.Params["X-Goog-Signature"] = "abc"
+	nr.Params["X-Goog-Expires"] = expires
+	nr.Params["X-Goog-Date"] = date
+	return nr
+}
+
+func TestSignedURLExpiredToken(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := signedRequest("bkt", "o.txt", "60", "20200101T000000Z")
+	_, err := p.ObjectsGetMedia(ctx, nr)
+	pe, ok := err.(*model.ProviderError)
+	if !ok || pe.HTTPStatus != 400 || pe.Code != "ExpiredToken" {
+		t.Fatalf("expected ExpiredToken 400, got %v", err)
+	}
+	if f, _ := pe.Data["errorFormat"].(string); f != "xml" {
+		t.Fatalf("expected xml errorFormat, got %q", f)
+	}
+}
+
+func TestSignedURLMalformedDate(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := signedRequest("bkt", "o.txt", "3600", "not-a-date")
+	_, err := p.ObjectsGetMedia(ctx, nr)
+	pe, ok := err.(*model.ProviderError)
+	if !ok || pe.HTTPStatus != 400 || pe.Code != "MalformedSecurityHeader" {
+		t.Fatalf("expected MalformedSecurityHeader 400, got %v", err)
+	}
+	if param, _ := pe.Data["parameterName"].(string); param != "Date" {
+		t.Fatalf("expected ParameterName Date, got %q", param)
+	}
+}
+
+func TestSignedURLInvalidExpires(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := signedRequest("bkt", "o.txt", "604801", "20260913T000000Z")
+	_, err := p.ObjectsGetMedia(ctx, nr)
+	pe, ok := err.(*model.ProviderError)
+	if !ok || pe.HTTPStatus != 400 || pe.Code != "MalformedSecurityHeader" {
+		t.Fatalf("expected MalformedSecurityHeader 400, got %v", err)
+	}
+	if param, _ := pe.Data["parameterName"].(string); param != "Expires" {
+		t.Fatalf("expected ParameterName Expires, got %q", param)
+	}
+}
+
+func TestSignedURLLowercaseParams(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParamsWithObj("bkt", "o.txt")
+	nr.Params[wire.SignedURLKey] = true
+	nr.Params["X-Goog-Signature"] = "abc"
+	nr.Params["x-goog-expires"] = "604801"
+	nr.Params["x-goog-date"] = "20260913T000000Z"
+	_, err := p.ObjectsGetMedia(ctx, nr)
+	pe, ok := err.(*model.ProviderError)
+	if !ok || pe.HTTPStatus != 400 || pe.Code != "MalformedSecurityHeader" {
+		t.Fatalf("expected MalformedSecurityHeader 400, got %v", err)
+	}
+	if param, _ := pe.Data["parameterName"].(string); param != "Expires" {
+		t.Fatalf("expected ParameterName Expires, got %q", param)
+	}
+}
+
+func TestSignedURLPutStoresObject(t *testing.T) {
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+
+	date := clock.Now().Format("20060102T150405Z")
+	nr = signedRequest("bkt", "o.txt", "3600", date)
+	nr.Params[wire.MediaKey] = []byte("signed data")
+	nr.Params[wire.ContentTypeKey] = "text/plain"
+	resp, err := p.ObjectsInsert(ctx, nr)
+	if err != nil || resp.HTTPStatus != 200 {
+		t.Fatalf("signed PUT: %v / %v", resp, err)
+	}
+
+	media, err := p.ObjectsGetMedia(ctx, bucketParamsWithObj("bkt", "o.txt"))
+	if err != nil {
+		t.Fatalf("get media: %v", err)
+	}
+	if got := string(streamBytes(t, media)); got != "signed data" {
+		t.Fatalf("expected 'signed data', got %q", got)
+	}
+}
+
+func TestSignedURLTamperedSignatureAccepted(t *testing.T) {
+	// Records the deliberate auth bypass: a syntactically valid, unexpired
+	// signed URL is accepted regardless of the signature value.
+	ctx := context.Background()
+	p := newTestProvider()
+	nr := bucketParams()
+	nr.Params["body"] = map[string]any{"name": "bkt"}
+	if _, err := p.BucketsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert bucket: %v", err)
+	}
+	nr = bucketParamsWithObj("bkt", "o.txt")
+	nr.Params[wire.MediaKey] = []byte("payload")
+	nr.Params[wire.ContentTypeKey] = "text/plain"
+	if _, err := p.ObjectsInsert(ctx, nr); err != nil {
+		t.Fatalf("insert object: %v", err)
+	}
+
+	date := clock.Now().Format("20060102T150405Z")
+	nr = signedRequest("bkt", "o.txt", "3600", date)
+	nr.Params["X-Goog-Signature"] = "garbage-forged-signature"
+	resp, err := p.ObjectsGetMedia(ctx, nr)
+	if err != nil || resp.HTTPStatus != 200 {
+		t.Fatalf("tampered signature must be accepted (200), got %v / %v", resp, err)
 	}
 }

--- a/internal/gcp/wire/wire.go
+++ b/internal/gcp/wire/wire.go
@@ -55,4 +55,9 @@ const (
 	// media downloads can surface x-goog-hash / x-goog-generation /
 	// x-goog-meta-* etc. alongside the streamed bytes.
 	HeadersKey = "jaiscloud:headers"
+	// SignedURLKey carries a bool in NormalizedRequest.Params (codec → provider)
+	// indicating the request is a V4 signed-URL request (X-Goog-Signature query
+	// param present). The provider validates parameter format and expiry; the
+	// cryptographic signature itself is deliberately not verified.
+	SignedURLKey = "jaiscloud:signedURL"
 )

--- a/tests/integration/gcp/gcs_resumable_test.go
+++ b/tests/integration/gcp/gcs_resumable_test.go
@@ -1,0 +1,165 @@
+package gcp_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// startResumable initiates a resumable session over the given base path and
+// returns the upload_id.
+func startResumable(t *testing.T, path string) string {
+	t.Helper()
+	resp, _ := do(t, "POST", path, nil, nil)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "resumable start %s", path)
+	loc := resp.Header.Get("Location")
+	require.NotEmpty(t, loc, "expected Location header")
+	uploadID := ""
+	for _, q := range strings.Split(strings.SplitN(loc, "?", 2)[1], "&") {
+		if k, v, ok := strings.Cut(q, "="); ok && k == "upload_id" {
+			uploadID = v
+		}
+	}
+	require.NotEmpty(t, uploadID, "no upload_id in Location %q", loc)
+	return uploadID
+}
+
+func TestGCSResumableUnknownSizeFinalChunk(t *testing.T) {
+	resetState(t)
+	createBucket(t, "rs-unknown-bucket")
+
+	uploadID := startResumable(t, "/upload/storage/v1/b/rs-unknown-bucket/o?uploadType=resumable&name=x.bin")
+
+	body := []byte("seventeen bytes!!")
+	resp, bodyB := do(t, "PUT", "/upload/storage/v1/b/rs-unknown-bucket/o?uploadType=resumable&upload_id="+uploadID,
+		body, map[string]string{"Content-Range": "bytes 0-*/*"})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", bodyB)
+	require.Equal(t, fmt.Sprintf("%d", len(body)), jsonMap(t, bodyB)["size"])
+}
+
+func TestGCSResumableOffsetGapPlain503(t *testing.T) {
+	resetState(t)
+	createBucket(t, "rs-gap-bucket")
+
+	uploadID := startResumable(t, "/upload/storage/v1/b/rs-gap-bucket/o?uploadType=resumable&name=x.bin")
+
+	resp, body := do(t, "PUT", "/upload/storage/v1/b/rs-gap-bucket/o?uploadType=resumable&upload_id="+uploadID,
+		[]byte("ok"), map[string]string{"Content-Range": "bytes 4-5/6"})
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	require.Contains(t, resp.Header.Get("Content-Type"), "text/plain")
+	require.Equal(t, "138", resp.Header.Get("Content-Length"))
+	require.Contains(t, strings.ToLower(string(body)), "content-range")
+	require.NotContains(t, strings.ToLower(string(body)), "earlier")
+}
+
+func TestGCSResumablePostContinuationAndReplay(t *testing.T) {
+	resetState(t)
+	createBucket(t, "rs-post-bucket")
+
+	uploadID := startResumable(t, "/upload/storage/v1/b/rs-post-bucket/o?uploadType=resumable&name=big.bin")
+
+	// POST chunks (the Go SDK uses POST for resumable chunks).
+	resp, _ := do(t, "POST", "/upload/storage/v1/b/rs-post-bucket/o?uploadType=resumable&upload_id="+uploadID,
+		[]byte("hello"), map[string]string{"Content-Range": "bytes 0-4/*"})
+	require.Equal(t, http.StatusPermanentRedirect, resp.StatusCode)
+	require.Equal(t, "bytes=0-4", resp.Header.Get("Range"))
+
+	resp, body := do(t, "POST", "/upload/storage/v1/b/rs-post-bucket/o?uploadType=resumable&upload_id="+uploadID,
+		[]byte(" world"), map[string]string{"Content-Range": "bytes 5-10/11"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "11", jsonMap(t, body)["size"])
+
+	// Post-completion status query -> 200 + object.
+	resp, body = do(t, "POST", "/upload/storage/v1/b/rs-post-bucket/o?uploadType=resumable&upload_id="+uploadID,
+		nil, map[string]string{"Content-Range": "bytes */11"})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "post-completion status body: %s", body)
+	require.Equal(t, "11", jsonMap(t, body)["size"])
+}
+
+func TestGCSResumableRewrittenJSONPath(t *testing.T) {
+	resetState(t)
+	createBucket(t, "rs-json-bucket")
+
+	// Initiate and chunk entirely on the rewritten /storage/v1/ path.
+	uploadID := startResumable(t, "/storage/v1/b/rs-json-bucket/o?uploadType=resumable&name=y.bin")
+
+	resp, _ := do(t, "PUT", "/storage/v1/b/rs-json-bucket/o?uploadType=resumable&upload_id="+uploadID,
+		[]byte("data"), map[string]string{"Content-Range": "bytes 0-3/4"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_, body := do(t, "GET", "/storage/v1/b/rs-json-bucket/o/y.bin?alt=media", nil, nil)
+	require.Equal(t, "data", string(body))
+}
+
+func TestGCSResumableDiscoveryPath(t *testing.T) {
+	resetState(t)
+	createBucket(t, "rs-disc-bucket")
+
+	// The Discovery-documented resumable initiation path used by gcloud.
+	uploadID := startResumable(t, "/resumable/upload/storage/v1/b/rs-disc-bucket/o?uploadType=resumable&name=z.bin")
+
+	// Chunk against the session URI path (/upload/...); completes.
+	resp, _ := do(t, "PUT", "/upload/storage/v1/b/rs-disc-bucket/o?uploadType=resumable&upload_id="+uploadID,
+		[]byte("done"), map[string]string{"Content-Range": "bytes 0-3/4"})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_, body := do(t, "GET", "/storage/v1/b/rs-disc-bucket/o/z.bin?alt=media", nil, nil)
+	require.Equal(t, "done", string(body))
+}
+
+func TestGCSMultipartSingleQuotedBoundary(t *testing.T) {
+	resetState(t)
+	createBucket(t, "mp-quote-bucket")
+
+	body := "--BND==\r\nContent-Type: application/json\r\n\r\n{\"name\":\"o.txt\",\"contentType\":\"text/plain\"}\r\n--BND==\r\nContent-Type: text/plain\r\n\r\nhello quoted\r\n--BND==--\r\n"
+	resp, bodyB := do(t, "POST", "/upload/storage/v1/b/mp-quote-bucket/o?uploadType=multipart",
+		[]byte(body), map[string]string{"Content-Type": "multipart/related; boundary='BND=='"})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", bodyB)
+	require.Equal(t, "o.txt", jsonMap(t, bodyB)["name"])
+
+	_, bodyB = do(t, "GET", "/storage/v1/b/mp-quote-bucket/o/o.txt?alt=media", nil, nil)
+	require.Equal(t, "hello quoted", string(bodyB))
+}
+
+// signedGetPath builds a path-style signed GET URL.
+func signedPath(bucket, object, expires, date, signature string) string {
+	return fmt.Sprintf("/%s/%s?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=test@test.iam.gserviceaccount.com/20260913/auto/storage/goog4_request&X-Goog-Date=%s&X-Goog-Expires=%s&X-Goog-SignedHeaders=host&X-Goog-Signature=%s",
+		bucket, object, date, expires, signature)
+}
+
+func TestGCSSignedURLExpiredReturnsExpiredToken(t *testing.T) {
+	resetState(t)
+	createBucket(t, "sgn-exp-bucket")
+
+	resp, body := do(t, "GET", signedPath("sgn-exp-bucket", "o.txt", "60", "20200101T000000Z", "sig"), nil, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Contains(t, string(body), "<Code>ExpiredToken</Code>")
+	require.NotContains(t, string(body), "<Details>")
+}
+
+func TestGCSSignedURLMalformedDate(t *testing.T) {
+	resetState(t)
+	createBucket(t, "sgn-date-bucket")
+
+	resp, body := do(t, "GET", signedPath("sgn-date-bucket", "o.txt", "3600", "not-a-date", "sig"), nil, nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Contains(t, string(body), "<Code>MalformedSecurityHeader</Code>")
+	require.Contains(t, string(body), "<ParameterName>Date</ParameterName>")
+}
+
+func TestGCSSignedURLPutStoresObject(t *testing.T) {
+	resetState(t)
+	createBucket(t, "sgn-put-bucket")
+
+	date := time.Now().UTC().Format("20060102T150405Z")
+	path := signedPath("sgn-put-bucket", "o.txt", "3600", date, "sig")
+	resp, body := do(t, "PUT", path, []byte("signed bytes"), map[string]string{"Content-Type": "text/plain"})
+	require.Equal(t, http.StatusOK, resp.StatusCode, "body: %s", body)
+
+	_, body = do(t, "GET", "/storage/v1/b/sgn-put-bucket/o/o.txt?alt=media", nil, nil)
+	require.Equal(t, "signed bytes", string(body))
+}

--- a/tests/integration/gcp/sdk/sdk_extra_test.go
+++ b/tests/integration/gcp/sdk/sdk_extra_test.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -184,4 +187,67 @@ func TestSDKObjectNameSpaceAndSlash(t *testing.T) {
 		}
 	}
 	require.True(t, found, "object %q not found in listing", name)
+}
+
+// signedURLOpts builds a V4 path-style signed URL option set against the
+// emulator host, using a throwaway SignBytes callback (the emulator does not
+// verify signatures).
+func signedURLOpts(method, contentType string, expires time.Time) *storage.SignedURLOptions {
+	host := strings.TrimPrefix(emulatorHost(), "http://")
+	host = strings.TrimPrefix(host, "https://")
+	return &storage.SignedURLOptions{
+		GoogleAccessID: "test@test.iam.gserviceaccount.com",
+		SignBytes:      func([]byte) ([]byte, error) { return []byte("fake-signature"), nil },
+		Method:         method,
+		ContentType:    contentType,
+		Expires:        expires,
+		Scheme:         storage.SigningSchemeV4,
+		Style:          storage.PathStyle(),
+		Insecure:       true,
+		Hostname:       host,
+	}
+}
+
+// TestSDKSignedURLRoundTrip exercises V4 signed GET and PUT through the SDK's
+// own URL builder (produces the exact X-Goog-* query shape).
+func TestSDKSignedURLRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	client := newClient(t)
+	bucket := fmt.Sprintf("sdk-signed-%d", time.Now().UnixNano())
+	require.NoError(t, client.Bucket(bucket).Create(ctx, "proj", nil))
+
+	writeObject(t, client, bucket, "o.txt", "signed via sdk")
+
+	// Signed GET -> 200 + object bytes.
+	getURL, err := client.Bucket(bucket).SignedURL("o.txt", signedURLOpts("GET", "", time.Now().Add(time.Hour)))
+	require.NoError(t, err)
+	resp, err := http.Get(getURL)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "signed via sdk", string(body))
+
+	// Signed PUT -> 200, object stored.
+	putURL, err := client.Bucket(bucket).SignedURL("put.txt", signedURLOpts("PUT", "text/plain", time.Now().Add(time.Hour)))
+	require.NoError(t, err)
+	req, err := http.NewRequest("PUT", putURL, strings.NewReader("put bytes"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "text/plain")
+	putResp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	putResp.Body.Close()
+	require.Equal(t, http.StatusOK, putResp.StatusCode)
+
+	// Tampered signature is accepted (records the deliberate auth bypass).
+	u, err := url.Parse(getURL)
+	require.NoError(t, err)
+	q := u.Query()
+	q.Set("X-Goog-Signature", "deadbeef-forged")
+	u.RawQuery = q.Encode()
+	resp, err = http.Get(u.String())
+	require.NoError(t, err)
+	resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 }


### PR DESCRIPTION
## Description

Make `jaiscloud-gcp` match real GCS wire behavior for resumable uploads and V4
signed URLs so the floci Java compatibility suites go green and the `gcloud`
storage CLI can reach the upload path — without regressing the 4 SDK-driven
resumable tests that already pass.

## What's in this PR

- `internal/gcp/wire/wire.go`: `SignedURLKey`.
- `internal/gcp/adapter/gcs.go`:
  - `Encode` emits `X-Http-Status-Code-Override` independently of `Range`, and returns an empty body for incomplete 308/override responses (Go SDK `X-GUploader-No-308` contract).
  - `EncodeError` honors `Data["errorFormat"] = "plain"` (text/plain) and `"xml"` (XML `<Error>` document with optional `<ParameterName>`).
  - `decodeRawMedia` detects V4 signed URLs (`X-Goog-Signature`) and routes signed `PUT` to `ObjectsInsert`.
  - `decodeStorage` + `decodeStorageResumable` handle resumable sessions on the rewritten `/storage/v1/` JSON path.
  - `Decode` routes `/resumable/upload/storage/v1/` (Discovery resumable path).
  - `parseMultipart` + `extractBoundary` accept single-quoted boundaries containing `=` (gcloud/apitools; `mime.ParseMediaType` rejects these).
- `internal/gcp/adapter/router.go` + `services.go`: signed-PUT routing and the `/resumable/upload/storage/v1/` path prefix.
- `internal/gcp/provider/storage/storage.go`:
  - `parseContentRange` exposes end-`*`; terminal unknown-end chunks (`bytes N-*/*`, `bytes N-*/T`) finalize with 200 (400 on size mismatch).
  - Empty-session status → 308 with no `Range`; offset-past-persisted → plain-text 503; rewind ignored.
  - Completion tombstones (bounded, TTL-swept, cleared on Reset) replay the object for post-completion status queries.
  - `validateSignedURL` (+`malformedSecurityHeader`) wired into `ObjectsGetMedia`/`ObjectsInsert`: Expires-first validation; expired → 400 `ExpiredToken`; malformed date / invalid-or-lowercase expires → 400 `MalformedSecurityHeader` + `ParameterName`.

## Deliberate bypass

V4 signatures are **not** cryptographically verified: the emulator accepts any
well-formed, unexpired signed URL. This is a conscious contract (consistent with
jaiscloud's auth-bypass model) and is recorded by a unit + SDK test that assert a
tampered/forged `X-Goog-Signature` returns 200.

## Out of scope

- localgcp bare `PUT` resumable, `POST /_localgcp/sign`.
- XML-API resumable initiation, `X-Amz-*` signed params, virtual-hosted signed URLs, gRPC resumable, signature verification.
- Session `DELETE` cancel (`499`/`204`) and `410 Gone` invalidation (documented deviations).

## How to test

```bash
go build ./... && go build -o /tmp/jc ./cmd/jaiscloud-gcp/
go test -race ./internal/gcp/... -count=1
go test -race ./tests/integration/gcp/ -count=1
cd tests/integration/gcp/sdk && STORAGE_EMULATOR_HOST=http://localhost:8080 go test -race -count=1 ./...
```

## Test report

- `go test -race ./internal/gcp/...` green (57 packages).
- Raw-HTTP integration (`tests/integration/gcp/`) green; SDK signed-URL round-trip + No-308 resumable green.
- gcloud CLI smoke (ephemeral emulator): `buckets create`, multipart `storage cp` (single-quoted boundary), and forced-resumable `storage cp` (`CLOUDSDK_STORAGE_RESUMABLE_THRESHOLD=0`, `/resumable/upload/` path) all succeed; downloaded bytes match.